### PR TITLE
Manually delete the predictor

### DIFF
--- a/paddlex/inference/models/common/static_infer.py
+++ b/paddlex/inference/models/common/static_infer.py
@@ -122,6 +122,9 @@ def _collect_trt_shape_range_info(
     # a garbage collector. Is there a more explicit and deterministic way to
     # handle this?
 
+    # HACK: Manually delete the predictor to trigger its destructor, ensuring that the shape_range_info file would be saved.
+    del predictor
+
 
 # pir trt
 def _convert_trt(


### PR DESCRIPTION
Manually delete the predictor to trigger its destructor, ensuring that the shape_range_info file would be saved