### PR TITLE
add 1-channel image requirement for the segmentation label file

### DIFF
--- a/paddlex/cv/models/slim/post_quantization.py
+++ b/paddlex/cv/models/slim/post_quantization.py
@@ -262,10 +262,12 @@ class PaddleXPostTrainingQuantization(PostTrainingQuantization):
             for var_name in self._quantized_act_var_name:
                 start = time.time()
                 sampling_data = []
-                filenames = [f for f in os.listdir(self._cache_dir) \
-                    if re.match(var_name + '_[0-9]+.npy', f)]
+                file_name = os.path.join(self._cache_dir, var_name)
+                cache_dir, var_name_ = os.path.split(file_name) 
+                filenames = [f for f in os.listdir(cache_dir) \
+                    if re.match(var_name_ + '_[0-9]+.npy', f)]
                 for filename in filenames:
-                    file_path = os.path.join(self._cache_dir, filename)
+                    file_path = os.path.join(cache_dir, filename)
                     sampling_data.append(np.load(file_path))
                     os.remove(file_path)
                 sampling_data = np.concatenate(sampling_data)
@@ -314,7 +316,7 @@ class PaddleXPostTrainingQuantization(PostTrainingQuantization):
                                          var_name + "_" + str(iter) + ".npy")
                 save_dir, file_name = os.path.split(save_path)
                 if not os.path.exists(save_dir):
-                    os.mkdirs(save_dir)
+                    os.makedir(save_dir)
                 np.save(save_path, var_tensor)
         else:
             for var_name in self._quantized_act_var_name:

--- a/paddlex/cv/transforms/seg_transforms.py
+++ b/paddlex/cv/transforms/seg_transforms.py
@@ -119,6 +119,10 @@ class Compose(SegTransform):
                     label = np.asarray(Image.open(label))
                 except:
                     ValueError('Can\'t read The label file {}!'.format(label))
+                if len(label.shape) != 2:
+                    raise Exception(
+                        "label should be a 1-channel image, but recevied a {}-channel image.".
+                        format(label.shape[2]))
             im_height, im_width, _ = im.shape
             label_height, label_width = label.shape
             if im_height != label_height or im_width != label_width:


### PR DESCRIPTION
The label file for segmentation is required to be a 1-channel image, we add the channel error information to remind users to check their label files.

see issue: https://github.com/PaddlePaddle/PaddleX/issues/526