### PR TITLE
fix pipeline hpi config 

### DIFF
--- a/libs/ultra-infer/ultra_infer/runtime/backends/paddle/option.h
+++ b/libs/ultra-infer/ultra_infer/runtime/backends/paddle/option.h
@@ -102,6 +102,8 @@ struct PaddleBackendOption {
    */
   XpuOption xpu_option;
 
+  /// Wenable_tuned_tensorrt_dynamic_shapeDynamicShape, default true
+  bool allow_build_trt_at_runtime = true;
   /// Collect shape for model while enable_trt is true
   bool collect_trt_shape = false;
   /// Collect shape for model by device (for some custom ops)

--- a/libs/ultra-infer/ultra_infer/runtime/backends/paddle/option_pybind.cc
+++ b/libs/ultra-infer/ultra_infer/runtime/backends/paddle/option_pybind.cc
@@ -47,6 +47,8 @@ void BindPaddleOption(pybind11::module &m) {
       .def_readwrite("ipu_option", &PaddleBackendOption::ipu_option)
       .def_readwrite("xpu_option", &PaddleBackendOption::xpu_option)
       .def_readwrite("trt_option", &PaddleBackendOption::trt_option)
+      .def_readwrite("allow_build_trt_at_runtime",
+                     &PaddleBackendOption::allow_build_trt_at_runtime)
       .def_readwrite("collect_trt_shape",
                      &PaddleBackendOption::collect_trt_shape)
       .def_readwrite("collect_trt_shape_by_device",

--- a/libs/ultra-infer/ultra_infer/runtime/backends/paddle/paddle_backend.cc
+++ b/libs/ultra-infer/ultra_infer/runtime/backends/paddle/paddle_backend.cc
@@ -93,7 +93,9 @@ void PaddleBackend::BuildOption(const PaddleBackendOption &option) {
                                    option.trt_min_subgraph_size, precision,
                                    use_static);
 
-      SetTRTDynamicShapeToConfig(option);
+      if (!option.collect_trt_shape) {
+        SetTRTDynamicShapeToConfig(option);
+      }
       if (option_.enable_fixed_size_opt) {
         paddle_infer::experimental::InternalUtils::SetTransformerMaskid(
             &config_, "opt");
@@ -320,7 +322,8 @@ bool PaddleBackend::InitFromPaddle(const std::string &model,
     }
     FDINFO << "Start loading shape range info file " << shape_range_info
            << " to set TensorRT dynamic shape." << std::endl;
-    config_.EnableTunedTensorRtDynamicShape(shape_range_info, true);
+    config_.EnableTunedTensorRtDynamicShape(shape_range_info,
+                                            option.allow_build_trt_at_runtime);
   }
   // Note(zhoushunjie): The pass deletion should be executed just before
   // creating predictor.

--- a/paddlex/inference/pipelines/base.py
+++ b/paddlex/inference/pipelines/base.py
@@ -90,6 +90,7 @@ class BasePipeline(ABC, metaclass=AutoRegisterABCMetaClass):
             batch_size=config.get("batch_size", 1),
             pp_option=self.pp_option,
             use_hpip=self.use_hpip,
+            hpi_params=hpi_params,
             **kwargs,
         )
         return model


### PR DESCRIPTION
1. 修复hpi配置问题，使得自定义hpi配置可以正确生效。
2. 补充遗漏的paddle后端的option。