### PR TITLE
enabel use_mkl for hrnet/deeplabv3/ppyolo/ when using paddlepaddle>=2.1.1 and paddlex==1.3.x

### DIFF
--- a/docs/deploy/jetson/jetson-docker.md
+++ b/docs/deploy/jetson/jetson-docker.md
@@ -33,7 +33,11 @@ sudo docker images
 本文档以PaddleX提供的jetson部署代码为示例：
 ```
 #通过如下命令下载代码，Jetson部署代码在 `PaddleX/deploy/cpp` 目录下面
+```
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
+```
 
 #在HOME目录下创建infer文件夹，将cpp文件夹拷贝到infer目录下面
 mkdir ~/infer

--- a/docs/deploy/jetson/nvidia-jetson.md
+++ b/docs/deploy/jetson/nvidia-jetson.md
@@ -12,7 +12,11 @@
 
 ### Step1: 下载代码
 
- `git clone https://github.com/PaddlePaddle/PaddleX.git`
+```
+git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
+```
 
 **说明**：其中`C++`预测代码在`PaddleX/deploy/cpp` 目录，该目录不依赖任何`PaddleX`下其他目录。
 

--- a/docs/deploy/openvino/export_openvino_model.md
+++ b/docs/deploy/openvino/export_openvino_model.md
@@ -27,7 +27,9 @@ paddlex --export_inference --model_dir=/path/to/paddle_model --save_dir=./infere
 mkdir -p /root/projects
 cd /root/projects
 git clone https://github.com/PaddlePaddle/PaddleX.git
-cd PaddleX/deploy/openvino/python
+cd PaddleX
+git checkout release/1.3
+cd deploy/openvino/python
 
 python converter.py --model_dir /path/to/inference_model --save_dir /path/to/openvino_model --fixed_input_shape [w,h]
 ```

--- a/docs/deploy/openvino/linux.md
+++ b/docs/deploy/openvino/linux.md
@@ -27,6 +27,8 @@
 mkdir -p /root/projects
 cd /root/projects
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
 ```
 **说明**：其中C++预测代码在PaddleX/deploy/openvino 目录，该目录不依赖任何PaddleX下其他目录。
 

--- a/docs/deploy/openvino/windows.md
+++ b/docs/deploy/openvino/windows.md
@@ -9,7 +9,7 @@ Windows 平台下，我们使用`Visual Studio 2019 Community` 进行了测试�
 * CMake 3.0+
 
 **说明**：
-- PaddleX安装请参考[PaddleX](https://paddlex.readthedocs.io/zh_CN/develop/install.html) ， OpenVINO安装请参考[OpenVINO-Windows](https://docs.openvinotoolkit.org/latest/openvino_docs_install_guides_installing_openvino_windows.html) 
+- PaddleX安装请参考[PaddleX](https://paddlex.readthedocs.io/zh_CN/develop/install.html) ， OpenVINO安装请参考[OpenVINO-Windows](https://docs.openvinotoolkit.org/latest/openvino_docs_install_guides_installing_openvino_windows.html)
 - CPU下请使用OpenVINO 2021.1+版本；VPU下请使用OpenVINO 2020.4版本
 
 
@@ -37,6 +37,8 @@ d:
 mkdir projects
 cd projects
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
 ```
 
 **说明**：其中`C++`预测代码在`PaddleX\deploy\openvino` 目录，该目录不依赖任何`PaddleX`下其他目录。

--- a/docs/deploy/raspberry/NCS2.md
+++ b/docs/deploy/raspberry/NCS2.md
@@ -4,7 +4,7 @@ PaddleX支持在树莓派上插入NCS2(神经计算棒2代)通过OpenVINO部署P
 **注意**：目前仅支持分类模型、仅支持Armv7hf的树莓派  
 
 ## 前置条件  
-* OS: Raspbian OS 
+* OS: Raspbian OS
 * PaddleX 1.0+
 * OpenVINO 2020.4  
 
@@ -13,7 +13,7 @@ PaddleX支持在树莓派上插入NCS2(神经计算棒2代)通过OpenVINO部署P
 - OpenVINO: OpenVINO的安装请参考[OpenVINO-Raspbian](https://docs.openvinotoolkit.org/latest/openvino_docs_install_guides_installing_openvino_raspbian.html)  
 
 **注意**：安装完OpenVINO后需要初始化OpenVINO环境，并且需要对USB进行配置，请参考：  
-  
+
 ```
 #初始化OpenVINO环境
 source /opt/intel/openvino/bin/setupvars.sh
@@ -22,14 +22,14 @@ echo "source /opt/intel/openvino/bin/setupvars.sh" >> ~/.bashrc
 #配置USB
 sh /opt/intel/openvino/install_dependencies/install_NCS_udev_rules.sh
 ```
-  
+
 ## 部署流程  
-  
+
 部署流程主要分为模型转换与转换后模型部署两个步骤，下面以MobilnetV2模型为例，介绍如何将PaddleX训练好的模型通过OpenVINO部署到插入NCS2的树莓派  
 教程的示例项目训练MobilenetV2模型，请参考[PaddleX模型训练示例](https://aistudio.baidu.com/aistudio/projectdetail/439860)  
 
 ## 模型转换
-  
+
 模型转换指的是将PaddleX训练出来的Paddle模型转换为OpenVINO的IR，对于模型转换教程可以参考[OpenVINO模型转换](../openvino/export_openvino_model.md)  
 
 **注意**：树莓派上面安装的OpenVINO是不带Model Optmizier模块的，不能在上面进行模型转换，请在Host下载与树莓派一直的OpenVINO版本，然后进行模型转换。  
@@ -40,8 +40,11 @@ sh /opt/intel/openvino/install_dependencies/install_NCS_udev_rules.sh
 pip install paddlex
 
 #下载PaddleX代码
+```
 git clone https://github.com/PaddlePaddle/PaddleX.git
-
+cd PaddleX
+git checkout release/1.3
+```
 #进入模型转换脚本文件夹
 cd PaddleX/deploy/openvino/python
 
@@ -65,12 +68,16 @@ PaddleX支持Python和C++两种方式在树莓派上通过NCS2部署：
 **准备工作**
 ```
 #在树莓派上下载PaddleX代码
+```
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
+```
 #进入OpenVINO部署代码
-cd PaddleX/deploy/openvino
+cd deploy/openvino
 #将MobileNetV2转好的OpenVINO IR以及测试图片拷贝到树莓派上面，并以及MobileNetV2文件夹放到OpenVINO部署的代码的目录
 ```
-  
+
 **C++部署**
 ```
 #修改编译文件script/build.sh，将ARCH参数修改为armv7

--- a/docs/deploy/raspberry/Raspberry.md
+++ b/docs/deploy/raspberry/Raspberry.md
@@ -40,11 +40,13 @@ sudo apt-get upgrade
 mkdir -p /root/projects
 cd /root/projects
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
 ```
 **说明**：其中C++预测代码在PaddleX/deploy/raspberry 目录，该目录不依赖任何PaddleX下其他目录，如果需要在python下预测部署请参考[Python预测部署](./python.md)。  
 
 #### Step2：Paddle-Lite预编译库下载
-对于Armv7hf的用户提供了2.6.1版本的Paddle-Lite在架构为armv7hf的ArmLinux下面的Full版本预编译库:[Paddle-Lite(ArmLinux)预编译库](https://bj.bcebos.com/paddlex/deploy/lite/inference_lite_2.6.1_armlinux.tar.bz2)    
+对于Armv7hf的用户提供了2.6.1版本的Paddle-Lite在架构为armv7hf的ArmLinux下面的Full版本预编译库:[Paddle-Lite(ArmLinux)预编译库](https://bj.bcebos.com/paddlex/deploy/lite/inference_lite_2.6.1_armlinux.tar.bz2)  
 对于Armv8的用户提供了2.6.3版本的Paddle-Lite在架构为armv8的ArmLinux下面的full版本预编译库:[Paddle-Lite(ArmLinux)与编译库](https://bj.bcebos.com/paddlex/paddle-lite/armlinux/paddle-Lite_armlinux_full_2.6.3.zip)  
 其他版本与arm架构的Paddle-Lite预测库请在官网[Releases](https://github.com/PaddlePaddle/Paddle-Lite/release)下载
 若用户需要在树莓派上自行编译Paddle-Lite，在树莓派上LX终端输入  

--- a/docs/deploy/server/cpp/linux.md
+++ b/docs/deploy/server/cpp/linux.md
@@ -12,7 +12,11 @@
 
 ### Step1: 下载代码
 
- `git clone https://github.com/PaddlePaddle/PaddleX.git`
+```
+git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
+```
 
 **说明**：其中`C++`预测代码在`/root/projects/PaddleX/deploy/cpp` 目录，该目录不依赖任何`PaddleX`下其他目录。
 

--- a/docs/deploy/server/cpp/windows.md
+++ b/docs/deploy/server/cpp/windows.md
@@ -19,6 +19,8 @@ d:
 mkdir projects
 cd projects
 git clone https://github.com/PaddlePaddle/PaddleX.git
+cd PaddleX
+git checkout release/1.3
 ```
 
 **说明**：其中`C++`预测代码在`PaddleX\deploy\cpp` 目录，该目录不依赖任何`PaddleX`下其他目录。

--- a/docs/examples/change_detection.md
+++ b/docs/examples/change_detection.md
@@ -14,6 +14,8 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/change_detection/`，进入该目录：

--- a/docs/examples/human_segmentation.md
+++ b/docs/examples/human_segmentation.md
@@ -21,7 +21,7 @@
 在训练完模型后，可能会遇到预测出来结果存在『锯齿』的问题，这个可能存在的原因是由于模型在预测过程中，经历了原图缩放再放大的过程，如下流程所示，
 
 ```
-原图输入 -> 预处理transforms将图像缩放至目标大小 -> Paddle模型预测 -> 预测结果放大至原图大小 
+原图输入 -> 预处理transforms将图像缩放至目标大小 -> Paddle模型预测 -> 预测结果放大至原图大小
 ```
 对于这种原因导致的问题，可以手动修改模型中的`model.yml`文件，将预处理中的目标大小**调整到更高**优化此问题，如在本文档中提供的人像分割server端模型中`model.yml`文件内容，修改`target_size`至1024*1024（这样也会带来模型预测所需的资源更多，预测速度更慢）
 ```
@@ -59,6 +59,8 @@ Transforms:
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 下载预训练模型的代码位于`PaddleX/examples/human_segmentation`，进入该目录：
@@ -97,6 +99,8 @@ python data/download_data.py
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 视频流人像分割和背景替换的执行文件均位于`PaddleX/examples/human_segmentation`，进入该目录：
@@ -165,6 +169,8 @@ python bg_replace.py --model_dir pretrain_weights/humanseg_mobile_inference --im
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 人像分割训练、评估、预测、模型导出、离线量化的执行文件均位于`PaddleX/examples/human_segmentation`，进入该目录：
@@ -341,6 +347,8 @@ step 1. 下载PaddleX源码
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 step 2. 将`PaddleX/examples/human_segmentation/deploy/cpp`下的`human_segmenter.cpp`和`CMakeList.txt`拷贝至`PaddleX/deploy/cpp`目录下，拷贝之前可以将`PaddleX/deploy/cpp`下原本的`CMakeList.txt`做好备份。

--- a/docs/examples/industrial_quality_inspection/gpu_solution.md
+++ b/docs/examples/industrial_quality_inspection/gpu_solution.md
@@ -25,8 +25,9 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
-
-cd PaddleX/examples/industrial_quality_inspection
+cd PaddleX
+git checkout release/1.3
+cd examples/industrial_quality_inspection
 ```
 
 ### (2) 下载数据集

--- a/docs/examples/meter_reader.md
+++ b/docs/examples/meter_reader.md
@@ -50,6 +50,8 @@ step 1. 下载PaddleX源码:
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 step 2. 预测执行文件位于`PaddleX/examples/meter_reader/`，进入该目录：
@@ -115,6 +117,8 @@ step 1. 下载PaddleX源码:
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 step 2. 将`PaddleX\examples\meter_reader\deploy\cpp`下的`meter_reader`文件夹和`CMakeList.txt`拷贝至`PaddleX\deploy\cpp`目录下，拷贝之前可以将`PaddleX\deploy\cpp`下原本的`CMakeList.txt`做好备份。
@@ -191,6 +195,8 @@ step 1. 下载PaddleX源码:
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 step 2. 将`PaddleX/examples/meter_reader/deploy/cpp`下的`meter_reader`文件夹和`CMakeList.txt`拷贝至`PaddleX/deploy/cpp`目录下，拷贝之前可以将`PaddleX/deploy/cpp`下原本的`CMakeList.txt`做好备份。

--- a/docs/examples/multi-channel_remote_sensing/README.md
+++ b/docs/examples/multi-channel_remote_sensing/README.md
@@ -21,6 +21,8 @@ conda install gdal
 
 ```  
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/channel_remote_sensing/`，进入该目录：  

--- a/docs/examples/remote_sensing.md
+++ b/docs/examples/remote_sensing.md
@@ -14,6 +14,8 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/remote_sensing/`，进入该目录：

--- a/docs/install.md
+++ b/docs/install.md
@@ -21,7 +21,7 @@ github代码会跟随开发进度不断更新
 ```
 git clone https://github.com/PaddlePaddle/PaddleX.git
 cd PaddleX
-git checkout develop
+git checkout release/1.3
 python setup.py install
 ```
 

--- a/examples/change_detection/README.md
+++ b/examples/change_detection/README.md
@@ -21,6 +21,8 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/change_detection/`，进入该目录：

--- a/examples/human_segmentation/README.md
+++ b/examples/human_segmentation/README.md
@@ -40,6 +40,8 @@
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 下载预训练模型的代码位于`PaddleX/examples/human_segmentation`，进入该目录：
@@ -80,6 +82,8 @@ python data/download_data.py
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 视频流人像分割和背景替换的执行文件均位于`PaddleX/examples/human_segmentation`，进入该目录：
@@ -150,6 +154,8 @@ python bg_replace.py --model_dir pretrain_weights/humanseg_mobile_inference --im
 
 ```bash
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 * 人像分割训练、评估、预测、模型导出、离线量化的执行文件均位于`PaddleX/examples/human_segmentation`，进入该目录：

--- a/examples/industrial_quality_inspection/gpu_solution.md
+++ b/examples/industrial_quality_inspection/gpu_solution.md
@@ -25,8 +25,9 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
-
-cd PaddleX/examples/industrial_quality_inspection
+cd PaddleX
+git checkout release/1.3
+cd examples/industrial_quality_inspection
 ```
 
 ### (2) 下载数据集

--- a/examples/meter_reader/README.md
+++ b/examples/meter_reader/README.md
@@ -59,6 +59,8 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 2. 预测执行文件位于`PaddleX/examples/meter_reader/`，进入该目录：
@@ -124,6 +126,8 @@ python reader_infer.py --detector_dir /path/to/det_inference_model --segmenter_d
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 2. 将`PaddleX\examples\meter_reader\deploy\cpp`下的`meter_reader`文件夹和`CMakeList.txt`拷贝至`PaddleX\deploy\cpp`目录下，拷贝之前可以将`PaddleX\deploy\cpp`下原本的`CMakeList.txt`做好备份。
@@ -200,6 +204,8 @@ git clone https://github.com/PaddlePaddle/PaddleX
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 2. 将`PaddleX/examples/meter_reader/deploy/cpp`下的`meter_reader`文件夹和`CMakeList.txt`拷贝至`PaddleX/deploy/cpp`目录下，拷贝之前可以将`PaddleX/deploy/cpp`下原本的`CMakeList.txt`做好备份。

--- a/examples/multi-channel_remote_sensing/README.md
+++ b/examples/multi-channel_remote_sensing/README.md
@@ -28,6 +28,8 @@ conda install gdal
 
 ```  
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/channel_remote_sensing/`，进入该目录：  

--- a/examples/remote_sensing/README.md
+++ b/examples/remote_sensing/README.md
@@ -20,6 +20,8 @@
 
 ```
 git clone https://github.com/PaddlePaddle/PaddleX
+cd PaddleX
+git checkout release/1.3
 ```
 
 该案例所有脚本均位于`PaddleX/examples/remote_sensing/`，进入该目录：

--- a/paddlex/deploy.py
+++ b/paddlex/deploy.py
@@ -123,13 +123,15 @@ class Predictor:
         else:
             config.disable_gpu()
         if use_mkl and not use_gpu:
-            if self.model_name not in ["HRNet", "DeepLabv3p", "PPYOLO"]:
-                config.enable_mkldnn()
-                config.set_cpu_math_library_num_threads(mkl_thread_num)
-            else:
-                logging.warning(
-                    "HRNet/DeepLabv3p/PPYOLO are not supported for the use of mkldnn\n"
-                )
+            import paddle
+            if not hasattr(paddle, 'enable_static'):
+                if self.model_name not in ["HRNet", "DeepLabv3p", "PPYOLO"]:
+                    config.enable_mkldnn()
+                    config.set_cpu_math_library_num_threads(mkl_thread_num)
+                else:
+                    logging.warning(
+                        "HRNet/DeepLabv3p/PPYOLO are not supported for the use of mkldnn\n"
+                    )
         if use_glog:
             config.enable_glog_info()
         else:


### PR DESCRIPTION
1. When using paddlepaddle>=2.1.1, hrnet/deeplabv3/ppyolo cannot be infered by using mkldnn, so we enable use_mdk if users using paddlex==1.3.x.
2. add ``` git checkout release/1.3 ``` for docs in release/1.3.