### PR TITLE
fix bug of detect model predict

### DIFF
--- a/static/deploy/openvino/src/paddlex.cpp
+++ b/static/deploy/openvino/src/paddlex.cpp
@@ -205,6 +205,7 @@ bool Model::predict(const cv::Mat& im, DetResult* result) {
       result->boxes.push_back(std::move(box));
     }
   }
+  return true;
 }
 
 


### PR DESCRIPTION
there is no return value of bool Model::predict(const cv::Mat& im, DetResult* result), it leads to no result return in ubuntu, but it works fine in windows.
布尔函数Model::predict(const cv::Mat& im, DetResult* result)没有返回值，导致在ubuntu上没有预测结果，但在windows上预测正常，经测试Model::predict(const cv::Mat& im, DetResult* result)不写return true的时候，打印值为2，所以可以正常返回预测结果。
## 此为PR说明模版

如提交的为部署C++代码，请确认以下自测点是否完成（完成勾选即可），并保留以下的自测点列表，便于Reviewer知晓。

- [√ ] Linux下测试通过
- - [ √ ] batch = 1 预测
- - [ ] batch > 1预测
- - [ ] 多GPU卡预测
- - [ ] TensorRT预测
- - [ ] Triton预测
- [√  ] Windows下测试通过
- - [√  ] batch = 1预测
- - [ ] batch > 1预测
