### PR TITLE
update the link for building a nvidia-jetson inference lib

### DIFF
--- a/docs/deploy/jetson/nvidia-jetson.md
+++ b/docs/deploy/jetson/nvidia-jetson.md
@@ -1,7 +1,7 @@
 # Nvidia Jetson开发板本地部署
 
 ## 说明
-本文档在基于Nvidia Jetpack 4.4的`Linux`平台上使用`GCC 7.4`测试过，如需使用不同G++版本，则需要重新编译Paddle预测库，请参考: [NVIDIA Jetson嵌入式硬件预测库源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/advanced_guide/inference_deployment/inference/build_and_install_lib_cn.html#id12)。
+本文档在基于Nvidia Jetpack 4.4的`Linux`平台上使用`GCC 7.4`测试过，如需使用不同G++版本，则需要重新编译Paddle预测库，请参考: [NVIDIA Jetson嵌入式硬件预测库源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/05_inference_deployment/inference/build_and_install_lib_cn.html)。
 
 ## 前置条件
 * G++ 7.4


### PR DESCRIPTION
update the link for building a nvidia-jetson inference lib
![image](https://user-images.githubusercontent.com/22235422/111095559-a70aba80-8578-11eb-8f57-0521690ea6cb.png)
