### PR TITLE
do not plus 1 while computing w and h for bbox

### DIFF
--- a/dygraph/paddlex/cv/datasets/voc.py
+++ b/dygraph/paddlex/cv/datasets/voc.py
@@ -216,8 +216,8 @@ class VOCDetection(Dataset):
                     annotations['annotations'].append({
                         'iscrowd': 0,
                         'image_id': int(im_id[0]),
-                        'bbox': [x1, y1, x2 - x1 + 1, y2 - y1 + 1],
-                        'area': float((x2 - x1 + 1) * (y2 - y1 + 1)),
+                        'bbox': [x1, y1, x2 - x1, y2 - y1],
+                        'area': float((x2 - x1) * (y2 - y1)),
                         'category_id': cname2cid[cname] + 1,
                         'id': ann_ct,
                         'difficult': _difficult


### PR DESCRIPTION
于预测结果后处理以及coco metric评估时的处理方式统一，会影响到GUi模型训练后的评估以及voc格式数据集使用coco metric做evaluation时的精度值。