### PR TITLE
[Enhancement] Add more info to voc x1<=x2 warning

### DIFF
--- a/paddlex/cv/datasets/voc.py
+++ b/paddlex/cv/datasets/voc.py
@@ -217,9 +217,8 @@ class VOCDetection(Dataset):
 
                     if not (x2 >= x1 and y2 >= y1):
                         logging.warning(
-                            "Bounding box for object {} does not satisfy x1 <= x2 and y1 <= y2, "
-                            "so this object is skipped. This error can be caused by specifying "
-                            "image width and height in wrong order. xml file: {}".format(i, xml_file))
+                            "Bounding box for object {} does not satisfy xmin {} <= xmax {} and ymin {} <= ymax {}, "
+                            "so this object is skipped. xml file: {}".format(i, x1, x2, y1, y2, xml_file))
                         continue
 
                     gt_bbox[i, :] = [x1, y1, x2, y2]

--- a/paddlex/cv/datasets/voc.py
+++ b/paddlex/cv/datasets/voc.py
@@ -218,7 +218,7 @@ class VOCDetection(Dataset):
                     if not (x2 >= x1 and y2 >= y1):
                         logging.warning(
                             "Bounding box for object {} does not satisfy x1 <= x2 and y1 <= y2, "
-                            "so this object is skipped".format(i))
+                            "so this object is skipped. xml file: {}".format(i, xml_file))
                         continue
 
                     gt_bbox[i, :] = [x1, y1, x2, y2]

--- a/paddlex/cv/datasets/voc.py
+++ b/paddlex/cv/datasets/voc.py
@@ -218,7 +218,8 @@ class VOCDetection(Dataset):
                     if not (x2 >= x1 and y2 >= y1):
                         logging.warning(
                             "Bounding box for object {} does not satisfy x1 <= x2 and y1 <= y2, "
-                            "so this object is skipped. xml file: {}".format(i, xml_file))
+                            "so this object is skipped. This error can be caused by specifying "
+                            "image width and height in wrong order. xml file: {}".format(i, xml_file))
                         continue
 
                     gt_bbox[i, :] = [x1, y1, x2, y2]


### PR DESCRIPTION
Include the file path and added a possible cause to warning
```shell
"Bounding box for object {} does not satisfy x1 <= x2 and y1 <= y2, so this object is skipped. xml file: {}"
```
Can possibly save user some time while debugging 

PR not related to cpp inference