### PR TITLE
fix pretrain_weight directory whose compressed name and decompressed name are not same when gui_mode is True

### DIFF
--- a/paddlex/cv/models/utils/pretrain_weights.py
+++ b/paddlex/cv/models/utils/pretrain_weights.py
@@ -215,7 +215,13 @@ def get_pretrain_weights(flag, class_name, backbone, save_dir):
             url = image_pretrain[backbone]
             fname = osp.split(url)[-1].split('.')[0]
             paddlex.utils.download_and_decompress(url, path=new_save_dir)
-            return osp.join(new_save_dir, fname)
+            if not osp.exists(osp.join(new_save_dir, fname)):
+                for f in os.listdir(new_save_dir):
+                    dir_name = osp.join(new_save_dir, f)
+                    if osp.isdir(dir_name) and fname.split('_')[0] in dir_name:
+                        return dir_name
+            else:
+                return osp.join(new_save_dir, fname)
 
         import paddlehub as hub
         try:
@@ -255,7 +261,13 @@ def get_pretrain_weights(flag, class_name, backbone, save_dir):
 
         if getattr(paddlex, 'gui_mode', False):
             paddlex.utils.download_and_decompress(url, path=new_save_dir)
-            return osp.join(new_save_dir, fname)
+            if not osp.exists(osp.join(new_save_dir, fname)):
+                for f in os.listdir(new_save_dir):
+                    dir_name = osp.join(new_save_dir, f)
+                    if osp.isdir(dir_name) and fname.split('_')[0] in dir_name:
+                        return dir_name
+            else:
+                return osp.join(new_save_dir, fname)
 
         import paddlehub as hub
         try:
@@ -288,7 +300,13 @@ def get_pretrain_weights(flag, class_name, backbone, save_dir):
 
         if getattr(paddlex, 'gui_mode', False):
             paddlex.utils.download_and_decompress(url, path=new_save_dir)
-            return osp.join(new_save_dir, fname)
+            if not osp.exists(osp.join(new_save_dir, fname)):
+                for f in os.listdir(new_save_dir):
+                    dir_name = osp.join(new_save_dir, f)
+                    if osp.isdir(dir_name) and fname.split('_')[0] in dir_name:
+                        return dir_name
+            else:
+                return osp.join(new_save_dir, fname)
 
         import paddlehub as hub
         try:


### PR DESCRIPTION
ShuffleNetv2 imagenet pretrain_weight download link is https://paddle-imagenet-models-name.bj.bcebos.com/ShuffleNetV2_pretrained.tar, but its decompressed directory is ShuffleNetV2_x1_0_pretrained.

When gui_mode is set to True, pretrian_weight_dir(`output/shufflenetv2/pretrain/ShuffleNetV2_pretrained`) does not exist because there is `output/shufflenetv2/pretrain/ShuffleNetV2_x1_0_pretrained`. 

We fix this bug by:
If `output/shufflenetv2/pretrain/ShuffleNetV2_pretrained` does not exist, we find the directory which has `ShuffleNetV2` in `output/shufflenetv2/pretrain/` and set it as the pretrian_weight_dir.

see issue #667 