### PR TITLE
bugfix: dont pass index_type and metric_type in append_index()

### DIFF
--- a/paddlex/inference/components/retrieval/faiss.py
+++ b/paddlex/inference/components/retrieval/faiss.py
@@ -333,8 +333,11 @@ class FaissBuilder:
             else:
                 index.train(gallery_features)
 
-        if not metric_type in cls.BINARY_METRIC_TYPE:
+        if metric_type not in cls.BINARY_METRIC_TYPE:
             index.add_with_ids(gallery_features, ids_now)
+        # TODO(gaotingquan): how append when using hamming metric type
+        # else:
+        #   pass
 
         for i, d in zip(list(ids_now), gallery_docs):
             ids[i] = d

--- a/paddlex/inference/pipelines/pp_shitu_v2.py
+++ b/paddlex/inference/pipelines/pp_shitu_v2.py
@@ -133,27 +133,20 @@ class ShiTuV2Pipeline(BasePipeline):
             self.rec_model.predict,
             metric_type=metric_type,
             index_type=index_type,
-            **kwargs
         )
 
-    def remove_index(self, remove_ids, index, **kwargs):
-        return FaissBuilder.remove(remove_ids, index, **kwargs)
+    def remove_index(self, remove_ids, index):
+        return FaissBuilder.remove(remove_ids, index)
 
     def append_index(
         self,
         gallery_imgs,
         gallery_label,
         index,
-        id_map=None,
-        metric_type="IP",
-        index_type="HNSW32",
-        **kwargs
     ):
         return FaissBuilder.append(
             gallery_imgs,
             gallery_label,
             self.rec_model.predict,
             index,
-            metric_type=metric_type,
-            **kwargs
         )


### PR DESCRIPTION
```python
index_data = pipeline.build_index(gallery_imgs="drink_dataset_v2.0/", gallery_label="drink_dataset_v2.0/gallery.txt", index_type="IVF", metric_type="IP")
index_data = pipeline.append_index(gallery_imgs="drink_dataset_v2.0/", gallery_label="drink_dataset_v2.0/gallery.txt", index=index_data)
index_data = pipeline.remove_index(remove_ids="drink_dataset_v2.0/remove_ids.txt", index=index_data)
index_data.save("drink_index")
```