### PR TITLE
set bbox_mmap and segm_mmap to 0 when there is no detected bbox

### DIFF
--- a/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
+++ b/dygraph/paddlex/cv/models/utils/det_metrics/metrics.py
@@ -210,6 +210,8 @@ class COCOMetric(Metric):
         pass
 
     def get(self):
+        if 'bbox' not in self.eval_stats:
+            return {'bbox_mmap': 0.}
         if 'mask' in self.eval_stats:
             return OrderedDict(
                 zip(['bbox_mmap', 'segm_mmap'],


### PR DESCRIPTION
当模型loss为nan时，self.details['bbox']为[]，self.eval_status不会被赋值。此时调用get函数会报错，因self.eval_status为[]。见issue https://github.com/PaddlePaddle/PaddleX/issues/959