### PR TITLE
RandomVerticalFlip 的 apply_bbox 方法api存在bug #1754

### DIFF
--- a/paddlex/cv/transforms/operators.py
+++ b/paddlex/cv/transforms/operators.py
@@ -524,8 +524,8 @@ class RandomVerticalFlip(Transform):
     def apply_bbox(self, bbox, height):
         oldy1 = bbox[:, 1].copy()
         oldy2 = bbox[:, 3].copy()
-        bbox[:, 0] = height - oldy2
-        bbox[:, 2] = height - oldy1
+        bbox[:, 1] = height - oldy2
+        bbox[:, 3] = height - oldy1
         return bbox
 
     def apply_segm(self, segms, height, width):


### PR DESCRIPTION
修复错误的bbox赋值，导致采用垂直翻转的训练时候的标注都有概率错误的问题

