### PR TITLE
fix wrong image channel in c# Program.cs

### DIFF
--- a/dygraph/examples/C#_deploy/Program.cs
+++ b/dygraph/examples/C#_deploy/Program.cs
@@ -38,7 +38,7 @@ namespace ConsoleApp2
             Byte[] labellist = new Byte[1000];    //新建字节数组
 
             //第四个参数为输入图像的通道数
-            ModelPredict(inputData, bmp.Width, bmp.Height, 4, results, boxesInfo, ref labellist[0]);
+            ModelPredict(inputData, bmp.Width, bmp.Height, 3, results, boxesInfo, ref labellist[0]);
             string strGet = System.Text.Encoding.Default.GetString(labellist, 0, labellist.Length);    //将字节数组转换为字符串
             Console.WriteLine("labellist: {0}", strGet);
             for (int i = 0; i < boxesInfo[0]; i++)


### PR DESCRIPTION
The origin setting of a image channel in c# Program.cs is 4, which is wrong, we change it to 3.

![image](https://user-images.githubusercontent.com/22235422/124852066-519a6380-dfd6-11eb-8bee-dc1efe47ee3c.png)

see issue https://github.com/PaddlePaddle/PaddleX/issues/930
