### PR TITLE
RandomVerticalFlip 的 apply_bbox 方法api存在bug #1754

### DIFF
--- a/paddlex/cv/transforms/operators.py
+++ b/paddlex/cv/transforms/operators.py
@@ -524,8 +524,8 @@ class RandomVerticalFlip(Transform):
     def apply_bbox(self, bbox, height):
         oldy1 = bbox[:, 1].copy()
         oldy2 = bbox[:, 3].copy()
-        bbox[:, 0] = height - oldy2
-        bbox[:, 2] = height - oldy1
+        bbox[:, 1] = height - oldy2
+        bbox[:, 3] = height - oldy1
         return bbox
 
     def apply_segm(self, segms, height, width):


### PR DESCRIPTION
修复错误的bbox赋值，导致采用垂直翻转的训练时候的标注都有概率错误的问题

## 此为PR说明模版

如提交的为部署C++代码，请确认以下自测点是否完成（完成勾选即可），并保留以下的自测点列表，便于Reviewer知晓。

- [ ] Linux下测试通过
- - [ ] batch = 1 预测
- - [ ] batch > 1预测
- - [ ] 多GPU卡预测
- - [ ] TensorRT预测
- - [ ] Triton预测
- [ ] Windows下测试通过
- - [ ] batch = 1预测
- - [ ] batch > 1预测
