### PR TITLE
add triton engine

### DIFF
--- a/deploy/cpp/demo/triton/CMakeLists.txt
+++ b/deploy/cpp/demo/triton/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(GLOG_DIR "" CACHE PATH "Location of libraries")
 SET(GFLAGS_DIR "" CACHE PATH "Location of libraries")
 SET(OPENCV_DIR "" CACHE PATH "Location of libraries")
 
-SET(PROJECT_ROOT_DIR  "." CACHE PATH  "root directory of project.")
+SET(PROJECT_ROOT_DIR  "../../" CACHE PATH  "root directory of project.")
 
 if (NOT WIN32)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -125,7 +125,7 @@ aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/ppseg/src DETECTOR_SRC)
 aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/ppclas/src DETECTOR_SRC)
 aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/paddlex/src DETECTOR_SRC)
 
-add_executable(model_infer ${PROJECT_ROOT_DIR}/demo/model_infer.cpp ${SRC} ${ENGINE_SRC} ${DETECTOR_SRC})
+add_executable(model_infer ${PROJECT_ROOT_DIR}/demo/triton/model_infer.cpp ${SRC} ${ENGINE_SRC} ${DETECTOR_SRC})
 ADD_DEPENDENCIES(model_infer ext-yaml-cpp)
 target_link_libraries(model_infer ${DEPS})
 

--- a/deploy/cpp/demo/triton/CMakeLists.txt
+++ b/deploy/cpp/demo/triton/CMakeLists.txt
@@ -1,19 +1,16 @@
 cmake_minimum_required(VERSION 3.0)
 project(PaddleDeploy CXX C)
 
-option(WITH_MKL        "Compile demo with MKL/OpenBlas support,defaultuseMKL."          ON)
-option(WITH_GPU        "Compile demo with GPU/CPU, default use CPU."                    OFF)
 if (NOT WIN32)
     option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   OFF)
 else()
     option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
 endif()
-option(WITH_TENSORRT "Compile demo with TensorRT."   OFF)
 
-SET(TENSORRT_DIR "" CACHE PATH "Location of libraries")
-SET(PADDLE_DIR "" CACHE PATH "Location of libraries")
+SET(TRITON_CLIENT "" CACHE PATH "Location of libraries")
+SET(GLOG_DIR "" CACHE PATH "Location of libraries")
+SET(GFLAGS_DIR "" CACHE PATH "Location of libraries")
 SET(OPENCV_DIR "" CACHE PATH "Location of libraries")
-SET(CUDA_LIB "" CACHE PATH "Location of libraries")
 
 SET(PROJECT_ROOT_DIR  "." CACHE PATH  "root directory of project.")
 
@@ -31,7 +28,7 @@ endif()
 include_directories("${CMAKE_SOURCE_DIR}/")
 link_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-#yaml-cpp
+# yaml-cpp
 if(WIN32)
   SET(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "yaml build shared library.")
 else()
@@ -41,65 +38,21 @@ include(${PROJECT_ROOT_DIR}/cmake/yaml-cpp.cmake)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/yaml-cpp/src/ext-yaml-cpp/include")
 link_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/yaml-cpp/lib")
 
-#paddle inference
-if (NOT DEFINED PADDLE_DIR OR ${PADDLE_DIR} STREQUAL "")
-    message(FATAL_ERROR "please set PADDLE_DIR with -DPADDLE_DIR=/path/paddle_influence_dir")
-endif()
+# Triton
+MESSAGE("${GFLAGS_DIR}")
+include_directories("${GFLAGS_DIR}/include")
+link_directories("${GFLAGS_DIR}/lib")
 
-#paddle inference third party
-include_directories("${PADDLE_DIR}")
-include_directories("${PADDLE_DIR}/third_party/install/protobuf/include")
-include_directories("${PADDLE_DIR}/third_party/install/glog/include")
-include_directories("${PADDLE_DIR}/third_party/install/gflags/include")
-include_directories("${PADDLE_DIR}/third_party/install/xxhash/include")
-include_directories("${PADDLE_DIR}/third_party/install/cryptopp/include")
+include_directories("${GLOG_DIR}/include")
+link_directories("${GLOG_DIR}/lib")
 
-link_directories("${PADDLE_DIR}/paddle/lib/")
-link_directories("${PADDLE_DIR}/third_party/install/protobuf/lib")
-link_directories("${PADDLE_DIR}/third_party/install/glog/lib")
-link_directories("${PADDLE_DIR}/third_party/install/gflags/lib")
-link_directories("${PADDLE_DIR}/third_party/install/xxhash/lib")
-link_directories("${PADDLE_DIR}/third_party/install/cryptopp/lib")
+include_directories("${TRITON_CLIENT}/include")
+link_directories("${TRITON_CLIENT}/lib")
 
-if (WIN32)
-  set(DEPS ${DEPS} ${PADDLE_DIR}/paddle/lib/paddle_inference.lib)
-  set(DEPS ${DEPS} glog gflags_static libprotobuf xxhash cryptopp-static libyaml-cppmt shlwapi)
-else()
-  if (WITH_STATIC_LIB)
-    set(DEPS ${PADDLE_DIR}/paddle/lib/libpaddle_inference${CMAKE_STATIC_LIBRARY_SUFFIX})
-  else()
-    set(DEPS ${PADDLE_DIR}/paddle/lib/libpaddle_inference${CMAKE_SHARED_LIBRARY_SUFFIX})
-  endif()
-  set(DEPS ${DEPS} glog gflags protobuf xxhash cryptopp yaml-cpp)
-endif(WIN32)
+set(DEPS ${TRITON_CLIENT}/lib/libhttpclient${CMAKE_SHARED_LIBRARY_SUFFIX})
+set(DEPS ${DEPS} glog gflags protobuf yaml-cpp)
 
-#MKL
-if(WITH_MKL)
-  ADD_DEFINITIONS(-DUSE_MKL)
-  set(MKLML_PATH "${PADDLE_DIR}/third_party/install/mklml")
-  include_directories("${MKLML_PATH}/include")
-  if (WIN32)
-    set(MATH_LIB ${MKLML_PATH}/lib/mklml.lib ${MKLML_PATH}/lib/libiomp5md.lib)
-  else ()
-    set(MATH_LIB ${MKLML_PATH}/lib/libmklml_intel${CMAKE_SHARED_LIBRARY_SUFFIX} ${MKLML_PATH}/lib/libiomp5${CMAKE_SHARED_LIBRARY_SUFFIX})
-    execute_process(COMMAND cp -r ${MKLML_PATH}/lib/libmklml_intel${CMAKE_SHARED_LIBRARY_SUFFIX} /usr/lib)
-  endif ()
-  set(MKLDNN_PATH "${PADDLE_DIR}/third_party/install/mkldnn")
-  if(EXISTS ${MKLDNN_PATH})
-    include_directories("${MKLDNN_PATH}/include")
-    if (WIN32)
-      set(MKLDNN_LIB ${MKLDNN_PATH}/lib/mkldnn.lib)
-    else ()
-      set(MKLDNN_LIB ${MKLDNN_PATH}/lib/libmkldnn.so.0)
-    endif ()
-  endif()
-else()
-  set(MATH_LIB ${PADDLE_DIR}/third_party/install/openblas/lib/libopenblas${CMAKE_STATIC_LIBRARY_SUFFIX})
-endif()
-
-set(DEPS ${DEPS} ${MATH_LIB} ${MKLDNN_LIB})
-
-#OPENCV
+# OPENCV
 if (NOT (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64"))
   if (NOT DEFINED OPENCV_DIR OR ${OPENCV_DIR} STREQUAL "")
     message(FATAL_ERROR "please set OPENCV_DIR with -DOPENCV_DIR=/path/opencv")
@@ -122,33 +75,7 @@ endif ()
 set(DEPS ${DEPS} ${OpenCV_LIBS})
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-#set GPU
-if(WITH_GPU)
-  if (NOT DEFINED CUDA_LIB OR ${CUDA_LIB} STREQUAL "")
-    message(FATAL_ERROR "please set CUDA_LIB with -DCUDA_LIB=/path/cuda/lib64")
-  endif()
-
-  if(NOT WIN32)
-    if (NOT DEFINED CUDNN_LIB)
-      message(FATAL_ERROR "please set CUDNN_LIB with -DCUDNN_LIB=/path/cudnn/")
-    endif()
-
-    if (WITH_TENSORRT)
-      include_directories("${TENSORRT_DIR}/include")
-      link_directories("${TENSORRT_DIR}/lib")
-
-      set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/libnvinfer${CMAKE_SHARED_LIBRARY_SUFFIX})
-      set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/libnvinfer_plugin${CMAKE_SHARED_LIBRARY_SUFFIX})
-    endif()
-    set(DEPS ${DEPS} ${CUDA_LIB}/libcudart${CMAKE_SHARED_LIBRARY_SUFFIX})
-    set(DEPS ${DEPS} ${CUDNN_LIB}/libcudnn${CMAKE_SHARED_LIBRARY_SUFFIX})
-  else()
-    set(DEPS ${DEPS} ${CUDA_LIB}/cudart${CMAKE_STATIC_LIBRARY_SUFFIX} )
-    set(DEPS ${DEPS} ${CUDA_LIB}/cublas${CMAKE_STATIC_LIBRARY_SUFFIX} )
-    set(DEPS ${DEPS} ${CUDA_LIB}/cudnn${CMAKE_STATIC_LIBRARY_SUFFIX})
-  endif()
-endif()
-
+# 
 macro(safe_set_static_flag)
     foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
@@ -190,7 +117,7 @@ message("-----DEPS = ${DEPS}")
 include_directories("${PROJECT_ROOT_DIR}")
 
 aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/common/src SRC)
-set(ENGINE_SRC ${PROJECT_ROOT_DIR}/model_deploy/engine/src/ppinference_engine.cpp)
+set(ENGINE_SRC ${PROJECT_ROOT_DIR}/model_deploy/engine/src/triton_engine.cpp)
 
 #detector seg
 aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/ppdet/src DETECTOR_SRC)
@@ -201,10 +128,6 @@ aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/paddlex/src DETECTOR_SRC)
 add_executable(model_infer ${PROJECT_ROOT_DIR}/demo/model_infer.cpp ${SRC} ${ENGINE_SRC} ${DETECTOR_SRC})
 ADD_DEPENDENCIES(model_infer ext-yaml-cpp)
 target_link_libraries(model_infer ${DEPS})
-
-add_executable(multi_gpu_model_infer ${PROJECT_ROOT_DIR}/demo/multi_gpu_model_infer.cpp ${SRC} ${ENGINE_SRC} ${DETECTOR_SRC})
-ADD_DEPENDENCIES(multi_gpu_model_infer ext-yaml-cpp)
-target_link_libraries(multi_gpu_model_infer ${DEPS})
 
 if(WIN32)
   add_custom_command(TARGET model_infer POST_BUILD

--- a/deploy/cpp/demo/triton/CMakeLists.txt
+++ b/deploy/cpp/demo/triton/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(PaddleDeploy CXX C)
 
-if (NOT WIN32)
-    option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   OFF)
-else()
-    option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
-endif()
-
 SET(TRITON_CLIENT "" CACHE PATH "Location of libraries")
 SET(GLOG_DIR "" CACHE PATH "Location of libraries")
 SET(GFLAGS_DIR "" CACHE PATH "Location of libraries")
@@ -14,26 +8,18 @@ SET(OPENCV_DIR "" CACHE PATH "Location of libraries")
 
 SET(PROJECT_ROOT_DIR  "../../" CACHE PATH  "root directory of project.")
 
-if (NOT WIN32)
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/demo)
-else()
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/paddle_deploy)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/paddle_deploy)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/paddle_deploy)
-endif()
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/demo)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -o2 -fopenmp -std=c++11")
 #source
 include_directories("${CMAKE_SOURCE_DIR}/")
 link_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 # yaml-cpp
-if(WIN32)
-  SET(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "yaml build shared library.")
-else()
-  SET(YAML_BUILD_SHARED_LIBS ON CACHE BOOL "yaml build shared library.")
-endif(WIN32)
+SET(YAML_BUILD_SHARED_LIBS ON CACHE BOOL "yaml build shared library.")
+
 include(${PROJECT_ROOT_DIR}/cmake/yaml-cpp.cmake)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/yaml-cpp/src/ext-yaml-cpp/include")
 link_directories("${CMAKE_CURRENT_BINARY_DIR}/ext/yaml-cpp/lib")
@@ -59,57 +45,16 @@ if (NOT (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64"))
   endif()
 endif()
 
-if (WIN32)
-  find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/build/ NO_DEFAULT_PATH)
-  unset(OpenCV_DIR CACHE)
-else ()
-  if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64") # x86_64 aarch64
-    set(OpenCV_INCLUDE_DIRS "/usr/include/opencv4")
-    file(GLOB OpenCV_LIBS /usr/lib/aarch64-linux-gnu/libopencv_*${CMAKE_SHARED_LIBRARY_SUFFIX})
-    message("OpenCV libs: ${OpenCV_LIBS}")
-  else()
-    find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/share/OpenCV NO_DEFAULT_PATH)
-  endif()
-endif ()
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64") # x86_64 aarch64
+  set(OpenCV_INCLUDE_DIRS "/usr/include/opencv4")
+  file(GLOB OpenCV_LIBS /usr/lib/aarch64-linux-gnu/libopencv_*${CMAKE_SHARED_LIBRARY_SUFFIX})
+  message("OpenCV libs: ${OpenCV_LIBS}")
+else()
+  find_package(OpenCV REQUIRED PATHS ${OPENCV_DIR}/share/OpenCV NO_DEFAULT_PATH)
+endif()
 
 set(DEPS ${DEPS} ${OpenCV_LIBS})
 include_directories(${OpenCV_INCLUDE_DIRS})
-
-# 
-macro(safe_set_static_flag)
-    foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-      if(${flag_var} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-      endif(${flag_var} MATCHES "/MD")
-    endforeach(flag_var)
-endmacro()
-
-if (WIN32)
-    add_definitions("/DGOOGLE_GLOG_DLL_DECL=")
-    find_package(OpenMP REQUIRED)
-    if (OPENMP_FOUND)
-        message("OPENMP FOUND")
-        set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} ${OpenMP_C_FLAGS}")
-        set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} ${OpenMP_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} ${OpenMP_CXX_FLAGS}")
-        set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS_RELEASE} ${OpenMP_CXX_FLAGS}")
-    endif()
-    set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} /bigobj /MTd")
-    set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} /bigobj /MT")
-    set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} /bigobj /MTd")
-    set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_CXX_FLAGS_RELEASE} /bigobj /MT")
-    if (WITH_STATIC_LIB)
-        safe_set_static_flag()
-        add_definitions(-DSTATIC_LIB)
-    endif()
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -o2 -fopenmp -std=c++11")
-    set(CMAKE_STATIC_LIBRARY_PREFIX "")
-    set(EXTERNAL_LIB "-ldl -lrt -lgomp -lz -lm -lpthread")
-    set(DEPS ${DEPS} ${EXTERNAL_LIB})
-endif()
 
 message("-----DEPS = ${DEPS}")
 
@@ -128,12 +73,3 @@ aux_source_directory(${PROJECT_ROOT_DIR}/model_deploy/paddlex/src DETECTOR_SRC)
 add_executable(model_infer ${PROJECT_ROOT_DIR}/demo/triton/model_infer.cpp ${SRC} ${ENGINE_SRC} ${DETECTOR_SRC})
 ADD_DEPENDENCIES(model_infer ext-yaml-cpp)
 target_link_libraries(model_infer ${DEPS})
-
-if(WIN32)
-  add_custom_command(TARGET model_infer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${PADDLE_DIR}/third_party/install/mklml/lib/mklml.dll ${CMAKE_BINARY_DIR}/paddle_deploy
-    COMMAND ${CMAKE_COMMAND} -E copy ${PADDLE_DIR}/third_party/install/mklml/lib/libiomp5md.dll ${CMAKE_BINARY_DIR}/paddle_deploy
-    COMMAND ${CMAKE_COMMAND} -E copy ${PADDLE_DIR}/third_party/install/mkldnn/lib/mkldnn.dll  ${CMAKE_BINARY_DIR}/paddle_deploy
-    COMMAND ${CMAKE_COMMAND} -E copy ${PADDLE_DIR}/paddle/lib/paddle_inference.dll ${CMAKE_BINARY_DIR}/paddle_deploy 
-  )
-endif()

--- a/deploy/cpp/demo/triton/model_infer.cpp
+++ b/deploy/cpp/demo/triton/model_infer.cpp
@@ -27,8 +27,6 @@ DEFINE_string(cfg_file, "", "Path of yaml file");
 DEFINE_string(model_type, "", "model type");
 DEFINE_string(image, "", "Path of test image file");
 DEFINE_string(image_list, "", "Path of test image file");
-DEFINE_int32(thread_num, 1, "thread num of preprocessing");
-DEFINE_int32(mkl_thread_num, 8, "thread num of mkldnn");
 
 int main(int argc, char** argv) {
   // Parsing command-line

--- a/deploy/cpp/demo/triton/model_infer.cpp
+++ b/deploy/cpp/demo/triton/model_infer.cpp
@@ -34,8 +34,8 @@ int main(int argc, char** argv) {
   // Parsing command-line
   google::ParseCommandLineFlags(&argc, &argv, true);
   std::cout << "ParseCommandLineFlags:FLAGS_model_type="
-            << FLAGS_model_type << " model_filename="
-            << FLAGS_model_filename << std::endl;
+            << FLAGS_model_type << " model_name="
+            << FLAGS_model_name << std::endl;
 
   // create model
   std::shared_ptr<PaddleDeploy::Model> model =
@@ -76,14 +76,20 @@ int main(int argc, char** argv) {
   std::cout << "start model predict " << image_paths.size() << std::endl;
   // infer
   std::vector<PaddleDeploy::Result> results;
+  std::vector<cv::Mat> imgs;
+  cv::Mat img;
   for (auto i = 0; i < image_paths.size(); ++i) {
-    std::Mat img = cv::imread(image_paths[i]);
+    img = cv::imread(image_paths[i]);
     if (img.empty()) {
       std::cerr << "Fail to read image: " << i << std::endl;
       return -1;
     }
-    model->Predict(img, &results, FLAGS_thread_num);
-    std::cout << << "image: " << i + 1 << std::endl;
+    imgs.clear();
+    imgs.push_back(std::move(img));
+
+    model->Predict(imgs, &results, FLAGS_thread_num);
+    
+    std::cout << "image: " << image_paths[i] << std::endl;
     for (auto j = 0; j < results.size(); ++j) {
       std::cout << "Result for sample " << j << std::endl;
       std::cout << results[j] << std::endl;

--- a/deploy/cpp/demo/triton/model_infer.cpp
+++ b/deploy/cpp/demo/triton/model_infer.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   // inference engine init
   model->TritonEngineInit(FLAGS_url, FLAGS_model_name, FLAGS_model_version);
 
-
+  // prepare data
   std::vector<std::string> image_paths;
   if (FLAGS_image_list != "") {
     std::ifstream inf(FLAGS_image_list);

--- a/deploy/cpp/demo/triton/model_infer.cpp
+++ b/deploy/cpp/demo/triton/model_infer.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+#include <omp.h>
+#include <memory>
+#include <string>
+#include <fstream>
+
+#include "model_deploy/common/include/paddle_deploy.h"
+
+DEFINE_string(model_name, "", "Path of inference model");
+DEFINE_string(url, "", "url of triton server");
+DEFINE_string(model_version, "", "model version of triton server");
+DEFINE_string(cfg_file, "", "Path of yaml file");
+DEFINE_string(model_type, "", "model type");
+DEFINE_string(image, "", "Path of test image file");
+DEFINE_string(image_list, "", "Path of test image file");
+DEFINE_int32(thread_num, 1, "thread num of preprocessing");
+DEFINE_int32(mkl_thread_num, 8, "thread num of mkldnn");
+
+int main(int argc, char** argv) {
+  // Parsing command-line
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  std::cout << "ParseCommandLineFlags:FLAGS_model_type="
+            << FLAGS_model_type << " model_filename="
+            << FLAGS_model_filename << std::endl;
+
+  // create model
+  std::shared_ptr<PaddleDeploy::Model> model =
+        PaddleDeploy::CreateModel(FLAGS_model_type);
+  if (!model) {
+    std::cout << "no model_type: " << FLAGS_model_type
+              << "  model=" << model << std::endl;
+    return 0;
+  }
+  std::cout << "start model init " << std::endl;
+
+  // model init
+  model->Init(FLAGS_cfg_file);
+  std::cout << "start engine init " << std::endl;
+
+  // inference engine init
+  model->TritonEngineInit(FLAGS_url, FLAGS_model_name, FLAGS_model_version);
+
+
+  std::vector<std::string> image_paths;
+  if (FLAGS_image_list != "") {
+    std::ifstream inf(FLAGS_image_list);
+    if (!inf) {
+      std::cerr << "Fail to open file " << FLAGS_image_list << std::endl;
+      return -1;
+    }
+    std::string image_path;
+    while (getline(inf, image_path)) {
+      image_paths.push_back(image_path);
+    }
+  } else if (FLAGS_image != "") {
+    image_paths.push_back(FLAGS_image);
+  } else {
+    std::cerr << "image_list or image should be defined" << std::endl;
+    return -1;
+  }
+
+  std::cout << "start model predict " << image_paths.size() << std::endl;
+  // infer
+  std::vector<PaddleDeploy::Result> results;
+  for (auto i = 0; i < image_paths.size(); ++i) {
+    std::Mat img = cv::imread(image_paths[i]);
+    if (img.empty()) {
+      std::cerr << "Fail to read image: " << i << std::endl;
+      return -1;
+    }
+    model->Predict(img, &results, FLAGS_thread_num);
+    std::cout << << "image: " << i + 1 << std::endl;
+    for (auto j = 0; j < results.size(); ++j) {
+      std::cout << "Result for sample " << j << std::endl;
+      std::cout << results[j] << std::endl;
+    }
+  }
+  return 0;
+}

--- a/deploy/cpp/docs/compile/triton/docker.md
+++ b/deploy/cpp/docs/compile/triton/docker.md
@@ -1,0 +1,214 @@
+# 基于Docker快速上手Triton部署
+
+本文档将介绍如何基于Docker快速将Paddle转换的ONNX模型部署到Triton服务上。 并以ResNet50模型为例， 讲述整个流程。[点击下载模型](https://bj.bcebos.com/paddlex/deploy2/models/resnet50_onnx.tar.gz)
+
+## 1 拉取Triton Docker镜像
+拉取 Triton Docker镜像之前，首先需要安装[Docker](https://docs.docker.com/engine/install/)，如果需要使用GPU预测请安装[NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker)。
+
+拉取镜像的命令：
+
+- `<xx.yy>`指的是你需要拉取的Triton docker版本，目前支持`20.11`，所以请手动替换`<xx.yy>`为`20.11`。
+- 镜像后缀为`-py3`为Triton的服务端（server），`-py3-clientsdk`为Triton的客户端（client）。
+
+```
+docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3
+docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk
+```
+
+## 2 部署Triton服务
+
+### 2.1 准备模型库（Model Repository）
+
+在启动Triton服务之前，我们需要准备模型库，主要包括模型文件，模型配置文件和标签文件等。模型库的概念和使用方法请参考[model_repository](https://github.com/triton-inference-server/server/blob/master/docs/model_repository.md)，模型配置文件涉及到需要关键的配置，更详细的使用方法可参考[model_configuration](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md)。 以PaddleClas中的ResNet50模型为例， 模型库的详细构成如下。
+
+
+
+完整的模型库目录结构如下：
+
+```
+model_repository             # 模型库目录
+-- resnet50_onnx             # 要加载的模型目录
+  |-- 1                      # 模型版本号, 默认加载最高版本
+  |   |-- model.onnx          # ResNet50转换后的onnx模型
+  -- config.pbtxt            # 模型配置文件
+-- model2                    # 如果有多个模型目录，会同时加载多个模型
+  |-- 1                      
+  |   |-- model.onnx         
+  -- config.pbtxt            
+```
+
+#### 模型配置文件
+
+模型配置文件config.pbtxt按需填写，最基本配置如下，如需要更高级配置请参考[model_configuration](https://github.com/triton-inference-server/server/blob/master/docs/model_configuration.md)。 
+
+```
+name: "resnet50_onnx"                     # 模型名， 需与外层目录名一致
+platform: "onnxruntime_onnx"              # 使用的推理引擎
+max_batch_size : 0                        # 最大的batch数， 0为不限制
+input [
+  {
+    name: "inputs"
+    data_type: TYPE_FP32
+    dims: [-1, 3, 224, 224]
+  }
+]
+output [
+  {
+    name: "save_infer_model/scale_0.tmp_1"
+    data_type: TYPE_FP32
+    dims: [-1, 1000]
+  }
+]
+```
+
+**注意：** ONNX 模型可以通过设置启动参数，自动生成最基本配置文件，这样可不用在模型目录中填写config.pbtxt文件
+
+```
+启动时设置 --strict-model-config=false
+# 例如
+docker run --gpus=1 --rm -p8000:8000 -p8001:8001 -p8002:8002 -v /path/to/model_repository/:/model_repository/ nvcr.io/nvidia/tritonserver:<xx.yy>-py3 tritonserver --model-repository=/model_repository/ --strict-model-config=false
+
+# 可通过curl指令获取配置文件
+curl localhost:8000/v2/models/<model name>/config
+# resnet50例子
+curl localhost:8000/v2/models/resnet50_onnx/config
+```
+
+
+
+#### Paddle Inference模型转为ONNX模型
+
+1.通过[PaddleClas模型部署指南](../../models/paddleclas.md) 得到Paddle Inference类型的ResNet50模型，其他套件模型请参考：[PaddleDetection模型部署指南](../../models/paddledetection.md) 、[PaddleSeg模型部署指南](../../models/paddleseg.md) 
+
+```
+ResNet50
+  |-- model.pdiparams        # 静态图模型参数
+  |-- model.pdiparams.info   # 参数额外信息，一般无需关注
+  |-- model.pdmodel          # 静态图模型文件
+  |-- resnet50_imagenet.yml  # 配置文件
+```
+
+2.将paddle inference模型转为onnx模型， 详细可参考[Paddle2ONNX](https://github.com/PaddlePaddle/Paddle2ONNX.git)文档
+
+ResNet50模型转换如下，转换后模型输出在 onnx_models/resnet50_onnx/model.onnx。 
+
+```
+paddle2onnx --model_dir path/to/ResNet50  --save_file onnx_models/resnet50_onnx/model.onnx  --opset_version 9 --enable_onnx_checker True --model_filename model.pdmodel --params_filename model.pdiparams
+```
+
+**注意：**
+
+- 留意模型转换的输出，根据提示调整opset_version的值
+- paddle inference模型中配置文件(如 resnet50_imagenet.yml)在进行推理请求时会用到
+
+
+
+### 2.2 启动Triton server服务
+
+经过Triton的优化可以使用GPU提供极佳的推理性能，且可以在仅支持CPU的系统上工作。以上两种情况下，我们都可以使用上述的Triton Docker镜像部署。
+
+#### 2.2.1 启动基于GPU的服务
+
+使用以下命令对刚刚创建的ResNet模型库运行Triton服务。必须安装[NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-docker)，Docker才能识别GPU。 --gpus = 1参数表明Triton可以使用1块GPU进行推理。
+
+```
+docker run --gpus=1 --rm -p8000:8000 -p8001:8001 -p8002:8002 -v /path/to/model_repository/:/model_repository/
+ nvcr.io/nvidia/tritonserver:<xx.yy>-py3 tritonserver --model-repository=/model_repository/
+```
+
+启动Triton之后，您将在控制台上看到如下输出，显示服务器正在启动并加载模型。当您看到如下输出时，Triton已加载好模型，可进行推理请求。
+
+```
++----------------------+---------+--------+
+| Model                | Version | Status |
++----------------------+---------+--------+
+| <model_name>         | <v>     | READY  |
+| ..                   | .       | ..     |
+| ..                   | .       | ..     |
++----------------------+---------+--------+
+...
+...
+...
+I1002 21:58:57.891440 62 grpc_server.cc:3914] Started GRPCInferenceService at 0.0.0.0:8001
+I1002 21:58:57.893177 62 http_server.cc:2717] Started HTTPService at 0.0.0.0:8000
+I1002 21:58:57.935518 62 http_server.cc:2736] Started Metrics Service at 0.0.0.0:8002
+```
+
+Triton会逐个目录加载模型，如果加载不成功，则会报告失败以及失败的原因。所有模型均应显示“ READY”状态，表示已正确加载。如果您的模型未显示在表中，请检查模型库和CUDA驱动程序的路径。
+
+#### 2.2.2 启动仅支持CPU的服务
+
+在没有GPU的系统上，请在不使用--gpus参数的情况下运行，其他参数与上述启动GPU部署服务的命令一致。
+
+```
+docker run --rm -p8000:8000 -p8001:8001 -p8002:8002 -v /path/to/model_repository/:/model_repository/
+ nvcr.io/nvidia/tritonserver:<xx.yy>-py3 tritonserver --model-repository=/model_repository/
+```
+
+### 2.3 验证远程服务
+
+使用Triton的ready接口来验证服务器和模型是否已准备好进行推断
+
+```
+curl -v localhost:8000/v2/health/ready
+
+打印：
+...
+< HTTP/1.1 200 OK
+< Content-Length: 0
+< Content-Type: text/plain
+```
+
+## 3 推理请求
+
+推理请求需要基于Triton的客户端代码，对部署代码进行编译。
+
+### 3.1 获取部署代码
+
+```
+git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout deploykit
+```
+
+### 3.2 启动Triton客户端容器
+
+启动容器时，需要-v参数把部署代码挂载进容器
+
+```
+# 启动前需把paddle模型的配置文件移到挂载目录，ResNet50模型为例
+mv ResNet50/resnet50_imagenet.yml /path/to/PaddleX/deploy/cpp
+# 启动容器
+docker run -it --net=host nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk -v /path/to/PaddleX/:/PaddleX/ bash
+```
+
+### 3.3 部署代码编译
+
+打开项目路径，运行编译脚本
+
+```
+cd /PaddleX/deploy/cpp/
+sh scripts/triton_build.sh --triton_client=/workspace/install/
+```
+
+### 3.4 进行推理请求
+
+编译后会在`PaddleX/deploy/cpp/build/demo`目录下生成`model_infer`可执行二进制文件示例，用于进行模型预处理、推理请求以及后处理。
+
+以[ResNet50](https://bj.bcebos.com/paddlex/deploy2/models/resnet50_onnx.tar.gz)为例，执行下面的指令即可进行推理请求。
+
+```
+./build/demo/model_infer --image resnet50/test.jpeg  --cfg_file resnet50/infer_cfg.yml --url localhost:8000 --model_name resnet50_onnx --model_type clas
+```
+
+**参数说明**
+
+| 参数名称      | 含义                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| model_name    | 模型名称                                                                                          |
+| url           | 服务的远程IP地址+端口，如：localhost:8000                                                         |
+| model_version | 模型版本号，默认为1                                                                               |
+| cfg_file      | Paddle Inference模型配置文件路径，如`resnet50/infer_cfg.yml`                                      |
+| image         | 需要预测的单张图片的文件路径                                                                      |
+| image_list    | 待预测的图片路径列表文件路径，列表里每一行是一张图片的文件路径                                    |
+| model_type    | 模型来源，det/seg/clas/paddlex，分别表示模型来源于PaddleDetection、PaddleSeg、PaddleClas和PaddleX |

--- a/deploy/cpp/model_deploy/common/include/base_model.h
+++ b/deploy/cpp/model_deploy/common/include/base_model.h
@@ -69,6 +69,11 @@ class Model {
                         bool use_gpu = false, int gpu_id = 0,
                         bool use_mkl = true, int mkl_thread_num = 8);
 
+  bool TritonEngineInit(const std::string& url,
+                        const std::string& model_name,
+                        const std::string& model_version,
+                        bool verbose = false)
+
   virtual bool PostprocessInit() {
     postprocess_ = nullptr;
     std::cerr << "model no Postprocess!" << std::endl;

--- a/deploy/cpp/model_deploy/common/include/base_model.h
+++ b/deploy/cpp/model_deploy/common/include/base_model.h
@@ -72,7 +72,7 @@ class Model {
   bool TritonEngineInit(const std::string& url,
                         const std::string& model_name,
                         const std::string& model_version,
-                        bool verbose = false)
+                        bool verbose = false);
 
   virtual bool PostprocessInit() {
     postprocess_ = nullptr;

--- a/deploy/cpp/model_deploy/common/include/output_struct.h
+++ b/deploy/cpp/model_deploy/common/include/output_struct.h
@@ -57,7 +57,12 @@ struct DataBlob {
   }
   void Resize(const std::vector<int>& new_shape, int data_type) {
     assert(data_type >= 0 && data_type < 4);
-    int unit = sizeof(data_type);
+    int unit = 4;
+    if (data_type == INT64) {
+      unit = 8;
+    } else if (data_type == INT8) {
+      unit = 1;
+    }
     int total_size = std::accumulate(new_shape.begin(),
                 new_shape.end(), 1, std::multiplies<int>());
     data.resize(total_size * unit);

--- a/deploy/cpp/model_deploy/common/include/output_struct.h
+++ b/deploy/cpp/model_deploy/common/include/output_struct.h
@@ -57,12 +57,7 @@ struct DataBlob {
   }
   void Resize(const std::vector<int>& new_shape, int data_type) {
     assert(data_type >= 0 && data_type < 4);
-    int unit = 32;
-    if (data_type == INT64) {
-      unit = 64;
-    } else if (data_type == INT8) {
-      unit = 8;
-    }
+    int unit = sizeof(data_type);
     int total_size = std::accumulate(new_shape.begin(),
                 new_shape.end(), 1, std::multiplies<int>());
     data.resize(total_size * unit);

--- a/deploy/cpp/model_deploy/engine/include/engine.h
+++ b/deploy/cpp/model_deploy/engine/include/engine.h
@@ -18,53 +18,13 @@
 #include <vector>
 
 #include "model_deploy/common/include/output_struct.h"
+#include "model_deploy/engine/include/engine_config.h"
 
 namespace PaddleDeploy {
 
-struct InferenceConfig {
-  //  Whether to use mkdnn accelerator library when deploying on CPU
-  bool use_mkl = true;
-
-  //  The number of threads set when using mkldnn accelerator
-  int mkl_thread_num = 8;
-
-  //  Whether to use GPU
-  bool use_gpu = false;
-
-  //  Set GPU ID, default is 0
-  int gpu_id = 0;
-
-  //  Enable IR optimization
-  bool use_ir_optim = true;
-
-  // Whether to use TensorRT
-  bool use_trt = false;
-
-  //  Set batchsize
-  int batch_size = 1;
-
-  //  Set TensorRT min_subgraph_size
-  int min_subgraph_size = 1;
-
-  /*Set TensorRT data precision
-  0: FP32
-  1: FP16
-  2: Int8
-  */
-  int precision = 0;
-
-  //  When tensorrt is used, whether to serialize tensorrt engine to disk
-  bool use_static = false;
-
-  //  Is offline calibration required, when tensorrt is used
-  bool use_calib_mode = false;
-};
-
 class InferEngine {
  public:
-  virtual bool Init(const std::string &model_filename,
-                    const std::string &params_filename,
-                    const InferenceConfig &engine_config) = 0;
+  virtual bool Init(const InferenceConfig &engine_config) = 0;
 
   virtual bool Infer(const std::vector<DataBlob> &inputs,
                      std::vector<DataBlob> *outputs) = 0;

--- a/deploy/cpp/model_deploy/engine/include/engine.h
+++ b/deploy/cpp/model_deploy/engine/include/engine.h
@@ -24,10 +24,10 @@ namespace PaddleDeploy {
 
 class InferEngine {
  public:
-  virtual bool Init(const InferenceConfig &engine_config) = 0;
+  virtual bool Init(const InferenceConfig& engine_config) = 0;
 
-  virtual bool Infer(const std::vector<DataBlob> &inputs,
-                     std::vector<DataBlob> *outputs) = 0;
+  virtual bool Infer(const std::vector<DataBlob>& inputs,
+                     std::vector<DataBlob>* outputs) = 0;
 };
 
 }  // namespace PaddleDeploy

--- a/deploy/cpp/model_deploy/engine/include/engine_config.h
+++ b/deploy/cpp/model_deploy/engine/include/engine_config.h
@@ -20,10 +20,10 @@ namespace PaddleDeploy {
 
 struct PaddleEngineConfig {
   //  model file path
-  std::string &model_filename;
+  std::string model_filename = "";
 
   //  model params file path
-  std::string &params_filename;
+  std::string params_filename = "";
 
   //  Whether to use mkdnn accelerator library when deploying on CPU
   bool use_mkl = true;
@@ -130,7 +130,7 @@ struct InferenceConfig {
     paddle_config = nullptr;
   }
 
-  explicit InferenceConfig(const std::string engine_type) {
+  explicit InferenceConfig(std::string engine_type) {
     engine_type = engine_type;
     paddle_config = nullptr;
   }
@@ -146,7 +146,7 @@ struct InferenceConfig {
     }
   }
 
-  ~Result() {
+  ~InferenceConfig() {
     if ("paddle" == engine_type) {
       delete paddle_config;
       paddle_config = NULL;

--- a/deploy/cpp/model_deploy/engine/include/engine_config.h
+++ b/deploy/cpp/model_deploy/engine/include/engine_config.h
@@ -1,0 +1,160 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+namespace PaddleDeploy {
+
+struct PaddleEngineConfig {
+  //  model file path
+  std::string &model_filename;
+
+  //  model params file path
+  std::string &params_filename;
+
+  //  Whether to use mkdnn accelerator library when deploying on CPU
+  bool use_mkl = true;
+
+  //  The number of threads set when using mkldnn accelerator
+  int mkl_thread_num = 8;
+
+  //  Whether to use GPU
+  bool use_gpu = false;
+
+  //  Set GPU ID, default is 0
+  int gpu_id = 0;
+
+  //  Enable IR optimization
+  bool use_ir_optim = true;
+
+  // Whether to use TensorRT
+  bool use_trt = false;
+
+  //  Set batchsize
+  int batch_size = 1;
+
+  //  Set TensorRT min_subgraph_size
+  int min_subgraph_size = 1;
+
+  /*Set TensorRT data precision
+  0: FP32
+  1: FP16
+  2: Int8
+  */
+  int precision = 0;
+
+  //  When tensorrt is used, whether to serialize tensorrt engine to disk
+  bool use_static = false;
+
+  //  Is offline calibration required, when tensorrt is used
+  bool use_calib_mode = false;
+};
+
+struct TritonInferenceConfigs {
+  TritonInferenceConfigs() : model_name_(""), model_version_(""),
+        request_id_(""), sequence_id_(0), sequence_start_(false),
+        sequence_end_(false), priority_(0), server_timeout_(0),
+        client_timeout_(0) {}
+  /// The name of the model to run inference.
+  std::string model_name_;
+  /// The version of the model to use while running inference. The default
+  /// value is an empty string which means the server will select the
+  /// version of the model based on its internal policy.
+  std::string model_version_;
+  /// An identifier for the request. If specified will be returned
+  /// in the response. Default value is an empty string which means no
+  /// request_id will be used.
+  std::string request_id_;
+  /// The unique identifier for the sequence being represented by the
+  /// object. Default value is 0 which means that the request does not
+  /// belong to a sequence.
+  uint64_t sequence_id_;
+  /// Indicates whether the request being added marks the start of the
+  /// sequence. Default value is False. This argument is ignored if
+  /// 'sequence_id' is 0.
+  bool sequence_start_;
+  /// Indicates whether the request being added marks the end of the
+  /// sequence. Default value is False. This argument is ignored if
+  /// 'sequence_id' is 0.
+  bool sequence_end_;
+  /// Indicates the priority of the request. Priority value zero
+  /// indicates that the default priority level should be used
+  /// (i.e. same behavior as not specifying the priority parameter).
+  /// Lower value priorities indicate higher priority levels. Thus
+  /// the highest priority level is indicated by setting the parameter
+  /// to 1, the next highest is 2, etc. If not provided, the server
+  /// will handle the request using default setting for the model.
+  uint64_t priority_;
+  /// The timeout value for the request, in microseconds. If the request
+  /// cannot be completed within the time by the server can take a
+  /// model-specific action such as terminating the request. If not
+  /// provided, the server will handle the request using default setting
+  /// for the model.
+  uint64_t server_timeout_;
+  // The maximum end-to-end time, in microseconds, the request is allowed
+  // to take. Note the HTTP library only offer the precision upto
+  // milliseconds. The client will abort request when the specified time
+  // elapses. The request will return error with message "Deadline Exceeded".
+  // The default value is 0 which means client will wait for the
+  // response from the server. This option is not supported for streaming
+  // requests. Instead see 'stream_timeout' argument in
+  // InferenceServerGrpcClient::StartStream().
+  uint64_t client_timeout_;
+
+  bool verbose_ = false;
+
+  std::string url_;
+};
+
+struct InferenceConfig {
+  std::string engine_type;
+  union {
+    PaddleEngineConfig* paddle_config;
+    TritonInferenceConfigs* triton_config;
+  };
+
+  InferenceConfig() {
+    paddle_config = nullptr;
+  }
+
+  explicit InferenceConfig(const std::string engine_type) {
+    engine_type = engine_type;
+    paddle_config = nullptr;
+  }
+
+  InferenceConfig(const InferenceConfig& config) {
+    engine_type = config.engine_type;
+    if ("paddle" == engine_type) {
+      paddle_config = new PaddleEngineConfig();
+      *paddle_config = *(config.paddle_config);
+    } else if ("triton" == engine_type) {
+      triton_config = new TritonInferenceConfigs();
+      *triton_config = *(config.triton_config);
+    }
+  }
+
+  ~Result() {
+    if ("paddle" == engine_type) {
+      delete paddle_config;
+      paddle_config = NULL;
+    } else if ("triton" == engine_type) {
+      delete triton_config;
+      triton_config = NULL;
+    }
+  }
+};
+
+}  // namespace PaddleDeploy

--- a/deploy/cpp/model_deploy/engine/include/ppinference_engine.h
+++ b/deploy/cpp/model_deploy/engine/include/ppinference_engine.h
@@ -29,10 +29,10 @@ namespace PaddleDeploy {
 
 class PaddleInferenceEngine : public InferEngine {
  public:
-  virtual bool Init(const InferenceConfig &engine_config);
+  virtual bool Init(const InferenceConfig& engine_config);
 
-  virtual bool Infer(const std::vector<DataBlob> &inputs,
-                     std::vector<DataBlob> *outputs);
+  virtual bool Infer(const std::vector<DataBlob>& inputs,
+                     std::vector<DataBlob>* outputs);
 
  private:
   std::shared_ptr<paddle_infer::Predictor> predictor_;

--- a/deploy/cpp/model_deploy/engine/include/ppinference_engine.h
+++ b/deploy/cpp/model_deploy/engine/include/ppinference_engine.h
@@ -29,9 +29,7 @@ namespace PaddleDeploy {
 
 class PaddleInferenceEngine : public InferEngine {
  public:
-  virtual bool Init(const std::string &model_filename,
-                    const std::string &params_filename,
-                    const InferenceConfig &engine_config);
+  virtual bool Init(const InferenceConfig &engine_config);
 
   virtual bool Infer(const std::vector<DataBlob> &inputs,
                      std::vector<DataBlob> *outputs);

--- a/deploy/cpp/model_deploy/engine/include/triton_engine.h
+++ b/deploy/cpp/model_deploy/engine/include/triton_engine.h
@@ -39,9 +39,9 @@ class TritonInferenceEngine : public InferEngine {
 
   TritonInferenceEngine() : options_("") {}
 
-  void Init(const InferenceConfig& engine_configs);
+  bool Init(const InferenceConfig& engine_configs);
 
-  void Infer(const std::vector<DataBlob>& input_blobs,
+  bool Infer(const std::vector<DataBlob>& input_blobs,
              std::vector<DataBlob>* output_blobs);
 
  private:

--- a/deploy/cpp/model_deploy/engine/include/triton_engine.h
+++ b/deploy/cpp/model_deploy/engine/include/triton_engine.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "./common.h"
+#include "./http_client.h"
+#include "rapidjson/document.h"
+#include "rapidjson/rapidjson.h"
+#include "rapidjson/error/en.h"
+
+#include "model_deploy/common/include/output_struct.h"
+#include "model_deploy/engine/include/engine.h"
+#include "model_deploy/common/include/base_model.h"
+
+namespace nic = nvidia::inferenceserver::client;
+
+namespace PaddleDeploy {
+
+class TritonInferenceEngine : public InferEngine {
+ public:
+  std::unique_ptr<nic::InferenceServerHttpClient> client_;
+
+  TritonInferenceEngine() : options_("") {}
+
+  void Init(const InferenceConfig& engine_configs);
+
+  void Infer(const std::vector<DataBlob>& input_blobs,
+             std::vector<DataBlob>* output_blobs);
+
+ private:
+  nic::InferOptions options_;
+  nic::Headers headers_;
+  nic::Parameters query_params_;
+
+  void ParseConfigs(const TritonInferenceConfigs& configs);
+
+  void CreateInput(const std::vector<DataBlob>& input_blobs,
+                   std::vector<nic::InferInput* >* inputs);
+
+  void CreateOutput(const rapidjson::Document& model_metadata,
+                    std::vector<const nic::InferRequestedOutput* >* outputs);
+
+  nic::Error GetModelMetaData(rapidjson::Document* model_metadata);
+};
+
+}  // namespace PaddleDeploy

--- a/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
@@ -19,19 +19,22 @@ bool Model::PaddleEngineInit(const std::string &model_filename,
                              const std::string &params_filename, bool use_gpu,
                              int gpu_id, bool use_mkl, int mkl_thread_num) {
   infer_engine_ = std::make_shared<PaddleInferenceEngine>();
-  InferenceConfig ppi_config;
-  ppi_config.use_gpu = use_gpu;
-  ppi_config.gpu_id = gpu_id;
-  ppi_config.use_mkl = use_mkl;
-  ppi_config.mkl_thread_num = mkl_thread_num;
-  return infer_engine_->Init(model_filename, params_filename, ppi_config);
+  InferenceConfig config("paddle");
+  config.paddle_config = new PaddleEngineConfig();
+  config.paddle_config->model_filename = model_filename;
+  config.paddle_config->params_filename = params_filename;
+  config.paddle_config->use_gpu = use_gpu;
+  config.paddle_config->gpu_id = gpu_id;
+  config.paddle_config->use_mkl = use_mkl;
+  config.paddle_config->mkl_thread_num = mkl_thread_num;
+  return infer_engine_->Init(config);
 }
 
-bool PaddleInferenceEngine::Init(const std::string &model_filename,
-                                 const std::string &params_filename,
-                                 const InferenceConfig &engine_config) {
+bool PaddleInferenceEngine::Init(const InferenceConfig &infer_config) {
+  const PaddleEngineConfig& engine_config = *infer_config.paddle_config;
   paddle_infer::Config config;
-  config.SetModel(model_filename, params_filename);
+  config.SetModel(engine_config.model_filename,
+                  engine_config.params_filename);
   if (engine_config.use_mkl && !engine_config.use_gpu) {
     config.EnableMKLDNN();
     config.SetCpuMathLibraryNumThreads(engine_config.mkl_thread_num);

--- a/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
@@ -31,7 +31,7 @@ bool Model::PaddleEngineInit(const std::string& model_filename,
 }
 
 bool PaddleInferenceEngine::Init(const InferenceConfig& infer_config) {
-  const PaddleEngineConfig& engine_config = *infer_config.paddle_config;
+  const PaddleEngineConfig& engine_config = *(infer_config.paddle_config);
   paddle_infer::Config config;
   config.SetModel(engine_config.model_filename,
                   engine_config.params_filename);

--- a/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/ppinference_engine.cpp
@@ -15,8 +15,8 @@
 #include "model_deploy/engine/include/ppinference_engine.h"
 
 namespace PaddleDeploy {
-bool Model::PaddleEngineInit(const std::string &model_filename,
-                             const std::string &params_filename, bool use_gpu,
+bool Model::PaddleEngineInit(const std::string& model_filename,
+                             const std::string& params_filename, bool use_gpu,
                              int gpu_id, bool use_mkl, int mkl_thread_num) {
   infer_engine_ = std::make_shared<PaddleInferenceEngine>();
   InferenceConfig config("paddle");
@@ -30,7 +30,7 @@ bool Model::PaddleEngineInit(const std::string &model_filename,
   return infer_engine_->Init(config);
 }
 
-bool PaddleInferenceEngine::Init(const InferenceConfig &infer_config) {
+bool PaddleInferenceEngine::Init(const InferenceConfig& infer_config) {
   const PaddleEngineConfig& engine_config = *infer_config.paddle_config;
   paddle_infer::Config config;
   config.SetModel(engine_config.model_filename,
@@ -73,8 +73,8 @@ bool PaddleInferenceEngine::Init(const InferenceConfig &infer_config) {
   return true;
 }
 
-bool PaddleInferenceEngine::Infer(const std::vector<DataBlob> &inputs,
-                                  std::vector<DataBlob> *outputs) {
+bool PaddleInferenceEngine::Infer(const std::vector<DataBlob>& inputs,
+                                  std::vector<DataBlob>* outputs) {
   if (inputs.size() == 0) {
     std::cerr << "empty input image on PaddleInferenceEngine" << std::endl;
     return true;
@@ -84,19 +84,19 @@ bool PaddleInferenceEngine::Infer(const std::vector<DataBlob> &inputs,
     auto in_tensor = predictor_->GetInputHandle(input_names[i]);
     in_tensor->Reshape(inputs[i].shape);
     if (inputs[i].dtype == FLOAT32) {
-      float *im_tensor_data;
+      float* im_tensor_data;
       im_tensor_data = (float*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
     } else if (inputs[i].dtype == INT64) {
-      int64_t *im_tensor_data;
+      int64_t* im_tensor_data;
       im_tensor_data = (int64_t*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
     } else if (inputs[i].dtype == INT32) {
-      int *im_tensor_data;
+      int* im_tensor_data;
       im_tensor_data = (int*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
     } else if (inputs[i].dtype == INT8) {
-      uint8_t *im_tensor_data;
+      uint8_t* im_tensor_data;
       im_tensor_data = (uint8_t*)(inputs[i].data.data());  // NOLINT
       in_tensor->CopyFromCpu(im_tensor_data);
     } else {

--- a/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "model_deploy/engine/include/triton_engine.h"
+
+namespace nic = nvidia::inferenceserver::client;
+
+#define FAIL_IF_ERR(X, MSG)                                                    \
+  {                                                                            \
+    nic::Error err = (X);                                                      \
+    if (!err.IsOk()) {                                                         \
+      std::cerr << "error: " << (MSG) << ": " << err << std::endl;             \
+      exit(1);                                                                 \
+    }                                                                          \
+  }
+
+namespace PaddleDeploy {
+
+std::string DtypeToString(int64_t dtype) {
+  if (dtype == 0) {
+    return "FP32";
+  } else if (dtype == 1) {
+    return "INT64";
+  } else if (dtype == 2) {
+    return "INT32";
+  } else if (dtype == 3) {
+    return "UINT8";
+  }
+}
+
+int DtypeToInt(std::string dtype) {
+  if (dtype == "FP32") {
+    return 0;
+  } else if (dtype == "INT64") {
+    return 1;
+  } else if (dtype == "INT32") {
+    return 2;
+  } else if (dtype == "UINT8") {
+    return 3;
+  }
+}
+
+bool Model::TritonEngineInit(const std::string& url,
+                             const std::string& model_name,
+                             const std::string& model_version,
+                             bool verbose) {
+  infer_engine_ = std::make_shared<TritonInferenceEngine>();
+  InferenceConfig config("triton");
+  config.triton_config->url_ = url;
+  config.triton_config->model_name_ = model_name;
+  config.triton_config->model_version_ = model_version;
+  config.triton_config->verbose_ = verbose;
+  infer_engine_->Init(config);
+}
+
+void TritonInferenceEngine::ParseConfigs(
+     const TritonInferenceConfigs& configs) {
+  options_.model_name_ = configs.model_name_;
+  options_.model_version_ = configs.model_version_;
+  options_.request_id_ = configs.request_id_;
+  options_.sequence_id_ = configs.sequence_id_;
+  options_.sequence_start_ = configs.sequence_start_;
+  options_.sequence_end_ = configs.sequence_end_;
+  options_.priority_ = configs.priority_;
+  options_.server_timeout_ = configs.server_timeout_;
+  options_.client_timeout_ = configs.client_timeout_;
+}
+
+void TritonInferenceEngine::Init(const InferenceConfig configs) {
+  const TritonInferenceConfigs& triton_configs = *configs.triton_config
+  headers_ = nic::Headers();
+  query_params_ = nic::Parameters();
+  ParseConfigs(triton_configs);
+  FAIL_IF_ERR(nic::InferenceServerHttpClient::Create(&client_,
+                                                     triton_configs.url_,
+                                                     triton_configs.verbose_),
+                "error: unable to create client for inference.")
+}
+
+nic::Error TritonInferenceEngine::GetModelMetaData(
+           rapidjson::Document* model_metadata) {
+  std::string model_metadata_str;
+  FAIL_IF_ERR(client_->ModelMetadata(&model_metadata_str,
+                                     options_.model_name,
+                                     options_.model_version,
+                                     headers_),
+              "error: failed to get model metadata.");
+  model_metadata->Parse(model_metadata_str.c_str(), model_metadata_str.size());
+  if (model_metadata->HasParseError()) {
+    return nic::Error(
+        "failed to parse JSON at" +
+        std::to_string(model_metadata->GetErrorOffset()) + ": " +
+        std::string(GetParseError_En(model_metadata->GetParseError())));
+  }
+  return nic::Error::Success;
+}
+
+void TritonInferenceEngine::CreateInput(
+     const std::vector<DataBlob>& input_blobs,
+     std::vector<nic::InferInput* >* inputs) {
+  for (int i = 0; i < input_blobs.size(); i++) {
+    nic::InferInput* input;
+    std::vector<int64_t> input_shape = input_blobs[i].GetShape<int64_t>();
+    nic::InferInput::Create(&input, input_blobs[i].name,
+                            input_blobs[i].GetShape<int64_t>(),
+                            DtypeToString(input_blobs[i].dtype));
+
+    FAIL_IF_ERR(input->AppendRaw(
+                    reinterpret_cast<const uint8_t *>(&input_blobs[i].data[0]),
+                    input_blobs[i].data.size()),
+                "error: unable to set data for INPUT.");
+    inputs->push_back(input);
+  }
+}
+
+void TritonInferenceEngine::CreateOutput(
+    const rapidjson::Document& model_metadata,
+    std::vector<const nic::InferRequestedOutput* >* outputs) {
+  const auto &output_itr = model_metadata.FindMember("outputs");
+  size_t output_count = 0;
+  for (rapidjson::Value::ConstValueIterator itr = output_itr->value.Begin();
+       itr != output_itr->value.End(); ++itr) {
+    auto output_name = (*itr)["name"].GetString();
+    nic::InferRequestedOutput* output;
+    nic::InferRequestedOutput::Create(&output, output_name);
+    outputs->push_back(std::move(output));
+  }
+}
+
+void TritonInferenceEngine::Infer(const std::vector<DataBlob>& input_blobs,
+                                  std::vector<DataBlob>* output_blobs) {
+  rapidjson::Document model_metadata;
+  GetModelMetaData(&model_metadata);
+
+  std::vector<nic::InferInput* > inputs;
+  CreateInput(input_blobs, &inputs);
+
+  std::vector<const nic::InferRequestedOutput* > outputs;
+  CreateOutput(model_metadata, &outputs);
+
+  nic::InferResult* results;
+  client_->Infer(&results, options, inputs, outputs, headers_, query_params_);
+
+  for (const auto output : outputs) {
+    std::string output_name = output->Name();
+
+    DataBlob output_blob;
+    output_blob.name = output->Name();
+
+    std::vector<int64_t> output_shape;
+    results->Shape(output->Name(), &output_shape);
+    output_blob.SetShape(output_shape);
+
+    std::string output_dtype;
+    results->Datatype(output->Name(), &output_dtype);
+    output_blob.dtype = DtypeToInt(output_dtype);
+
+    // TODO(channingss): set output.lod when batch_size >1;
+
+    int size = 1;
+    for (const auto &i : output_blob.shape) {
+      size *= i;
+    }
+    size_t output_byte_size;
+    uint8_t* output_data;
+    results->RawData(output_blob.name, (const uint8_t**)&output_data,
+                     &output_byte_size);
+
+    if (output_blob.dtype == 0) {
+      output_blob.data.resize(size * sizeof(float));
+      memcpy(output_blob.data.data(), output_data, size * sizeof(float));
+    } else if (output_blob.dtype == 1) {
+      output_blob.data.resize(size * sizeof(int64_t));
+      memcpy(output_blob.data.data(), output_data, size * sizeof(int64_t));
+    } else if (output_blob.dtype == 2) {
+      output_blob.data.resize(size * sizeof(int));
+      memcpy(output_blob.data.data(), output_data, size * sizeof(int));
+    } else if (output_blob.dtype == 3) {
+      output_blob.data.resize(size * sizeof(uint8_t));
+      memcpy(output_blob.data.data(), output_data, size * sizeof(uint8_t));
+    }
+
+    output_blobs->push_back(output_blob);
+  }
+}
+
+}  // namespace PaddleDeploy

--- a/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
@@ -170,8 +170,8 @@ bool TritonInferenceEngine::Infer(const std::vector<DataBlob>& input_blobs,
 
     // TODO(my_username): set output.lod when batch_size >1;
 
-    int size = std::accumulate(output_blob.begin(),
-                    output_blob.end(), 1, std::multiplies<int>());
+    int size = std::accumulate(output_blob.shape.begin(),
+                    output_blob.shape.end(), 1, std::multiplies<int>());
     size_t output_byte_size;
     uint8_t* output_data;
     results->RawData(output_blob.name, (const uint8_t**)&output_data,

--- a/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
+++ b/deploy/cpp/model_deploy/engine/src/triton_engine.cpp
@@ -80,8 +80,6 @@ void TritonInferenceEngine::ParseConfigs(
 
 bool TritonInferenceEngine::Init(const InferenceConfig& configs) {
   const TritonInferenceConfigs& triton_configs = *(configs.triton_config);
-  headers_ = nic::Headers();
-  query_params_ = nic::Parameters();
   ParseConfigs(triton_configs);
   FAIL_IF_ERR(nic::InferenceServerHttpClient::Create(&client_,
                                                      triton_configs.url_,
@@ -172,10 +170,8 @@ bool TritonInferenceEngine::Infer(const std::vector<DataBlob>& input_blobs,
 
     // TODO(my_username): set output.lod when batch_size >1;
 
-    int size = 1;
-    for (const auto &i : output_blob.shape) {
-      size *= i;
-    }
+    int size = std::accumulate(output_blob.begin(),
+                    output_blob.end(), 1, std::multiplies<int>());
     size_t output_byte_size;
     uint8_t* output_data;
     results->RawData(output_blob.name, (const uint8_t**)&output_data,

--- a/deploy/cpp/model_deploy/ppdet/src/det_postprocess.cpp
+++ b/deploy/cpp/model_deploy/ppdet/src/det_postprocess.cpp
@@ -33,7 +33,10 @@ bool DetPostprocess::ProcessBbox(const std::vector<DataBlob>& outputs,
 
   std::vector<int> num_bboxes_each_sample;
   if (outputs[0].lod.empty()) {
-    num_bboxes_each_sample.push_back(outputs[0].data.size() / sizeof(float));
+    for (auto i = 0; i < shape_infos.size(); ++i) {
+      num_bboxes_each_sample.push_back(
+          outputs[0].shape[0]/static_cast<int>(shape_infos.size()));
+    }
   } else {
     for (auto i = 0; i < outputs[0].lod[0].size() - 1; ++i) {
       int num = outputs[0].lod[0][i + 1] - outputs[0].lod[0][i];

--- a/deploy/cpp/scripts/triton_build.sh
+++ b/deploy/cpp/scripts/triton_build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+for i in "$@"; do
+    case $i in
+        --triton_client=*)
+         TRITON_CLIENT="${i#*=}"
+         shift
+         ;;
+        *)
+         echo "unknown option $i"
+         exit 1
+         ;;
+    esac
+done
+
+if [ $TRITON_CLIENT ];then
+	echo "TRITON_CLIENT = $TRITON_CLIENT"
+else
+	echo "TRITON_CLIENT is not exist, please set by --triton_client"
+    exit 1
+fi
+
+# install relayed library
+sh $(pwd)/scripts/triton_env.sh 
+
+# download opencv library
+OPENCV_DIR=$(pwd)/deps/opencv3.4.6gcc4.8ffmpeg/
+{
+    bash $(pwd)/scripts/bootstrap.sh ${OPENCV_DIR}
+} || {
+    echo "Fail to execute script/bootstrap.sh"
+    exit -1
+}
+
+# download glog library
+GLOG_DIR=$(pwd)/deps/glog/
+GLOG_URL=https://bj.bcebos.com/paddlex/deploy/glog.tar.gz
+
+if [ ! -d $(pwd)deps/ ]; then
+    mkdir -p deps
+fi
+
+if [ ! -d ${GLOG_DIR} ]; then
+    cd deps
+    wget -c ${GLOG_URL} -O glog.tar.gz
+    tar -zxvf glog.tar.gz 
+    rm -rf glog.tar.gz 
+    cd ..
+fi
+
+# download gflogs library
+GFLAGS_DIR=$(pwd)/deps/gflags/
+GFLAGS_URL=https://bj.bcebos.com/paddlex/deploy/gflags.tar.gz
+if [ ! -d ${GFLAGS_DIR} ]; then
+    cd deps
+    wget -c ${GFLAGS_URL} -O glog.tar.gz
+    tar -zxvf glog.tar.gz 
+    rm -rf glog.tar.gz 
+    cd ..
+fi
+
+rm -rf build
+mkdir -p build
+cd build
+cmake ../demo/triton/ \
+    -DTRITON_CLIENT=${TRITON_CLIENT} \
+    -DOPENCV_DIR=${OPENCV_DIR}  \
+    -DGLOG_DIR=${GLOG_DIR} \
+    -DGFLAGS_DIR=${GFLAGS_DIR}
+
+make -j16
+

--- a/deploy/cpp/scripts/triton_env.sh
+++ b/deploy/cpp/scripts/triton_env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# install libpng needed by opencv
+ldconfig -p | grep png16 > log 
+if [ $? -ne 0 ];then
+    apt-get install libpng16-16
+fi
+
+# install libjasper1 needed by opencv
+ldconfig -p | grep libjasper  > log 
+if [  $? -ne 0  ];then
+    add-apt-repository > log
+    if [  $? -ne 0 ]; then
+        apt-get install software-properties-common
+    fi
+    add-apt-repository "deb http://security.ubuntu.com/ubuntu xenial-security main"
+    apt update
+    apt install libjasper1 libjasper-dev
+fi
+
+rm -rf log
+


### PR DESCRIPTION
1.  将engine config单独放入一个文件，存放所有引擎的配置文件
2. 增加Triton 引擎及相关demo、编译文件脚本
3. 修复预处理和后处理的数据拷贝bug

seg clas已在linux环境完成diff， ppdet的yolov3 、 ppyolo暂不支持，windows环境暂不支持。