### PR TITLE
using ssh connection when paltform is github, and set depth=1 when cl…

### DIFF
--- a/paddlex/repo_manager/repo.py
+++ b/paddlex/repo_manager/repo.py
@@ -150,6 +150,9 @@ class PPRepository(object):
         """ clone_repos """
         branch = self.meta.get('branch', None)
         repo_url = f'https://{platform}{self.repo_url}'
+        # using ssh connection when it's github
+        if platform == 'github.com':
+            repo_url = f'git@github.com:{self.repo_url}'
         os.makedirs(self.repo_parent_dir, exist_ok=True)
         with switch_working_dir(self.repo_parent_dir):
             clone_repos_using_git(repo_url, branch=branch)

--- a/paddlex/repo_manager/repo.py
+++ b/paddlex/repo_manager/repo.py
@@ -150,9 +150,9 @@ class PPRepository(object):
         """ clone_repos """
         branch = self.meta.get('branch', None)
         repo_url = f'https://{platform}{self.repo_url}'
-        # using ssh connection when it's github
-        if platform == 'github.com':
-            repo_url = f'git@github.com:{self.repo_url}'
+        # uncomment this if you prefer using ssh connection (requires additional setup)
+        # if platform == 'github.com':
+        #    repo_url = f'git@github.com:{self.repo_url}'
         os.makedirs(self.repo_parent_dir, exist_ok=True)
         with switch_working_dir(self.repo_parent_dir):
             clone_repos_using_git(repo_url, branch=branch)

--- a/paddlex/repo_manager/utils.py
+++ b/paddlex/repo_manager/utils.py
@@ -80,7 +80,7 @@ def install_deps_using_pip():
 
 def clone_repos_using_git(url, branch=None):
     """ clone_repos_using_git """
-    args = ['git', 'clone']
+    args = ['git', 'clone', '--depth', '1']
     if isinstance(url, str):
         url = [url]
     args.extend(url)


### PR DESCRIPTION
- add `--depth 1` arguments when clone codes, which means shallow clone, since paddlex doesn't need commit history
- using ssh connection for clone, when platform is github, since it's more stable.