### PR TITLE
fix wrong links in docs/examples/industrial_quality_inspection/

### DIFF
--- a/docs/examples/industrial_quality_inspection/README.md
+++ b/docs/examples/industrial_quality_inspection/README.md
@@ -63,7 +63,7 @@
 
 ### 模型训练
 
-[环境前置依赖](./gpu_solution.md#%E5%89%8D%E7%BD%AE%E4%BE%9D%E8%B5%96)、[下载PaddleX源码](./gpu_solution.md#1-%E4%B8%8B%E8%BD%BDpaddlex%E6%BA%90%E7%A0%81)、[下载数据集](./gpu_solution.md#2-%E4%B8%8B%E8%BD%BD%E6%95%B0%E6%8D%AE%E9%9B%86)与GPU端是一样的，可点击文档[GPU端最终解决方案](./gpu_solution.md)查看，在此不做赘述。
+[环境前置依赖](./gpu_solution.html#id1)、[下载PaddleX源码](./gpu_solution.html#paddlex)、[下载数据集](./gpu_solution.html#id3)与GPU端是一样的，可点击文档[GPU端最终解决方案](./gpu_solution.md)查看，在此不做赘述。
 
 如果不想再次训练模型，可以直接下载已经训练好的模型完成后面的模型测试和部署推理：
 
@@ -92,7 +92,7 @@ python params_analysis.py
 python train_pruned_yolov3.py
 ```
 
-[分析预测错误的原因](./gpu_solution.md#4-%E5%88%86%E6%9E%90%E9%A2%84%E6%B5%8B%E9%94%99%E8%AF%AF%E7%9A%84%E5%8E%9F%E5%9B%A0)、[统计图片级召回率和误检率](./gpu_solution.md#5-%E7%BB%9F%E8%AE%A1%E5%9B%BE%E7%89%87%E7%BA%A7%E5%8F%AC%E5%9B%9E%E7%8E%87%E5%92%8C%E8%AF%AF%E6%A3%80%E7%8E%87)、[模型测试](./gpu_solution.md#6-%E6%A8%A1%E5%9E%8B%E6%B5%8B%E8%AF%95)这些步骤与GPU端是一样的，可点击文档[GPU端最终解决方案](./gpu_solution.md)查看，在此不做赘述。
+[分析预测错误的原因](./gpu_solution.html#id6)、[统计图片级召回率和误检率](./gpu_solution.html#id7)、[模型测试](./gpu_solution.html#id8)这些步骤与GPU端是一样的，可点击文档[GPU端最终解决方案](./gpu_solution.md)查看，在此不做赘述。
 
 ### 推理部署
 

--- a/docs/examples/industrial_quality_inspection/gpu_solution.md
+++ b/docs/examples/industrial_quality_inspection/gpu_solution.md
@@ -61,7 +61,7 @@ python train_rcnn.py
 python error_analysis.py
 ```
 
-可参考[性能优化部分的模型效果分析](./accuracy_improvement.md#2-%E6%A8%A1%E5%9E%8B%E6%95%88%E6%9E%9C%E5%88%86%E6%9E%90)来理解当前模型预测错误的原因。
+可参考[性能优化部分的模型效果分析](./accuracy_improvement.html#id3)来理解当前模型预测错误的原因。
 
 运行以下代码，生成可视化真值和预测结果的对比图以进一步理解模型效果，代码中的置信度阈值可根据实际情况进行调整。
 
@@ -75,7 +75,7 @@ python compare.py
 
 ### (6) 统计图片级召回率和误检率
 
-模型迭代完成后，计算不同置信度阈值下[图片级召回率](./accuracy_improvement.md#6-%E8%83%8C%E6%99%AF%E5%9B%BE%E7%89%87%E5%8A%A0%E5%85%A5)和[图片级误检率](./accuracy_improvement.md#6-%E8%83%8C%E6%99%AF%E5%9B%BE%E7%89%87%E5%8A%A0%E5%85%A5)，找到符合要求的召回率和误检率，对应的置信度阈值用于后续模型预测阶段。
+模型迭代完成后，计算不同置信度阈值下[图片级召回率](./accuracy_improvement.html#id7)和[图片级误检率](./accuracy_improvement.html#id7)，找到符合要求的召回率和误检率，对应的置信度阈值用于后续模型预测阶段。
 
 ```
 python cal_tp_fp.py


### PR DESCRIPTION
Some links in docs/examples/industrial_quality_inspection/README.md are wrong, we fix them.

see issue #587 