### PR TITLE
fix difference between python and cpp

### DIFF
--- a/deploy/cpp/model_deploy/common/include/base_preprocess.h
+++ b/deploy/cpp/model_deploy/common/include/base_preprocess.h
@@ -55,6 +55,7 @@ class BasePreProcess {
  private:
   std::shared_ptr<Transform> CreateTransform(const std::string& name);
   Padding batch_padding_;
+  Permute permute_;
 };
 
 }  // namespace PaddleDeploy

--- a/deploy/cpp/model_deploy/common/include/model_factory.h
+++ b/deploy/cpp/model_deploy/common/include/model_factory.h
@@ -46,7 +46,7 @@ class Register {
   class class_name##Register {                                    \
    public:                                                        \
     static std::shared_ptr<Model> newInstance() {                 \
-      std::cout << "REGISTER_CLASS:" << #model_type << std::endl; \
+      std::cerr << "REGISTER_CLASS:" << #model_type << std::endl; \
       return std::make_shared<class_name>(#model_type);           \
     }                                                             \
                                                                   \

--- a/deploy/cpp/model_deploy/common/include/output_struct.h
+++ b/deploy/cpp/model_deploy/common/include/output_struct.h
@@ -73,10 +73,10 @@ struct DataBlob {
 
 struct ShapeInfo {
   std::vector<std::vector<int>> shapes;
-  std::vector<std::string> transform_names;
+  std::vector<std::string> transforms;
   bool has_batch_padding = false;
   void Insert(const std::string& name, int width, int height) {
-    transform_names.push_back(name);
+    transforms.push_back(name);
     shapes.push_back({width, height});
   }
 };

--- a/deploy/cpp/model_deploy/common/include/transforms.h
+++ b/deploy/cpp/model_deploy/common/include/transforms.h
@@ -74,12 +74,6 @@ class Normalize : public Transform {
   std::vector<float> max_val_;
 };
 
-/*interp_: std::vector<int> interpolations = {
-    cv::INTER_LINEAR,
-    cv::INTER_NEAREST,
-    cv::INTER_AREA,
-    cv::INTER_CUBIC,
-    cv::INTER_LANCZOS4}*/
 class ResizeByShort : public Transform {
  public:
   virtual void Init(const YAML::Node& item) {
@@ -88,6 +82,11 @@ class ResizeByShort : public Transform {
       interp_ = item["interp"].as<int>();
     } else {
       interp_ = 1;
+    }
+    if (item["use_scale"].IsDefined()) {
+      use_scale_ = item["use_scale"].as<bool>();
+    } else {
+      use_scale_ = true;
     }
     if (item["max_size"].IsDefined()) {
       max_size_ = item["max_size"].as<int>();
@@ -105,6 +104,7 @@ class ResizeByShort : public Transform {
   int target_size_;
   int max_size_;
   int interp_;
+  bool use_scale_;
 };
 
 class ResizeByLong : public Transform {
@@ -149,6 +149,11 @@ class Resize : public Transform {
     } else {
       interp_ = 1;
     }
+    if (item["use_scale"].IsDefined()) {
+      use_scale_ = item["use_scale"].as<bool>();
+    } else {
+      use_scale_ = true;
+    }
     height_ = item["height"].as<int>();
     width_ = item["width"].as<int>();
     if (height_ <= 0 || width_ <= 0) {
@@ -166,6 +171,7 @@ class Resize : public Transform {
   int height_;
   int width_;
   int interp_;
+  bool use_scale_;
 };
 
 class BGR2RGB : public Transform {

--- a/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
@@ -65,7 +65,7 @@ bool PaddleInferenceEngine::Init(const std::string &model_filename,
         1 << 10 /* workspace_size*/,
         engine_config.batch_size /* max_batch_size*/,
         engine_config.min_subgraph_size /* min_subgraph_size*/,
-        precision /* precision*/, 
+        precision /* precision*/,
         engine_config.use_static /* use_static*/,
         engine_config.use_calib_mode /* use_calib_mode*/);
   }
@@ -75,25 +75,25 @@ bool PaddleInferenceEngine::Init(const std::string &model_filename,
 
 bool PaddleInferenceEngine::Infer(const std::vector<DataBlob> &inputs,
                                   std::vector<DataBlob> *outputs) {
+  auto input_names = predictor_->GetInputNames();
   for (int i = 0; i < inputs.size(); i++) {
-    auto input_names = predictor_->GetInputNames();
     auto in_tensor = predictor_->GetInputHandle(input_names[i]);
     in_tensor->Reshape(inputs[i].shape);
-    if (inputs[i].dtype == 0) {
+    if (inputs[i].dtype == FLOAT32) {
       float *im_tensor_data;
-      im_tensor_data = (float *)(inputs[i].data.data());  // NOLINT
+      im_tensor_data = (float*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
-    } else if (inputs[i].dtype == 1) {
+    } else if (inputs[i].dtype == INT64) {
       int64_t *im_tensor_data;
-      im_tensor_data = (int64_t *)(inputs[i].data.data());  // NOLINT
+      im_tensor_data = (int64_t*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
-    } else if (inputs[i].dtype == 2) {
+    } else if (inputs[i].dtype == INT32) {
       int *im_tensor_data;
-      im_tensor_data = (int *)(inputs[i].data.data());  // NOLINT
+      im_tensor_data = (int*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
-    } else if (inputs[i].dtype == 3) {
+    } else if (inputs[i].dtype == INT8) {
       uint8_t *im_tensor_data;
-      im_tensor_data = (uint8_t *)(inputs[i].data.data());  // NOLINT
+      im_tensor_data = (uint8_t*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
     } else {
       std::cerr << "There's unexpected input dtype: " << inputs[i].dtype

--- a/deploy/cpp/model_deploy/ppdet/include/det_model.h
+++ b/deploy/cpp/model_deploy/ppdet/include/det_model.h
@@ -31,7 +31,7 @@ class DetModel : public Model {
 
  public:
   explicit DetModel(const std::string model_type) : model_type(model_type) {
-    std::cout << "init DetModel,model_type=" << model_type << std::endl;
+    std::cerr << "init DetModel,model_type=" << model_type << std::endl;
   }
 
   bool YamlConfigInit(const std::string &cfg_file);

--- a/deploy/cpp/model_deploy/ppdet/src/det_model.cpp
+++ b/deploy/cpp/model_deploy/ppdet/src/det_model.cpp
@@ -63,6 +63,7 @@ bool DetModel::DetParserTransforms(const YAML::Node& preprocess_op) {
       yaml_config_["transforms"]["Resize"]["interp"] =
           preprocess_op["interp"].as<int>();
       yaml_config_["transforms"]["Resize"]["max_size"] = max_size;
+      yaml_config_["transforms"]["Resize"]["use_scale"] = false;
     }
   } else if (preprocess_op_type == "PadStride") {
     yaml_config_["transforms"]["Padding"]["stride"] =

--- a/deploy/cpp/model_deploy/ppdet/src/det_postprocess.cpp
+++ b/deploy/cpp/model_deploy/ppdet/src/det_postprocess.cpp
@@ -53,6 +53,10 @@ bool DetPostProcess::ProcessBbox(const std::vector<DataBlob>& outputs,
     for (auto j = 0; j < num_bboxes_each_sample[i]; ++j) {
       Box box;
       box.category_id = static_cast<int>(round(data[idx * 6]));
+      if (box.category_id < 0) {
+        std::cerr << "Compute category id is less than 0" << std::endl;
+        return false;
+      }
       if (box.category_id >= labels_.size()) {
         std::cerr << "Compute category id is greater than labels "
                   << "in your config file" << std::endl;

--- a/deploy/cpp/scripts/build.sh
+++ b/deploy/cpp/scripts/build.sh
@@ -23,10 +23,6 @@ CUDNN_LIB=/usr/lib/x86_64-linux-gnu
     exit -1
 }
 
-# 是否加载加密后的模型
-WITH_ENCRYPTION=OFF
-# 加密工具的路径, 如果使用自带预编译版本可不修改
-ENCRYPTION_DIR=$(pwd)/paddlex-encryption
 # OPENCV 路径, 如果使用自带预编译版本可不修改
 OPENCV_DIR=$(pwd)/deps/opencv3.4.6gcc4.8ffmpeg/
 
@@ -38,12 +34,10 @@ cmake .. \
     -DWITH_GPU=${WITH_GPU} \
     -DWITH_MKL=${WITH_MKL} \
     -DWITH_TENSORRT=${WITH_TENSORRT} \
-    -DWITH_ENCRYPTION=${WITH_ENCRYPTION} \
     -DTENSORRT_DIR=${TENSORRT_DIR} \
     -DPADDLE_DIR=${PADDLE_DIR} \
     -DWITH_STATIC_LIB=${WITH_STATIC_LIB} \
     -DCUDA_LIB=${CUDA_LIB} \
     -DCUDNN_LIB=${CUDNN_LIB} \
-    -DENCRYPTION_DIR=${ENCRYPTION_DIR} \
     -DOPENCV_DIR=${OPENCV_DIR}
 make -j16


### PR DESCRIPTION
1. 修复FasterRCNN、FasterRCNN-FPN、YOLOv3、PPYOLO模型在python和cpp代码中结果的差异问题
2. 优化部分代码风格
3. 修改demo示例，用于自测

自测流程
1. 准备测试包 `paddlex_deploy_test`
2. 编译二进制`model_infer`
3. 使用如下命令测试
```
cd paddlex_deploy_test
# 第1个参数为编译后的二进制路径
sh run_det.sh /projects/build/demo/model_infer
```
如若没有问题，测试结果如下
```
======Test model det/models/YOLOv3-DarkNet======
Diff Pass!
======Test model det/models/PPYOLO======
Diff Pass!
======Test model det/models/FasterRCNN-R50======
Diff Pass!
======Test model det/models/FasterRCNN-R50-FPN======
Diff Pass!
```