### PR TITLE
deploy support pdx 2.0.0rc model

### DIFF
--- a/dygraph/deploy/cpp/model_deploy/common/include/transforms.h
+++ b/dygraph/deploy/cpp/model_deploy/common/include/transforms.h
@@ -166,6 +166,11 @@ class Resize : public Transform {
     } else {
       use_scale_ = true;
     }
+    if (item["keep_ratio"].IsDefined()) {
+      keep_ratio_ = item["keep_ratio"].as<bool>();
+    } else {
+      keep_ratio_ = false;
+    }
     height_ = item["height"].as<int>();
     width_ = item["width"].as<int>();
     if (height_ <= 0 || width_ <= 0) {
@@ -184,6 +189,7 @@ class Resize : public Transform {
   int width_;
   int interp_;
   bool use_scale_;
+  bool keep_ratio_;
 };
 
 class BGR2RGB : public Transform {

--- a/dygraph/deploy/cpp/model_deploy/common/include/transforms.h
+++ b/dygraph/deploy/cpp/model_deploy/common/include/transforms.h
@@ -68,8 +68,8 @@ class Normalize : public Transform {
       if (is_scale_) {
         alpha /= (max_val_[c] - min_val_[c]);
       }
+      double beta = -1.0 * (mean_[c] + min_val_[c] * alpha) / std_[c];
       alpha /= std_[c];
-      double beta = -1.0 * mean_[c] / std_[c];
 
       alpha_.push_back(alpha);
       beta_.push_back(beta);

--- a/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
+++ b/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
@@ -169,8 +169,20 @@ bool Resize::ShapeInfer(
         const std::vector<int>& in_shape,
         std::vector<int>* out_shape) {
   out_shape->clear();
-  out_shape->push_back(width_);
-  out_shape->push_back(height_);
+  double width;
+  double height;
+  if (keep_ratio_) {
+    int w = in_shape[0];
+    int h = in_shape[1];
+    double scale_w = width_ / static_cast<double>(w);
+    double scale_h = height_ / static_cast<double>(h);
+    scale_h = std::min(scale_w, scale_h);
+    scale_w = scale_h;
+    width = static_cast<int>(round(scale_w * w));
+    height = static_cast<int>(round(scale_h * h));
+  }
+  out_shape->push_back(width);
+  out_shape->push_back(height);
   return true;
 }
 

--- a/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
+++ b/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
@@ -147,11 +147,19 @@ bool Resize::Run(cv::Mat *im) {
               << std::endl;
     return false;
   }
+  double scale_w;
+  double scale_h;
+  if (keep_ratio_) {
+    scale_w = width_ / static_cast<double>(im->cols);
+    scale_h = height_ / static_cast<double>(im->rows);
+    scale_h = std::min(scale_w, scale_h);
+    scale_w = scale_h;
+  }
   if (use_scale_) {
-    double scale_w = width_ / static_cast<double>(im->cols);
-    double scale_h = height_ / static_cast<double>(im->rows);
     cv::resize(*im, *im, cv::Size(), scale_w, scale_h, interp_);
   } else {
+    width_ = static_cast<int>(round(scale_w * im->cols));
+    height_ = static_cast<int>(round(scale_h * im->rows));
     cv::resize(*im, *im, cv::Size(width_, height_), 0, 0, interp_);
   }
   return true;

--- a/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
+++ b/dygraph/deploy/cpp/model_deploy/common/src/transforms.cpp
@@ -147,19 +147,17 @@ bool Resize::Run(cv::Mat *im) {
               << std::endl;
     return false;
   }
-  double scale_w;
-  double scale_h;
+  double scale_w = width_ / static_cast<double>(im->cols);
+  double scale_h = height_ / static_cast<double>(im->rows);
   if (keep_ratio_) {
-    scale_w = width_ / static_cast<double>(im->cols);
-    scale_h = height_ / static_cast<double>(im->rows);
     scale_h = std::min(scale_w, scale_h);
     scale_w = scale_h;
+    width_ = static_cast<int>(round(scale_w * im->cols));
+    height_ = static_cast<int>(round(scale_h * im->rows));
   }
   if (use_scale_) {
     cv::resize(*im, *im, cv::Size(), scale_w, scale_h, interp_);
   } else {
-    width_ = static_cast<int>(round(scale_w * im->cols));
-    height_ = static_cast<int>(round(scale_h * im->rows));
     cv::resize(*im, *im, cv::Size(width_, height_), 0, 0, interp_);
   }
   return true;
@@ -169,8 +167,8 @@ bool Resize::ShapeInfer(
         const std::vector<int>& in_shape,
         std::vector<int>* out_shape) {
   out_shape->clear();
-  double width;
-  double height;
+  double width = width_;
+  double height = height_;
   if (keep_ratio_) {
     int w = in_shape[0];
     int h = in_shape[1];

--- a/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
+++ b/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
@@ -87,6 +87,9 @@ void XResize(const YAML::Node& src, YAML::Node* dst) {
       assert(false);
     }
   }
+  if (src["keep_ratio"].IsDefined() && src["keep_ratio"].as<bool>()) {
+    (*dst)["transforms"]["Resize"]["keep_ratio"] = w;
+  }
   (*dst)["transforms"]["Resize"]["width"] = w;
   (*dst)["transforms"]["Resize"]["height"] = h;
   (*dst)["transforms"]["Resize"]["interp"] = interp;
@@ -118,7 +121,8 @@ void XResizeByShort(const YAML::Node& src, YAML::Node* dst) {
 
 // dygraph version
 void XPaddingV2(const YAML::Node& src, YAML::Node* dst) {
-  if (src["target_size"].IsDefined() && src["target_size"] != YAML::Null) {
+  if (src["target_size"].IsDefined() &&
+      src["target_size"].Type() != YAML::NodeType::Null) {
     assert(src["target_size"].IsScalar() || src["target_size"].IsSequence());
     if (src["target_size"].IsScalar()) {
       (*dst)["transforms"]["Padding"]["width"] = src["target_size"].as<int>();
@@ -144,7 +148,7 @@ void XPaddingV2(const YAML::Node& src, YAML::Node* dst) {
   }
 
   if (src["pad_mode"].IsDefined()) {
-    if (src["pad_mode"].as<int>() != 1) {
+    if (src["pad_mode"].as<int>() != 0) {
       std::cerr << "[Error] No support pad_mode :"
               << src["pad_mode"].as<int>()
               << std::endl;

--- a/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
+++ b/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
@@ -51,6 +51,9 @@ void XNormalize(const YAML::Node& src, YAML::Node* dst) {
     (*dst)["transforms"]["Normalize"]["mean"].push_back(mean[i]);
     (*dst)["transforms"]["Normalize"]["std"].push_back(std[i]);
   }
+  if (src["is_scale"].IsDefined()) {
+    (*dst)["transforms"]["Normalize"]["is_scale"] = src["is_scale"];
+  }
 }
 
 void XResize(const YAML::Node& src, YAML::Node* dst) {
@@ -62,8 +65,13 @@ void XResize(const YAML::Node& src, YAML::Node* dst) {
     w = src["target_size"].as<int>();
     h = src["target_size"].as<int>();
   } else if (src["target_size"].IsSequence()) {
-    w = src["target_size"].as<std::vector<int>>()[0];
-    h = src["target_size"].as<std::vector<int>>()[1];
+    if ((*dst)["version"].as<std::string>() >= "2.0.0") {
+      h = src["target_size"].as<std::vector<int>>()[0];
+      w = src["target_size"].as<std::vector<int>>()[1];
+    } else {
+      w = src["target_size"].as<std::vector<int>>()[0];
+      h = src["target_size"].as<std::vector<int>>()[1];
+    }
   } else {
     std::cerr << "[ERROR] Unexpected value type of `target_size`" << std::endl;
     assert(false);
@@ -88,7 +96,7 @@ void XResize(const YAML::Node& src, YAML::Node* dst) {
     }
   }
   if (src["keep_ratio"].IsDefined() && src["keep_ratio"].as<bool>()) {
-    (*dst)["transforms"]["Resize"]["keep_ratio"] = w;
+    (*dst)["transforms"]["Resize"]["keep_ratio"] = true;
   }
   (*dst)["transforms"]["Resize"]["width"] = w;
   (*dst)["transforms"]["Resize"]["height"] = h;

--- a/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
+++ b/dygraph/deploy/cpp/model_deploy/paddlex/include/x_standard_config.h
@@ -116,6 +116,43 @@ void XResizeByShort(const YAML::Node& src, YAML::Node* dst) {
   (*dst)["transforms"]["ResizeByShort"]["use_scale"] = false;
 }
 
+// dygraph version
+void XPaddingV2(const YAML::Node& src, YAML::Node* dst) {
+  if (src["target_size"].IsDefined() && src["target_size"] != YAML::Null) {
+    assert(src["target_size"].IsScalar() || src["target_size"].IsSequence());
+    if (src["target_size"].IsScalar()) {
+      (*dst)["transforms"]["Padding"]["width"] = src["target_size"].as<int>();
+      (*dst)["transforms"]["Padding"]["height"] = src["target_size"].as<int>();
+    } else {
+      std::vector<int> target_size = src["target_size"].as<std::vector<int>>();
+      (*dst)["transforms"]["Padding"]["width"] = target_size[0];
+      (*dst)["transforms"]["Padding"]["height"] = target_size[1];
+    }
+  } else if (src["size_divisor"].IsDefined()) {
+    (*dst)["transforms"]["Padding"]["stride"] =
+                        src["size_divisor"].as<int>();
+  } else {
+    std::cerr << "[Error] As least one of size_divisor/"
+              << "target_size must be defined for Padding"
+              << std::endl;
+    assert(false);
+  }
+
+  if (src["im_padding_value"].IsDefined()) {
+    (*dst)["transforms"]["Padding"]["im_padding_value"] =
+            src["im_padding_value"].as<std::vector<float>>();
+  }
+
+  if (src["pad_mode"].IsDefined()) {
+    if (src["pad_mode"].as<int>() != 1) {
+      std::cerr << "[Error] No support pad_mode :"
+              << src["pad_mode"].as<int>()
+              << std::endl;
+      assert(false);
+    }
+  }
+}
+
 void XPadding(const YAML::Node& src, YAML::Node* dst) {
   if (src["coarsest_stride"].IsDefined()) {
     (*dst)["transforms"]["Padding"]["stride"] =

--- a/dygraph/deploy/cpp/model_deploy/paddlex/src/x_model.cpp
+++ b/dygraph/deploy/cpp/model_deploy/paddlex/src/x_model.cpp
@@ -32,7 +32,11 @@ bool PaddleXModel::GenerateTransformsConfig(const YAML::Node& src) {
     } else if (op_name == "ResizeByLong") {
       XResizeByLong(op.begin()->second, &yaml_config_);
     } else if (op_name == "Padding") {
-      XPadding(op.begin()->second, &yaml_config_);
+      if (src["version"].as<std::string>() >= "2.0.0") {
+        XPaddingV2(op.begin()->second, &yaml_config_);
+      } else {
+        XPadding(op.begin()->second, &yaml_config_);
+      }
     } else if (op_name == "CenterCrop") {
       XCenterCrop(op.begin()->second, &yaml_config_);
     } else if (op_name == "Resize") {


### PR DESCRIPTION
预处理支持pdx最新python代码导出的模型
1.resize 支持keep_ratio参数
2.normalize增加scale
3.padding新增2.0版本
如提交的为部署C++代码，请确认以下自测点是否完成（完成勾选即可），并保留以下的自测点列表，便于Reviewer知晓。

- [x] Linux下测试通过
- - [ ] batch = 1 预测
- - [ ] batch > 1预测
- - [ ] 多GPU卡预测
- - [ ] TensorRT预测
- - [ ] Triton预测
- [x] Windows下测试通过
- - [ ] batch = 1预测
- - [ ] batch > 1预测
