### PR TITLE
change det eval metric keys

### DIFF
--- a/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
+++ b/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
@@ -139,18 +139,14 @@ class VOCMetric(Metric):
 
     def log(self):
         map_stat = 100. * self.detection_map.get_map()
-        logging.info("mAP({:.2f}, {}) = {:.2f}%".format(
-            self.overlap_thresh, self.map_type, map_stat))
+        logging.info("bbox_map = {:.2f}%".format(map_stat))
 
     def get_results(self):
         return {'bbox': [self.detection_map.get_map()]}
 
     def get(self):
         map_stat = 100. * self.detection_map.get_map()
-        stats = {
-            "mAP({:.2f}, {})".format(self.overlap_thresh, self.map_type):
-            map_stat
-        }
+        stats = {"bbox_map": map_stat}
         return stats
 
 


### PR DESCRIPTION
由mAP(0.50, 11point)改为bbox_map，与老版本统一