### PR TITLE
fix 'local variable 'im' referenced before assignment' for classification transform

### DIFF
--- a/paddlex/cv/transforms/cls_transforms.py
+++ b/paddlex/cv/transforms/cls_transforms.py
@@ -73,6 +73,7 @@ class Compose(ClsTransform):
                 raise Exception(
                     "im should be 3-dimension, but now is {}-dimensions".
                     format(len(im_file.shape)))
+            im = im_file
         else:
             try:
                 if input_channel == 3:


### PR DESCRIPTION
Local variable 'im' is not declared in classification transform, we fix this bug.

see issue https://github.com/PaddlePaddle/PaddleX/issues/703