### PR TITLE
fix CenterCrop

### DIFF
--- a/paddlex/cv/transforms/operators.py
+++ b/paddlex/cv/transforms/operators.py
@@ -628,7 +628,7 @@ class CenterCrop(Transform):
         return image
 
     def apply_mask(self, mask):
-        mask = center_crop(mask)
+        mask = center_crop(mask, self.crop_size)
         return mask
 
     def apply(self, sample):


### PR DESCRIPTION
Fixed the problem that the mask in `transforms.CenterCrop` was not cropped.