### PR TITLE
add `from osgeo import gdal` when use high-version gdal

### DIFF
--- a/paddlex/cv/transforms/seg_transforms.py
+++ b/paddlex/cv/transforms/seg_transforms.py
@@ -72,10 +72,13 @@ class Compose(SegTransform):
             try:
                 import gdal
             except:
-                six.reraise(*sys.exc_info())
-                raise Exception(
-                    "Please refer to https://github.com/PaddlePaddle/PaddleX/tree/develop/examples/multi-channel_remote_sensing/README.md to install gdal"
-                )
+                try:
+                    from osgeo import gdal
+                except:
+                    raise Exception(
+                        "Please refer to https://github.com/PaddlePaddle/PaddleX/tree/develop/examples/multi-channel_remote_sensing/README.md to install gdal"
+                    )
+                    six.reraise(*sys.exc_info())
 
             dataset = gdal.Open(img_path)
             if dataset == None:


### PR DESCRIPTION
When use high-version gdal, gdal cannot be  imported directly but by `from osgeo import gdal`. 

see #558 