### PR TITLE
fix empty output in voc

### DIFF
--- a/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
+++ b/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
@@ -85,9 +85,10 @@ class VOCMetric(Metric):
         self.detection_map.reset()
 
     def update(self, inputs, outputs):
-        bboxes = outputs['bbox'][:, 2:].numpy()
-        scores = outputs['bbox'][:, 1].numpy()
-        labels = outputs['bbox'][:, 0].numpy()
+        bbox_np = outputs['bbox'].numpy()
+        bboxes = bbox_np[:, 2:]
+        scores = bbox_np[:, 1]
+        labels = bbox_np[:, 0]
         bbox_lengths = outputs['bbox_num'].numpy()
 
         if bboxes.shape == (1, 1) or bboxes is None:


### PR DESCRIPTION
当使用VOC metric进行评估时，空的`bbox`会引起segmentation fault。已修复。https://github.com/PaddlePaddle/PaddleDetection/commit/b8581b74a0291269a3cc762d47506f2adb1351f8