### PR TITLE
add cv2.IMREAD_COLOR to decode when input_channel is 3

### DIFF
--- a/paddlex/cv/transforms/cls_transforms.py
+++ b/paddlex/cv/transforms/cls_transforms.py
@@ -77,9 +77,10 @@ class Compose(ClsTransform):
             try:
                 if input_channel == 3:
                     im = cv2.imread(im_file, cv2.IMREAD_ANYDEPTH |
-                                    cv2.IMREAD_ANYCOLOR)
+                                    cv2.IMREAD_ANYCOLOR | cv2.IMREAD_COLOR)
                 else:
-                    im = cv2.imread(im_file, cv2.IMREAD_UNCHANGED)
+                    im = cv2.imread(im_file, cv2.IMREAD_ANYDEPTH |
+                                    cv2.IMREAD_ANYCOLOR)
                     if im.ndim < 3:
                         im = np.expand_dims(im, axis=-1)
             except:

--- a/paddlex/cv/transforms/det_transforms.py
+++ b/paddlex/cv/transforms/det_transforms.py
@@ -112,9 +112,10 @@ class Compose(DetTransform):
                 try:
                     if input_channel == 3:
                         im = cv2.imread(im_file, cv2.IMREAD_ANYDEPTH |
-                                        cv2.IMREAD_ANYCOLOR)
+                                        cv2.IMREAD_ANYCOLOR | cv2.IMREAD_COLOR)
                     else:
-                        im = cv2.imread(im_file, cv2.IMREAD_UNCHANGED)
+                        im = cv2.imread(im_file, cv2.IMREAD_ANYDEPTH |
+                                        cv2.IMREAD_ANYCOLOR)
                         if im.ndim < 3:
                             im = np.expand_dims(im, axis=-1)
                 except:

--- a/paddlex/cv/transforms/seg_transforms.py
+++ b/paddlex/cv/transforms/seg_transforms.py
@@ -89,9 +89,10 @@ class Compose(SegTransform):
         elif img_format in ['jpeg', 'bmp', 'png', 'jpg']:
             if input_channel == 3:
                 return cv2.imread(img_path, cv2.IMREAD_ANYDEPTH |
-                                  cv2.IMREAD_ANYCOLOR)
+                                  cv2.IMREAD_ANYCOLOR | cv2.IMREAD_COLOR)
             else:
-                return cv2.imread(im_file, cv2.IMREAD_UNCHANGED)
+                return cv2.imread(im_file, cv2.IMREAD_ANYDEPTH |
+                                  cv2.IMREAD_ANYCOLOR)
         elif ext == '.npy':
             return np.load(img_path)
         else:


### PR DESCRIPTION
* When `input_channel` is set to be 3，if the input image is 1-channel，the decode function shown as below will output a 1-channel array, we append `cv2.IMREAD_COLOR` to the existing flag to copy a 1-channel uint8/uint16/float32 image data to a 3-channel one.
![image](https://user-images.githubusercontent.com/22235422/116350379-6adba280-a824-11eb-8291-c64aa613d572.png)

* When `input_channel` is set to be 1,  we add `cv2.IMREAD_ANYDEPTH | cv2.IMREAD_ANYCOLOR` to decode uint8/uint16/float32 image data.
