### PR TITLE
set matplotlib.backends to be Agg for the first time 

### DIFF
--- a/paddlex/__init__.py
+++ b/paddlex/__init__.py
@@ -41,11 +41,6 @@ if version[0] == '1':
 if hasattr(paddle, 'enable_static'):
     paddle.enable_static()
 
-# matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
-# or matplotlib.backends is imported for the first time
-import matplotlib
-matplotlib.use('Agg')
-
 from .utils.utils import get_environ_info
 from . import cv
 from . import det

--- a/paddlex/__init__.py
+++ b/paddlex/__init__.py
@@ -34,10 +34,17 @@ if version[0] == '1':
             format(__version__))
     import paddlehub as hub
     if hub.__version__.strip().split('.')[0] > '1':
-        raise Exception("Try to reinstall Paddlehub by 'pip install paddlehub==1.8.2' while paddlepaddle < 2.0")
+        raise Exception(
+            "Try to reinstall Paddlehub by 'pip install paddlehub==1.8.2' while paddlepaddle < 2.0"
+        )
 
 if hasattr(paddle, 'enable_static'):
     paddle.enable_static()
+
+# matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+# or matplotlib.backends is imported for the first time
+import matplotlib
+matplotlib.use('Agg')
 
 from .utils.utils import get_environ_info
 from . import cv

--- a/paddlex/cv/datasets/coco.py
+++ b/paddlex/cv/datasets/coco.py
@@ -48,6 +48,11 @@ class CocoDetection(VOCDetection):
                  buffer_size=100,
                  parallel_method='process',
                  shuffle=False):
+        # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+        # or matplotlib.backends is imported for the first time
+        # pycocotools import matplotlib
+        import matplotlib
+        matplotlib.use('Agg')
         from pycocotools.coco import COCO
 
         try:

--- a/paddlex/cv/datasets/easydata_det.py
+++ b/paddlex/cv/datasets/easydata_det.py
@@ -168,6 +168,11 @@ class EasyDataDet(VOCDetection):
         logging.info("{} samples in file {}".format(
             len(self.file_list), file_list))
         self.num_samples = len(self.file_list)
+        # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+        # or matplotlib.backends is imported for the first time
+        # pycocotools import matplotlib
+        import matplotlib
+        matplotlib.use('Agg')
         from pycocotools.coco import COCO
         self.coco_gt = COCO()
         self.coco_gt.dataset = annotations

--- a/paddlex/cv/datasets/voc.py
+++ b/paddlex/cv/datasets/voc.py
@@ -54,6 +54,11 @@ class VOCDetection(Dataset):
                  buffer_size=100,
                  parallel_method='process',
                  shuffle=False):
+        # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+        # or matplotlib.backends is imported for the first time
+        # pycocotools import matplotlib
+        import matplotlib
+        matplotlib.use('Agg')
         from pycocotools.coco import COCO
         super(VOCDetection, self).__init__(
             transforms=transforms,

--- a/paddlex/cv/models/utils/detection_eval.py
+++ b/paddlex/cv/models/utils/detection_eval.py
@@ -107,6 +107,11 @@ def coco_bbox_eval(results,
                    with_background=True,
                    is_bbox_normalized=False):
     assert 'bbox' in results[0]
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
 
     cat_ids = coco_gt.getCatIds()
@@ -139,6 +144,11 @@ def loadRes(coco_obj, anns):
     :param   resFile (str)     : file name of result file
     :return: res (obj)         : result api object
     """
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
     import pycocotools.mask as maskUtils
     import time
@@ -198,6 +208,11 @@ def loadRes(coco_obj, anns):
 
 def mask_eval(results, coco_gt, resolution, thresh_binarize=0.5):
     assert 'mask' in results[0]
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
 
     clsid2catid = {i + 1: v for i, v in enumerate(coco_gt.getCatIds())}
@@ -229,6 +244,11 @@ def cocoapi_eval(anns,
         max_dets: COCO evaluation maxDets.
     """
     assert coco_gt != None or anno_file != None
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval
 
@@ -340,6 +360,11 @@ def bbox2out(results, clsid2catid, is_bbox_normalized=False):
 
 
 def mask2out(results, clsid2catid, resolution, thresh_binarize=0.5):
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     import pycocotools.mask as mask_util
     scale = (resolution + 2.0) / resolution
 
@@ -465,6 +490,11 @@ def voc_bbox_eval(results,
     assert 'bbox' in results[0]
 
     logging.debug("Start evaluate...")
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
 
     cat_ids = coco_gt.getCatIds()
@@ -843,6 +873,11 @@ def analyze_individual_category(k, cocoDt, cocoGt, catId, iou_type):
 
     """
 
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval
 
@@ -922,6 +957,11 @@ def coco_error_analysis(eval_details_file=None,
     """
 
     import multiprocessing as mp
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.coco import COCO
     from pycocotools.cocoeval import COCOeval
 
@@ -972,7 +1012,8 @@ def coco_error_analysis(eval_details_file=None,
         thread_pool = mp.pool.ThreadPool(thread_num)
         args = [(k, cocoDt, cocoGt, catId, iou_type)
                 for k, catId in enumerate(catIds)]
-        analyze_results = thread_pool.starmap(analyze_individual_category, args)
+        analyze_results = thread_pool.starmap(analyze_individual_category,
+                                              args)
         for k, catId in enumerate(catIds):
             nm = cocoGt.loadCats(catId)[0]
             logging.info('--------------saving {}-{}---------------'.format(
@@ -1001,6 +1042,11 @@ def coco_error_analysis(eval_details_file=None,
     coco_gt = COCO()
     coco_gt.dataset = gt
     coco_gt.createIndex()
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
     from pycocotools.cocoeval import COCOeval
     if pred_bbox is not None:
         coco_dt = loadRes(coco_gt, pred_bbox)

--- a/paddlex/cv/models/utils/visualize.py
+++ b/paddlex/cv/models/utils/visualize.py
@@ -386,7 +386,6 @@ def draw_pr_curve(eval_details_file=None,
         return mean_s
 
     def cal_pr(coco_gt, coco_dt, iou_thresh, save_dir, style='bbox'):
-        from pycocotools.cocoeval import COCOeval
         coco_dt = loadRes(coco_gt, coco_dt)
         np.linspace = fixed_linspace
         coco_eval = COCOeval(coco_gt, coco_dt, style)

--- a/paddlex/tools/dataset_split/coco_split.py
+++ b/paddlex/tools/dataset_split/coco_split.py
@@ -15,12 +15,18 @@
 import os.path as osp
 import random
 import json
-from pycocotools.coco import COCO
+
 from .utils import MyEncoder
 import paddlex.utils.logging as logging
 
 
 def split_coco_dataset(dataset_dir, val_percent, test_percent, save_dir):
+    # matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+    # or matplotlib.backends is imported for the first time
+    # pycocotools import matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
+    from pycocotools.coco import COCO
     if not osp.exists(osp.join(dataset_dir, "annotations.json")):
         logging.error("\'annotations.json\' is not found in {}!".format(
             dataset_dir))


### PR DESCRIPTION
Matplotlib.pyplot in the function pdx.det.draw_pr_curve raises a error on the aistudio platform:
_tkinter.TclError: no display name and no $DISPLAY environment variable.

We fix this by setting the matplotlib.backends to be `Agg` for the first importing time. Because pycocotools imports matplotlib, so 'matplotlib.use('Agg')' is set before pycocotools been imported.

see #585 