### PR TITLE
[Feat] Optimize CLI

### DIFF
--- a/paddlex/paddlex_cli.py
+++ b/paddlex/paddlex_cli.py
@@ -58,15 +58,10 @@ def args_cfg():
     ################# install pdx #################
     install_group.add_argument(
         "--install",
-        action="store_true",
-        default=False,
-        help="Install specified PaddleX plugins.",
-    )
-    install_group.add_argument(
-        "plugins",
         nargs="*",
         default=[],
-        help="Names of custom development plugins to install (space-separated).",
+        metavar="PLUGIN",
+        help="Install specified PaddleX plugins.",
     )
     install_group.add_argument(
         "--no_deps",
@@ -265,7 +260,7 @@ def install(args):
     # Disable eager initialization
     os.environ["PADDLE_PDX_EAGER_INIT"] = "False"
 
-    plugins = args.plugins[:]
+    plugins = args.install[:]
 
     if "serving" in plugins:
         plugins.remove("serving")

--- a/paddlex/paddlex_cli.py
+++ b/paddlex/paddlex_cli.py
@@ -59,7 +59,6 @@ def args_cfg():
     install_group.add_argument(
         "--install",
         nargs="*",
-        default=[],
         metavar="PLUGIN",
         help="Install specified PaddleX plugins.",
     )
@@ -175,7 +174,10 @@ def args_cfg():
     pipeline = args.pipeline
     pipeline_args = []
 
-    if not (args.install or args.serve or args.paddle2onnx) and pipeline is not None:
+    if (
+        not (args.install is not None or args.serve or args.paddle2onnx)
+        and pipeline is not None
+    ):
         if os.path.isfile(pipeline):
             pipeline_name = load_pipeline_config(pipeline)["pipeline_name"]
         else:
@@ -439,8 +441,9 @@ def main():
         parser.print_help()
         sys.exit(2)
 
-    if args.install:
+    if args.install is not None:
         install(args)
+        return
     elif args.serve:
         serve(
             args.pipeline,
@@ -449,12 +452,14 @@ def main():
             host=args.host,
             port=args.port,
         )
+        return
     elif args.paddle2onnx:
         paddle_to_onnx(
             args.paddle_model_dir,
             args.onnx_model_dir,
             opset_version=args.opset_version,
         )
+        return
     else:
         if args.get_pipeline_config is not None:
             interactive_get_pipeline(args.get_pipeline_config, args.save_path)
@@ -467,7 +472,7 @@ def main():
                     pipeline_args_dict[arg_name] = getattr(args, arg_name)
                 else:
                     logging.warning(f"Argument {arg_name} is missing in args")
-            return pipeline_predict(
+            pipeline_predict(
                 args.pipeline,
                 args.input,
                 args.device,
@@ -475,3 +480,4 @@ def main():
                 use_hpip=args.use_hpip,
                 **pipeline_args_dict,
             )
+            return


### PR DESCRIPTION
目前PaddleX CLI的所有命令行参数都处在同一命名空间，并且位置参数被插件安装功能占用，这导致了不同功能之间的“不对称”：看起来像是先有一个安装插件的CLI，然后再把其他功能以可选参数的方式硬塞进CLI，显得不太优雅。例如，执行`paddlex --help`会得到如下结果：

![image](https://github.com/user-attachments/assets/0be7ac66-e8ec-4861-9ddb-b57b68fa40c6)

其中的位置参数`plugins`看起来像是所有功能都需要用到的公共参数，但实际只有插件安装功能会用到。

本PR对PaddleX CLI进行改造，在基本不改动接口的情况下，使各功能尽可能“对称”，看起来更自然。修改后，执行`paddlex --help`会得到如下结果：

![image](https://github.com/user-attachments/assets/ae4f03ad-4a18-4457-94ec-b33f8563b93b)

至少，从上述帮助信息来看，`PLUGIN`只用于`--install`，而与其他功能无关。

如上所述，本PR所做的修改只能说是“基本不改动接口”，实际上，此前允许的类似`paddlex --install -y PaddleOCR`的用法将不再支持，`--install`和插件名之间不再允许插入额外的参数。经过搜索，此前的文档和代码示例中均未涉及到上述用法，所以我认为本PR做的修改还是相对安全的。

更优雅的方案可能是使用subparser将不同功能隔离到不同的命名空间，这也符合目前业界大部分同类CLI的实践。不过，考虑到那样修改后的形式可能与现有接口存在较大的不兼容，目前暂不考虑。