### PR TITLE
Refine multi-card evaluation logistics

### DIFF
--- a/dygraph/paddlex/cv/models/base.py
+++ b/dygraph/paddlex/cv/models/base.py
@@ -333,12 +333,13 @@ class BaseModel:
             eval_epoch_tic = time.time()
             if (i + 1) % save_interval_epochs == 0 or i == num_epochs - 1:
                 if eval_dataset is not None and eval_dataset.num_samples > 0:
-                    self.eval_metrics, self.eval_details = self.evaluate(
+                    eval_result = self.evaluate(
                         eval_dataset,
                         batch_size=eval_batch_size,
                         return_details=True)
                     # 保存最优模型
                     if local_rank == 0:
+                        self.eval_metrics, self.eval_details = eval_result
                         logging.info('[EVAL] Finished, Epoch={}, {} .'.format(
                             i + 1, dict2str(self.eval_metrics)))
                         best_accuracy_key = list(self.eval_metrics.keys())[0]

--- a/dygraph/paddlex/cv/models/detector.py
+++ b/dygraph/paddlex/cv/models/detector.py
@@ -419,9 +419,6 @@ class BaseDetector(BaseModel):
             if return_details:
                 return scores, self.eval_details
             return scores
-        if return_details:
-            return None, None
-        return None
 
     def predict(self, img_file, transforms=None):
         """

--- a/dygraph/tutorials/train/object_detection/ppyolo.py
+++ b/dygraph/tutorials/train/object_detection/ppyolo.py
@@ -51,9 +51,9 @@ model.train(
     train_batch_size=8,
     eval_dataset=eval_dataset,
     learning_rate=0.005 / 12,
-    warmup_steps=500,
+    warmup_steps=1000,
     warmup_start_lr=0.0,
     save_interval_epochs=5,
-    lr_decay_epochs=[160, 210, 230],
+    lr_decay_epochs=[243, 324],
     save_dir='output/ppyolo_r50vd_dcn',
     use_vdl=True)

--- a/dygraph/tutorials/train/object_detection/ppyolo.py
+++ b/dygraph/tutorials/train/object_detection/ppyolo.py
@@ -51,9 +51,9 @@ model.train(
     train_batch_size=8,
     eval_dataset=eval_dataset,
     learning_rate=0.005 / 12,
-    warmup_steps=1000,
+    warmup_steps=500,
     warmup_start_lr=0.0,
     save_interval_epochs=5,
-    lr_decay_epochs=[243, 324],
+    lr_decay_epochs=[160, 210, 230],
     save_dir='output/ppyolo_r50vd_dcn',
     use_vdl=True)


### PR DESCRIPTION
1. Refine detector multi-card evaluation, elaborate return value of `evaluate` only on card 0.
2. Fix classifier multi-card evaluation bug when `return_details` is `True`, gather `softmax_out` from all cards so that `eval_details` contains output from all cards.
3. Update ppyolo tutorial training configuration.