### PR TITLE
upgrade paddlehub to 2.1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         "pycocotools;platform_system!='Windows'", 'pyyaml', 'colorama', 'tqdm',
         'paddleslim==1.1.1', 'visualdl>=2.0.0', 'paddlehub==2.0.1',
         'shapely>=1.7.0', 'opencv-python', 'flask_cors', 'sklearn', 'psutil',
-        'xlwt', 'paddle2onnx==0.4'
+        'xlwt'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     setup_requires=['cython', 'numpy'],
     install_requires=[
         "pycocotools;platform_system!='Windows'", 'pyyaml', 'colorama', 'tqdm',
-        'paddleslim==1.1.1', 'visualdl>=2.0.0', 'paddlehub==2.0.1',
+        'paddleslim==1.1.1', 'visualdl>=2.0.0', 'paddlehub==2.1.0',
         'shapely>=1.7.0', 'opencv-python', 'flask_cors', 'sklearn', 'psutil',
         'xlwt'
     ],


### PR DESCRIPTION
We add paddle2onnx==0.4 in setup.py, because paddlehub import paddle2onnx but do not forcibly install paddle2onnx when install paddlehub.

But when upgrade paddlehub to 2.1.0, paddlehub forcibly installs paddle2onnx, so we delete paddle2onnx in setup.py.