### PR TITLE
Optimize PDF reader

### DIFF
--- a/paddlex/inference/utils/io/readers.py
+++ b/paddlex/inference/utils/io/readers.py
@@ -249,11 +249,11 @@ class PDFReaderBackend(_BaseReaderBackend):
 
     def read_file(self, in_path):
         for page in fitz.open(in_path):
-            pix = page.get_pixmap(matrix=self.mat, alpha=False)
-            getpngdata = pix.tobytes(output="png")
-            # decode as np.uint8
-            image_array = np.frombuffer(getpngdata, dtype=np.uint8)
-            img_cv = cv2.imdecode(image_array, cv2.IMREAD_ANYCOLOR)
+            pixmap = page.get_pixmap(matrix=self.mat, alpha=False)
+            img_cv = np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(
+                pixmap.h, pixmap.w, pixmap.n
+            )
+            img_cv = cv2.cvtColor(img_cv, cv2.COLOR_RGB2BGR)
             yield img_cv
 
 


### PR DESCRIPTION
优化PDF读取逻辑。之前的逻辑是先把pixmap编码成图像，再把图像解码成cv2数据，但这样其实绕了一圈，在图像比较大的时候开销较大；修改后的逻辑直接把pixmap转换为numpy数组（按照cv2图像的格式）。修改前后，输出不变，使用 https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/contract2.pdf 测试PDF的每页读取耗时（单位为s）：

- 修改前：
  ```
  0.14109396934509277
  0.09376382827758789
  0.10400724411010742
  0.0987849235534668
  0.10510611534118652
  0.11766195297241211
  ```

- 修改后：
  ```
  0.06064653396606445
  0.011306047439575195
  0.014446020126342773
  0.013953924179077148
  0.011344432830810547
  0.02837228775024414
  ```

速度提升明显。
