### PR TITLE
typo 修正"PaddleX文本检测/文本识别任务模块数据标注教程"链接

### DIFF
--- a/docs/module_usage/tutorials/ocr_modules/text_detection.md
+++ b/docs/module_usage/tutorials/ocr_modules/text_detection.md
@@ -38,7 +38,7 @@ for res in output:
 
 ### 4.1 数据准备
 在进行模型训练前，需要准备相应任务模块的数据集。PaddleX 针对每一个模块提供了数据校验功能，**只有通过数据校验的数据才可以进行模型训练**。
-此外，PaddleX 为每一个模块都提供了 Demo 数据集，您可以基于官方提供的 Demo 数据完成后续的开发。若您希望用私有数据集进行后续的模型训练，可以参考 [PaddleX文本检测/文本识别任务模块数据标注教程](../../../data_annotations/ocr_modules/text_detection_regognition.md)。
+此外，PaddleX 为每一个模块都提供了 Demo 数据集，您可以基于官方提供的 Demo 数据完成后续的开发。若您希望用私有数据集进行后续的模型训练，可以参考 [PaddleX文本检测/文本识别任务模块数据标注教程](../../../data_annotations/ocr_modules/text_detection_recognition.md)。
 
 #### 4.1.1 Demo 数据下载
 


### PR DESCRIPTION
单词拼写错误，应为`c`而非`g`
