### PR TITLE
fix VarifocalLoss import error

### DIFF
--- a/paddlex/ppdet/modeling/losses/__init__.py
+++ b/paddlex/ppdet/modeling/losses/__init__.py
@@ -25,6 +25,7 @@ from . import fairmot_loss
 from . import gfocal_loss
 from . import detr_loss
 from . import sparsercnn_loss
+from . import varifocal_loss
 
 from .yolo_loss import *
 from .iou_aware_loss import *
@@ -39,3 +40,4 @@ from .fairmot_loss import *
 from .gfocal_loss import *
 from .detr_loss import *
 from .sparsercnn_loss import *
+from .varifocal_loss import *


### PR DESCRIPTION
fix bug as below:

```
Traceback (most recent call last):
  File "picodet.py", line 42, in <module>
    model = pdx.det.PicoDet(num_classes=num_classes, backbone='ESNet_l')
  File "/usr/local/lib/python3.7/site-packages/paddlex-2.1.0-py3.7.egg/paddlex/cv/models/detector.py", line 727, in __init__
    loss_class = ppdet.modeling.VarifocalLoss(
AttributeError: module 'paddlex.ppdet.modeling' has no attribute 'VarifocalLoss'
```