### PR TITLE
add pipeline for docbee

### DIFF
--- a/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml
+++ b/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml
@@ -1,0 +1,14 @@
+Global:
+  model: PP-DocBee-2B
+  mode: predict # only support predict
+  device: gpu:0
+  output: "output"
+
+Predict:
+  batch_size: 1
+  model_dir: "/path/to/PP-DocBee-2B"
+  input:
+    image: "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/medal_table.png"
+    query: "识别这份表格的内容"
+  kernel_option:
+    run_mode: paddle

--- a/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml
+++ b/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml
@@ -1,0 +1,14 @@
+Global:
+  model: PP-DocBee-7B
+  mode: predict # only support predict
+  device: gpu:0
+  output: "output"
+
+Predict:
+  batch_size: 1
+  model_dir: "/path/to/PP-DocBee-7B"
+  input:
+    image: "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/medal_table.png"
+    query: "识别这份表格的内容"
+  kernel_option:
+    run_mode: paddle

--- a/paddlex/configs/pipelines/doc_understanding.yaml
+++ b/paddlex/configs/pipelines/doc_understanding.yaml
@@ -1,0 +1,9 @@
+
+pipeline_name: doc_understanding
+
+SubModules:
+  DocUnderstanding:
+    module_name: doc_vlm
+    model_name: PP-DocBee-2B
+    model_dir: null
+    batch_size: 1

--- a/paddlex/inference/common/result/base_result.py
+++ b/paddlex/inference/common/result/base_result.py
@@ -56,7 +56,7 @@ class BaseResult(dict, JsonMixin, StrMixin):
                 func()
 
     def _get_input_fn(self):
-        if (fp := self["input_path"]) is None:
+        if self.get("input_path", None) is None:
             if self._rand_fn:
                 return self._rand_fn
 
@@ -68,4 +68,5 @@ class BaseResult(dict, JsonMixin, StrMixin):
             )
             self._rand_fn = Path(fp).name
             return self._rand_fn
+        fp = self["input_path"]
         return Path(fp).name

--- a/paddlex/inference/pipelines/__init__.py
+++ b/paddlex/inference/pipelines/__init__.py
@@ -27,6 +27,7 @@ from .attribute_recognition import (
 from .base import BasePipeline
 from .components import BaseChat, BaseGeneratePrompt, BaseRetriever
 from .doc_preprocessor import DocPreprocessorPipeline
+from .doc_understanding import DocUnderstandingPipeline
 from .face_recognition import FaceRecPipeline
 from .formula_recognition import FormulaRecognitionPipeline
 from .image_classification import ImageClassificationPipeline

--- a/paddlex/inference/pipelines/doc_understanding/__init__.py
+++ b/paddlex/inference/pipelines/doc_understanding/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .pipeline import DocUnderstandingPipeline

--- a/paddlex/inference/pipelines/doc_understanding/pipeline.py
+++ b/paddlex/inference/pipelines/doc_understanding/pipeline.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Optional, Union
+
+from ....utils.deps import pipeline_requires_extra
+from ...models.doc_vlm.result import DocVLMResult
+from ...utils.hpi import HPIConfig
+from ...utils.pp_option import PaddlePredictorOption
+from ..base import BasePipeline
+
+
+@pipeline_requires_extra("multimodal")
+class DocUnderstandingPipeline(BasePipeline):
+    """Doc Understanding Pipeline"""
+
+    entities = "doc_understanding"
+
+    def __init__(
+        self,
+        config: Dict,
+        device: str = None,
+        pp_option: PaddlePredictorOption = None,
+        use_hpip: bool = False,
+        hpi_config: Optional[Union[Dict[str, Any], HPIConfig]] = None,
+    ) -> None:
+        """
+        Initializes the class with given configurations and options.
+
+        Args:
+            config (Dict): Configuration dictionary containing model and other parameters.
+            device (str): The device to run the prediction on. Default is None.
+            pp_option (PaddlePredictorOption): Options for PaddlePaddle predictor. Default is None.
+            use_hpip (bool, optional): Whether to use the high-performance
+                inference plugin (HPIP) by default. Defaults to False.
+            hpi_config (Optional[Union[Dict[str, Any], HPIConfig]], optional):
+                The default high-performance inference configuration dictionary.
+                Defaults to None.
+        """
+        super().__init__(
+            device=device, pp_option=pp_option, use_hpip=use_hpip, hpi_config=hpi_config
+        )
+
+        doc_understanding_model_config = config.get("SubModules", {}).get(
+            "DocUnderstanding",
+            {"model_config_error": "config error for doc_understanding_model!"},
+        )
+        self.doc_understanding_model = self.create_model(doc_understanding_model_config)
+
+    def predict(self, input: Dict, **kwargs) -> DocVLMResult:
+        """Predicts doc understanding results for the given input.
+
+        Args:
+            input (dict): The input image and query.
+            **kwargs: Additional keyword arguments that can be passed to the function.
+
+        Returns:
+            DocVLMResult: The predicted doc understanding results.
+        """
+        yield from self.doc_understanding_model(input, **kwargs)


### PR DESCRIPTION
1. add pipeline for pp-docbee.
2. adapt `class BaseResult` for pipelines which do not contain an `input_path` field.