### PR TITLE
enable fused_attn and fused_linear for CLIP_vit

### DIFF
--- a/paddlex/repo_apis/PaddleClas_api/configs/CLIP_vit_base_patch16_224.yaml
+++ b/paddlex/repo_apis/PaddleClas_api/configs/CLIP_vit_base_patch16_224.yaml
@@ -30,6 +30,8 @@ Arch:
   class_num: 1000
   return_embed: False
   pretrained: True
+  use_fused_attn: True
+  use_fused_linear: True
 
 # loss function config for traing/eval process
 Loss:

--- a/paddlex/repo_apis/PaddleClas_api/configs/CLIP_vit_large_patch14_224.yaml
+++ b/paddlex/repo_apis/PaddleClas_api/configs/CLIP_vit_large_patch14_224.yaml
@@ -27,6 +27,8 @@ Arch:
   class_num: 1000
   return_embed: False
   pretrained: True
+  use_fused_attn: True
+  use_fused_linear: True
 
 # loss function config for traing/eval process
 Loss:


### PR DESCRIPTION
在CLIP_vit_base/large模型中启用fused_attn和fused_linear算子，可以一定程度提升fp16下的性能，但需注意fp32的兼容性问题