### PR TITLE
Fixed the potential errors that may occur in PaddleX when the Pillow version is greater than 10.0.0

### DIFF
--- a/paddlex/modules/object_detection/dataset_checker/dataset_src/utils/visualizer.py
+++ b/paddlex/modules/object_detection/dataset_checker/dataset_src/utils/visualizer.py
@@ -11,6 +11,7 @@ import os
 import numpy as np
 import json
 from pathlib import Path
+import PIL
 from PIL import Image, ImageDraw, ImageFont
 from pycocotools.coco import COCO
 
@@ -113,7 +114,12 @@ def draw_bbox(image, coco_info: COCO, img_id):
         # draw label
         label = coco_info.loadCats(catid)[0]['name']
         text = "{}".format(label)
-        tw, th = draw.textsize(text, font=font)
+        if tuple(map(int, PIL.__version__.split('.'))) <= (10, 0, 0):
+            tw, th = draw.textsize(text, font=font)
+        else:
+            left, top, right, bottom = draw.textbbox((0, 0), text, font)
+            tw, th = right - left, bottom - top
+        
         if ymin < th:
             draw.rectangle(
                 [(xmin, ymin), (xmin + tw + 4, ymin + th + 1)], fill=color)


### PR DESCRIPTION
## 此为PR说明模版

Pillow 在 10.0.0 版本中删除了 textsize 函数，详情见 [https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods)。这个 PR 添加对高版本 Pillow 的支持，保证在使用 Detection 模型时可以正常进行数据校验。