### PR TITLE
#fix deploy语义分割任务中，图像宽高不是1:1时，后处理使用的宽高和预处理不一致导致的结果变形

### DIFF
--- a/deploy/cpp/src/paddlex.cpp
+++ b/deploy/cpp/src/paddlex.cpp
@@ -791,25 +791,25 @@ bool Model::predict(const std::vector<cv::Mat>& im_batch,
         auto before_shape =
             inputs_batch_[i].im_size_before_resize_[len_postprocess - idx];
         inputs_batch_[i].im_size_before_resize_.pop_back();
-        auto padding_w = before_shape[0];
-        auto padding_h = before_shape[1];
+        auto padding_h = before_shape[0];
+        auto padding_w = before_shape[1];
         mask_label = mask_label(cv::Rect(0, 0, padding_h, padding_w));
         mask_score = mask_score(cv::Rect(0, 0, padding_h, padding_w));
       } else if (*iter == "resize") {
         auto before_shape =
             inputs_batch_[i].im_size_before_resize_[len_postprocess - idx];
         inputs_batch_[i].im_size_before_resize_.pop_back();
-        auto resize_w = before_shape[0];
-        auto resize_h = before_shape[1];
+        auto resize_h = before_shape[0];
+        auto resize_w = before_shape[1];
         cv::resize(mask_label,
                    mask_label,
-                   cv::Size(resize_h, resize_w),
+                   cv::Size(resize_w, resize_h),
                    0,
                    0,
                    cv::INTER_NEAREST);
         cv::resize(mask_score,
                    mask_score,
-                   cv::Size(resize_h, resize_w),
+                   cv::Size(resize_w, resize_h),
                    0,
                    0,
                    cv::INTER_LINEAR);

--- a/deploy/openvino/src/paddlex.cpp
+++ b/deploy/openvino/src/paddlex.cpp
@@ -295,24 +295,24 @@ bool Model::predict(const cv::Mat& im, SegResult* result) {
     if (*iter == "padding") {
       auto before_shape = inputs_.im_size_before_resize_[len_postprocess - idx];
       inputs_.im_size_before_resize_.pop_back();
-      auto padding_w = before_shape[0];
-      auto padding_h = before_shape[1];
+      auto padding_h = before_shape[0];
+      auto padding_w = before_shape[1];
       mask_label = mask_label(cv::Rect(0, 0, padding_h, padding_w));
       mask_score = mask_score(cv::Rect(0, 0, padding_h, padding_w));
     } else if (*iter == "resize") {
       auto before_shape = inputs_.im_size_before_resize_[len_postprocess - idx];
       inputs_.im_size_before_resize_.pop_back();
-      auto resize_w = before_shape[0];
-      auto resize_h = before_shape[1];
+      auto resize_h = before_shape[0];
+      auto resize_w = before_shape[1];
       cv::resize(mask_label,
                  mask_label,
-                 cv::Size(resize_h, resize_w),
+                 cv::Size(resize_w, resize_h),
                  0,
                  0,
                  cv::INTER_NEAREST);
       cv::resize(mask_score,
                  mask_score,
-                 cv::Size(resize_h, resize_w),
+                 cv::Size(resize_w, resize_h),
                  0,
                  0,
                  cv::INTER_LINEAR);


### PR DESCRIPTION
#fix deploy语义分割任务中，图像宽高不是1:1时，后处理使用的宽高和预处理不一致导致的结果变形
Signed-off-by: wysimples@163.com <wysimples@163.com>