### PR TITLE
change variable name  to  in function f1_score()

### DIFF
--- a/paddlex/cv/models/utils/seg_eval.py
+++ b/paddlex/cv/models/utils/seg_eval.py
@@ -170,7 +170,7 @@ class ConfusionMatrix(object):
             else:
                 recall = self.confusion_matrix[c][c] / vij[c]
             if recall + precision <= 1e-06:
-                f1_score = 0
+                f1score = 0
             else:
                 f1score = 2 * precision * recall / (recall + precision)
             f1score_list.append(f1score)


### PR DESCRIPTION
Local variable 'f1score' referenced before assignment, to solve this bug, we change variable name `f1_score` to `f1score` in function f1_score().

see issue https://github.com/PaddlePaddle/PaddleX/issues/532