### PR TITLE
Fix Dy2St Issue When Running Video Object Detection 

### DIFF
--- a/paddlex/repo_apis/PaddleVideo_api/video_det/config.py
+++ b/paddlex/repo_apis/PaddleVideo_api/video_det/config.py
@@ -295,7 +295,7 @@ indicating that no pretrained model to be used."
         Args:
             dy2st (bool): whether or not to use the dynamic to static mode.
         """
-        self.update({"Global.to_static": dy2st})
+        self.update({"to_static": dy2st})
 
     def _update_use_vdl(self, use_vdl: bool):
         """update config to set VisualDL


### PR DESCRIPTION
In PaddleVideo, the code directly searches for the `to_static` configuration from the global configuration instead of under the `Global` section. The relevant code is as follows:

```python
    # Location: paddlevideo/tasks/train.py
    if cfg.get("to_static", False):
        specs = None
        model = paddle.jit.to_static(model, input_spec=specs)
        logger.info("Successfully to apply @to_static with specs: {}".format(specs))
```

Currently, the generated YAML file structure is:

```yaml
Global:
  checkpoints: null
  device: gpu
  use_visualdl: false
  save_inference_dir: ./inference
  to_static: true                                   # <------ Incorrect placement
MODEL:
  framework: YOWOLocalizer
......
```

The correct YAML structure should be:

```yaml
Global:
  checkpoints: null
  device: gpu
  use_visualdl: false
  save_inference_dir: ./inference
MODEL:
  framework: YOWOLocalizer
......
to_static: true                                   # <------ Correct placement
```