### PR TITLE
fix trt6 bug

### DIFF
--- a/dygraph/deploy/cpp/CMakeLists.txt
+++ b/dygraph/deploy/cpp/CMakeLists.txt
@@ -125,6 +125,28 @@ endif ()
 set(DEPS ${DEPS} ${OpenCV_LIBS})
 include_directories(${OpenCV_INCLUDE_DIRS})
 
+
+if (WITH_TENSORRT AND WITH_GPU)
+  include_directories("${TENSORRT_DIR}/include")
+  link_directories("${TENSORRT_DIR}/lib")
+
+  file(READ ${TENSORRT_DIR}/include/NvInfer.h TENSORRT_VERSION_FILE_CONTENTS)
+  string(REGEX MATCH "define NV_TENSORRT_MAJOR +([0-9]+)" TENSORRT_MAJOR_VERSION
+    "${TENSORRT_VERSION_FILE_CONTENTS}")
+  if("${TENSORRT_MAJOR_VERSION}" STREQUAL "")
+    file(READ ${TENSORRT_DIR}/include/NvInferVersion.h TENSORRT_VERSION_FILE_CONTENTS)
+    string(REGEX MATCH "define NV_TENSORRT_MAJOR +([0-9]+)" TENSORRT_MAJOR_VERSION
+      "${TENSORRT_VERSION_FILE_CONTENTS}")
+  endif()
+  if("${TENSORRT_MAJOR_VERSION}" STREQUAL "")
+    message(SEND_ERROR "Failed to detect TensorRT version.")
+  endif()
+  string(REGEX REPLACE "define NV_TENSORRT_MAJOR +([0-9]+)" "\\1"
+    TENSORRT_MAJOR_VERSION "${TENSORRT_MAJOR_VERSION}")
+  message(STATUS "Current TensorRT header is ${TENSORRT_INCLUDE_DIR}/NvInfer.h. "
+    "Current TensorRT version is v${TENSORRT_MAJOR_VERSION}. ")
+endif()
+
 #set GPU
 if(WITH_GPU)
   if (NOT DEFINED CUDA_LIB OR ${CUDA_LIB} STREQUAL "")
@@ -140,9 +162,6 @@ if(WITH_GPU)
     set(DEPS ${DEPS} ${CUDNN_LIB}/libcudnn${CMAKE_SHARED_LIBRARY_SUFFIX})
 
     if (WITH_TENSORRT)
-      include_directories("${TENSORRT_DIR}/include")
-      link_directories("${TENSORRT_DIR}/lib")
-
       set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/libnvinfer${CMAKE_SHARED_LIBRARY_SUFFIX})
       set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/libnvinfer_plugin${CMAKE_SHARED_LIBRARY_SUFFIX})
     endif()
@@ -153,12 +172,11 @@ if(WITH_GPU)
     set(DEPS ${DEPS} ${CUDA_LIB}/cudnn${CMAKE_STATIC_LIBRARY_SUFFIX})
 
     if (WITH_TENSORRT)
-      include_directories("${TENSORRT_DIR}/include")
-      link_directories("${TENSORRT_DIR}/lib")
-
       set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/nvinfer${CMAKE_STATIC_LIBRARY_SUFFIX})
       set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/nvinfer_plugin${CMAKE_STATIC_LIBRARY_SUFFIX})
-      set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/myelin64_1${CMAKE_STATIC_LIBRARY_SUFFIX})
+      if(${TENSORRT_MAJOR_VERSION} GREATER_EQUAL 7)
+        set(DEPS ${DEPS} ${TENSORRT_DIR}/lib/myelin64_1${CMAKE_STATIC_LIBRARY_SUFFIX})
+      endif()
     endif()
   endif()
 endif()

--- a/dygraph/deploy/cpp/CMakeLists.txt
+++ b/dygraph/deploy/cpp/CMakeLists.txt
@@ -284,7 +284,11 @@ if(WIN32)
     add_custom_command(TARGET model_infer POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${TENSORRT_DIR}/lib/nvinfer.dll ${CMAKE_BINARY_DIR}/paddle_deploy
       COMMAND ${CMAKE_COMMAND} -E copy ${TENSORRT_DIR}/lib/nvinfer_plugin.dll ${CMAKE_BINARY_DIR}/paddle_deploy
-      COMMAND ${CMAKE_COMMAND} -E copy ${TENSORRT_DIR}/lib/myelin64_1.dll ${CMAKE_BINARY_DIR}/paddle_deploy
     )
+    if(${TENSORRT_MAJOR_VERSION} GREATER_EQUAL 7)
+      add_custom_command(TARGET model_infer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${TENSORRT_DIR}/lib/myelin64_1.dll ${CMAKE_BINARY_DIR}/paddle_deploy
+      )
+    endif()
   endif()
 endif()

--- a/dygraph/deploy/cpp/scripts/bootstrap.sh
+++ b/dygraph/deploy/cpp/scripts/bootstrap.sh
@@ -42,8 +42,8 @@ OPENSSL_URL=https://bj.bcebos.com/paddlex/tools/openssl-1.1.0k.tar.gz
 if [ ! -d "./deps/openssl-1.1.0k/" ]; then
     mkdir -p deps
     cd deps
-    wget -c ${OPENCV_URL} -O openssl-1.1.0k.tar.gz
-    tar xvfj openssl-1.1.0k.tar.gz
+    wget -c ${OPENSSL_URL} -O openssl-1.1.0k.tar.gz
+    tar -zxvf openssl-1.1.0k.tar.gz
     rm -rf openssl-1.1.0k.tar.gz
     cd ..
 fi


### PR DESCRIPTION
1. 修复windows环境使用trt6没有 myelin64_1报错问题

如提交的为部署C++代码，请确认以下自测点是否完成（完成勾选即可），并保留以下的自测点列表，便于Reviewer知晓。

- [x] Linux下测试通过
- - [ ] batch = 1 预测
- - [ ] batch > 1预测
- - [ ] 多GPU卡预测
- - [ ] TensorRT预测
- - [ ] Triton预测
- [x] Windows下测试通过
- - [ ] batch = 1预测
- - [ ] batch > 1预测
