### PR TITLE
set the version of paddle2onnx to 0.4

### DIFF
--- a/paddlex/converter.py
+++ b/paddlex/converter.py
@@ -268,7 +268,13 @@ def export_onnx_model(model, save_file, opset_version=10):
     except:
         logging.error(
             "You need to install paddle2onnx first, pip install paddle2onnx==0.4")
+
     import paddle2onnx as p2o
+
+    if p2o.__version__ != '0.4':
+        logging.error(
+            "You need install paddle2onnx==0.4, but the version of paddle2onnx is {}".format(p2o.__version__))
+
     if opset_version == 10 and model.__class__.__name__ == "YOLOv3":
         logging.warning(
             "Export for openVINO by default, the output of multiclass_nms exported to onnx will contains background. If you need onnx completely consistent with paddle, please use paddle2onnx to export"

--- a/paddlex/converter.py
+++ b/paddlex/converter.py
@@ -267,7 +267,7 @@ def export_onnx_model(model, save_file, opset_version=10):
         import paddle2onnx 
     except:
         logging.error(
-            "You need to install paddle2onnx first, pip install paddle2onnx")
+            "You need to install paddle2onnx first, pip install paddle2onnx==0.4")
     import paddle2onnx as p2o
     if opset_version == 10 and model.__class__.__name__ == "YOLOv3":
         logging.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pycocotools
 visualdl >= 2.0.0b
 paddleslim == 1.1.1
 shapely
-paddle2onnx
+paddle2onnx==0.4
 paddlepaddle-gpu
 opencv-python
 psutil


### PR DESCRIPTION
背景：
paddle2onnx为0.3-0.4时，在转换多个输入的模型时，可能导出来的ONNX模型输入顺序和原Paddle模型不一致。
以YOLOv3为例，原始输入顺序为['image', 'im_size']，转换为ONNX之后，输入顺序为[ 'im_size', 'image']，openvino部署模块是根据[ 'im_size', 'image']来处理的。

由于paddle2onnx升级为0.5以后，纠正了该问题，所以会影响YOLOv3等模型的openvino部署模块，未来等openvino模型适配之后再接触paddle2onnx的版本限制。