### PR TITLE
[Docs] Fix device docs

### DIFF
--- a/docs/module_usage/instructions/model_python_API.en.md
+++ b/docs/module_usage/instructions/model_python_API.en.md
@@ -101,7 +101,7 @@ PaddleX supports modifying the inference configuration through `PaddlePredictorO
 #### Attributes:
 
 * `device`: Inference device.
-  * Supports setting the device type and card number represented by `str`. Device types include 'gpu', 'cpu', 'npu', 'xpu', 'mlu', 'dcu'. When using an accelerator card, you can specify the card number, e.g., 'gpu:0' for GPU 0. By default, using 0 id GPU if available, otherwise CPU.
+  * Supports setting the device type and card number represented by `str`. Device types include 'gpu', 'cpu', 'npu', 'xpu', 'mlu', 'dcu'. When using an accelerator card, you can specify the card number, e.g., 'gpu:0' for GPU 0. By default, if a GPU is available, the one with the smallest ID number will be used; otherwise, the CPU will be used.
   * Return value: `str` type, the currently set inference device.
 * `run_mode`: Operating mode.
   * Supports setting the operating mode as a `str` type, options include 'paddle', 'trt_fp32', 'trt_fp16', 'trt_int8', 'mkldnn', 'mkldnn_bf16'. Note that 'trt_fp32' and 'trt_fp16' correspond to using the TensorRT subgraph engine for inference with FP32 and FP16 precision respectively; these options are only available when the inference device is a GPU. Additionally, 'mkldnn' is only available when the inference device is a CPU. The default value is 'paddle'.

--- a/docs/module_usage/instructions/model_python_API.md
+++ b/docs/module_usage/instructions/model_python_API.md
@@ -35,7 +35,7 @@ for res in output:
     * `model_name`：`str` 类型，模型名，如“PP-LCNet_x1_0”；
     * `model_dir`：`str` 类型，本地 inference 模型文件目录路径，如“/path/to/PP-LCNet_x1_0_infer/”，默认为 `None`，表示使用`model_name`指定的官方推理模型；
     * `batch_size`：`int` 类型，默认为 `1`；
-    * `device`：`str` 类型，用于设置模型推理设备，如为GPU设置则可以指定卡号，如“cpu”、“gpu:2”，默认情况下，如有 GPU 设置则使用 0 号 GPU，否则使用 CPU；
+    * `device`：`str` 类型，用于设置模型推理设备，如为GPU设置则可以指定卡号，如“cpu”、“gpu:2”，默认情况下，如有可用 GPU 设置则使用编号最小的 GPU，否则使用 CPU；
     * `pp_option`：`PaddlePredictorOption` 类型，用于改变运行模式等配置项，关于推理配置的详细说明，请参考下文[4-推理配置](#4-推理配置)；
     * `use_hpip`：`bool` 类型，是否启用高性能推理插件；
     * `hpi_config`：`dict | None` 类型，高性能推理配置；
@@ -103,7 +103,7 @@ PaddleX 支持通过`PaddlePredictorOption`修改推理配置，相关API如下�
 #### 属性：
 
 * `device`：推理设备；
-  * 支持设置 `str` 类型表示的推理设备类型及卡号，设备类型支持可选 “gpu”、“cpu”、“npu”、“xpu”、“mlu”、“dcu”，当使用加速卡时，支持指定卡号，如使用 0 号 GPU：`gpu:0`，默认情况下，如有 GPU 设置则使用 0 号 GPU，否则使用 CPU；
+  * 支持设置 `str` 类型表示的推理设备类型及卡号，设备类型支持可选 “gpu”、“cpu”、“npu”、“xpu”、“mlu”、“dcu”，当使用加速卡时，支持指定卡号，如使用 0 号 GPU：`gpu:0`，默认情况下，如有可用 GPU 设置则使用编号最小的 GPU，否则使用 CPU；
   * 返回值：`str`类型，当前设置的推理设备。
 * `run_mode`：运行模式；
   * 支持设置 `str` 类型的运行模式，支持可选 'paddle'，'trt_fp32'，'trt_fp16'，'trt_int8'，'mkldnn'，'mkldnn_bf16'，其中 'trt_fp32' 和' trt_fp16' 分别对应使用 TensorRT 子图引擎进行 FP32 和 FP16 精度的推理，仅当推理设备使用 GPU 时可选，'mkldnn' 仅当推理设备使用 CPU 时可选，默认为 'paddle'；

--- a/docs/pipeline_deploy/serving.en.md
+++ b/docs/pipeline_deploy/serving.en.md
@@ -72,7 +72,7 @@ The command-line options related to serving are as follows:
 </tr>
 <tr>
 <td><code>--device</code></td>
-<td>Device for pipeline deployment. By default the GPU will be used if it is available; otherwise, the CPU will be used.</td>
+<td>Device for pipeline deployment. By default the GPU will be used when it is available; otherwise, the CPU will be used.</td>
 </tr>
 <tr>
 <td><code>--host</code></td>

--- a/docs/pipeline_deploy/serving.en.md
+++ b/docs/pipeline_deploy/serving.en.md
@@ -72,7 +72,7 @@ The command-line options related to serving are as follows:
 </tr>
 <tr>
 <td><code>--device</code></td>
-<td>Device for pipeline deployment. Defaults to <code>cpu</code> (if GPU is unavailable) or <code>gpu</code> (if GPU is available).</td>
+<td>Device for pipeline deployment. By default the GPU will be used if it is available; otherwise, the CPU will be used.</td>
 </tr>
 <tr>
 <td><code>--host</code></td>

--- a/docs/pipeline_deploy/serving.md
+++ b/docs/pipeline_deploy/serving.md
@@ -72,7 +72,7 @@ INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
 </tr>
 <tr>
 <td><code>--device</code></td>
-<td>产线部署设备。默认为 <code>cpu</code>（如 GPU 不可用）或 <code>gpu</code>（如 GPU 可用）。</td>
+<td>产线部署设备。默认情况下，当 GPU 可用时，将使用 GPU；否则使用 CPU。</td>
 </tr>
 <tr>
 <td><code>--host</code></td>

--- a/docs/pipeline_usage/instructions/pipeline_CLI_usage.en.md
+++ b/docs/pipeline_usage/instructions/pipeline_CLI_usage.en.md
@@ -23,7 +23,7 @@ This single step completes the inference prediction and saves the prediction res
 
 * `pipeline`: The name of the pipeline or the local path to the pipeline configuration file, such as the pipeline name "image_classification", or the path to the pipeline configuration file "path/to/image_classification.yaml";
 * `input`: The path to the data file to be predicted, supporting local file paths, local directories containing data files to be predicted, and file URL links;
-* `device`: Used to set the inference device. If set for GPU, you can specify the card number, such as "cpu", "gpu:2". By default, using 0 id GPU if available, otherwise CPU;
+* `device`: Used to set the inference device. If set for GPU, you can specify the card number, such as "cpu", "gpu:2". By default, if a GPU is available, the one with the smallest ID number will be used; otherwise, the CPU will be used;
 * `save_path`: The save path for prediction results. By default, the prediction results will not be saved;
 * `use_hpip`: Enable the high-performance inference plugin;
 * `hpi_config`: The high-performance inference configuration;

--- a/docs/pipeline_usage/instructions/pipeline_CLI_usage.md
+++ b/docs/pipeline_usage/instructions/pipeline_CLI_usage.md
@@ -24,7 +24,7 @@ paddlex --pipeline image_classification \
 
 * `pipeline`：模型产线名称或是模型产线配置文件的本地路径，如模型产线名 “image_classification”，或模型产线配置文件路径 “path/to/image_classification.yaml”；
 * `input`：待预测数据文件路径，支持本地文件路径、包含待预测数据文件的本地目录、文件URL链接；
-* `device`：用于设置模型推理设备，如为 GPU 则可以指定卡号，如 “cpu”、“gpu:2”，默认情况下，如有 GPU 设置则使用 0 号 GPU，否则使用 CPU；
+* `device`：用于设置模型推理设备，如为 GPU 则可以指定卡号，如 “cpu”、“gpu:2”，默认情况下，如有可用 GPU 设置则使用编号最小的 GPU，否则使用 CPU；
 * `save_path`：预测结果的保存路径，默认情况下，不保存预测结果；
 * `use_hpip`：启用高性能推理插件；
 * `hpi_config`：高性能推理配置；

--- a/docs/pipeline_usage/instructions/pipeline_python_API.en.md
+++ b/docs/pipeline_usage/instructions/pipeline_python_API.en.md
@@ -100,7 +100,7 @@ PaddleX supports modifying the inference configuration through `PaddlePredictorO
 #### Attributes:
 
 * `device`: Inference device.
-  * Supports setting the device type and card number represented by `str`. Device types include 'gpu', 'cpu', 'npu', 'xpu', 'mlu', 'dcu'. When using an accelerator card, you can specify the card number, e.g., 'gpu:0' for GPU 0. By default, using 0 id GPU if available, otherwise CPU.
+  * Supports setting the device type and card number represented by `str`. Device types include 'gpu', 'cpu', 'npu', 'xpu', 'mlu', 'dcu'. When using an accelerator card, you can specify the card number, e.g., 'gpu:0' for GPU 0. By default, if a GPU is available, the one with the smallest ID number will be used; otherwise, the CPU will be used.
   * Return value: `str` type, the currently set inference device.
 * `run_mode`: Operating mode.
   * Supports setting the operating mode as a `str` type, options include 'paddle', 'trt_fp32', 'trt_fp16', 'trt_int8', 'mkldnn', 'mkldnn_bf16'. Note that 'trt_fp32' and 'trt_fp16' correspond to using the TensorRT subgraph engine for inference with FP32 and FP16 precision respectively; these options are only available when the inference device is a GPU. Additionally, 'mkldnn' is only available when the inference device is a CPU. The default value is 'paddle'.

--- a/docs/pipeline_usage/instructions/pipeline_python_API.md
+++ b/docs/pipeline_usage/instructions/pipeline_python_API.md
@@ -33,7 +33,7 @@ for res in output:
 * `create_pipeline`：实例化预测模型产线对象；
   * 参数：
     * `pipeline`：`str` 类型，产线名或是本地产线配置文件路径，如“image_classification”、“/path/to/image_classification.yaml”；
-    * `device`：`str` 类型，用于设置模型推理设备，如为 GPU 则可以指定卡号，如“cpu”、“gpu:2”，默认情况下，如有 GPU 设置则使用 0 号 GPU，否则使用 CPU；
+    * `device`：`str` 类型，用于设置模型推理设备，如为 GPU 则可以指定卡号，如“cpu”、“gpu:2”，默认情况下，如有可用 GPU 设置则使用编号最小的 GPU，否则使用 CPU；
     * `pp_option`：`PaddlePredictorOption` 类型，用于改变运行模式等配置项，关于推理配置的详细说明，请参考下文[4-推理配置](#4-推理配置)；
     * `use_hpip`：`bool | None` 类型，是否启用高性能推理插件（`None` 表示使用配置文件中的配置）；
     * `hpi_config`：`dict | None` 类型，高性能推理配置；
@@ -101,7 +101,7 @@ PaddleX 支持通过`PaddlePredictorOption`修改推理配置，相关API如下�
 #### 属性：
 
 * `device`：推理设备；
-  * 支持设置 `str` 类型表示的推理设备类型及卡号，设备类型支持可选 “gpu”、“cpu”、“npu”、“xpu”、“mlu”、“dcu”，当使用加速卡时，支持指定卡号，如使用 0 号 GPU：`gpu:0`，默认情况下，如有 GPU 设置则使用 0 号 GPU，否则使用 CPU；
+  * 支持设置 `str` 类型表示的推理设备类型及卡号，设备类型支持可选 “gpu”、“cpu”、“npu”、“xpu”、“mlu”、“dcu”，当使用加速卡时，支持指定卡号，如使用 0 号 GPU：`gpu:0`，默认情况下，如有可用 GPU 设置则使用编号最小的 GPU，否则使用 CPU；
   * 返回值：`str`类型，当前设置的推理设备。
 * `run_mode`：运行模式；
   * 支持设置 `str` 类型的运行模式，支持可选 'paddle'，'trt_fp32'，'trt_fp16'，'trt_int8'，'mkldnn'，'mkldnn_bf16'，其中 'trt_fp32' 和' trt_fp16' 分别对应使用 TensorRT 子图引擎进行 FP32 和 FP16 精度的推理，仅当推理设备使用 GPU 时可选，'mkldnn' 仅当推理设备使用 CPU 时可选，默认为 'paddle'；

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_anomaly_detection.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_anomaly_detection.en.md
@@ -188,23 +188,6 @@ In the above Python script, the following steps are executed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>Pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Such as <code>cpu</code> indicating using CPU for inference;</li>
-  <li><b>GPU</b>: Such as <code>gpu:0</code> indicating using the 1st GPU for inference;</li>
-  <li><b>NPU</b>: Such as <code>npu:0</code> indicating using the 1st NPU for inference;</li>
-  <li><b>XPU</b>: Such as <code>xpu:0</code> indicating using the 1st XPU for inference;</li>
-  <li><b>MLU</b>: Such as <code>mlu:0</code> indicating using the 1st MLU for inference;</li>
-  <li><b>DCU</b>: Such as <code>dcu:0</code> indicating using the 1st DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, it will default to using the parameter value initialized by the pipeline. During initialization, it will preferentially use the local GPU 0 device, if not available, it will use the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_anomaly_detection.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_anomaly_detection.md
@@ -192,23 +192,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </table>
 
 （3）对预测结果进行处理，每个样本的预测结果均为对应的Result对象，且支持打印、保存为图片、保存为`json`文件的操作:

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_classification.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_classification.en.md
@@ -856,23 +856,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device used for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, such as <code>cpu</code>.</li>
-<li><b>GPU</b>: Use the specified GPU for inference, such as <code>gpu:0</code> for the first GPU.</li>
-<li><b>NPU</b>: Use the specified NPU for inference, such as <code>npu:0</code> for the first NPU.</li>
-<li><b>XPU</b>: Use the specified XPU for inference, such as <code>xpu:0</code> for the first XPU.</li>
-<li><b>MLU</b>: Use the specified MLU for inference, such as <code>mlu:0</code> for the first MLU.</li>
-<li><b>DCU</b>: Use the specified DCU for inference, such as <code>dcu:0</code> for the first DCU.</li>
-<li><b>None</b>: If set to <code>None</code>, the default value from the pipeline initialization will be used. During initialization, it will prioritize the local GPU device 0; if unavailable, it will use the CPU.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>topk</code></td>
 <td>The top <code>topk</code> values of the prediction results. If not specified, the default configuration of the official PaddleX model will be used.</td>
 <td><code>int</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_classification.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_classification.md
@@ -851,23 +851,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>topk</code></td>
 <td>预测结果的前<code>topk</code>值，如果不指定，将默认使用PaddleX官方模型配置</td>
 <td><code>int</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_multi_label_classification.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_multi_label_classification.en.md
@@ -223,23 +223,6 @@ In the above Python script, the following steps are performed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Such as <code>cpu</code> indicates using CPU for inference;</li>
-  <li><b>GPU</b>: Such as <code>gpu:0</code> indicates using the 1st GPU for inference;</li>
-  <li><b>NPU</b>: Such as <code>npu:0</code> indicates using the 1st NPU for inference;</li>
-  <li><b>XPU</b>: Such as <code>xpu:0</code> indicates using the 1st XPU for inference;</li>
-  <li><b>MLU</b>: Such as <code>mlu:0</code> indicates using the 1st MLU for inference;</li>
-  <li><b>DCU</b>: Such as <code>dcu:0</code> indicates using the 1st DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, it will preferentially use the local GPU 0 device, if not available, the CPU device will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>threshold</code></td>
 <td>Multi-label classification threshold</td>
 <td><code>float | dict | list | None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/image_multi_label_classification.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/image_multi_label_classification.md
@@ -223,23 +223,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>threshold</code></td>
 <td>多标签分类阈值</td>
 <td><code>float | dict | list｜ None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/instance_segmentation.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/instance_segmentation.en.md
@@ -331,23 +331,6 @@ In the above Python script, the following steps are performed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>Pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Such as <code>cpu</code> indicates using CPU for inference;</li>
-<li><b>GPU</b>: Such as <code>gpu:0</code> indicates using the 1st GPU for inference;</li>
-<li><b>NPU</b>: Such as <code>npu:0</code> indicates using the 1st NPU for inference;</li>
-<li><b>XPU</b>: Such as <code>xpu:0</code> indicates using the 1st XPU for inference;</li>
-<li><b>MLU</b>: Such as <code>mlu:0</code> indicates using the 1st MLU for inference;</li>
-<li><b>DCU</b>: Such as <code>dcu:0</code> indicates using the 1st DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, it will preferentially use the local GPU 0 device, if not available, the CPU device will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>threshold</code></td>
 <td>Low score object filtering threshold for the model</td>
 <td><code>float|None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/instance_segmentation.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/instance_segmentation.md
@@ -333,23 +333,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>threshold</code></td>
 <td>模型的低分object过滤阈值</td>
 <td><code>float|None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_detection.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_detection.en.md
@@ -199,23 +199,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: For example, <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: For example, <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: For example, <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: For example, <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: For example, <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: For example, <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the parameter value initialized by the pipeline will be used by default. During initialization, the local GPU device 0 will be prioritized; if unavailable, the CPU device will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>thresholds</code></td>
 <td>The thresholds used during model inference.</td>
 <td><code>dict[str, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_detection.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_detection.md
@@ -197,23 +197,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>thresholds</code></td>
 <td>模型推理时使用的阈值</td>
 <td><code>dict[str, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_segmentation.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_segmentation.en.md
@@ -199,23 +199,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: For example, <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: For example, <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: For example, <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: For example, <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: For example, <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: For example, <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the parameter value initialized by the pipeline will be used by default. During initialization, the local GPU device 0 will be prioritized; if unavailable, the CPU device will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>prompt_type</code></td>
 <td>The type of prompt used during model inference.</td>
 <td><code>str</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_segmentation.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/open_vocabulary_segmentation.md
@@ -194,24 +194,6 @@ for res in output:
 </ul>
 </td>
 <td><code>None</code></td>
-</tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>prompt_type</code></td>
 <td>模型推理时使用的提示类型</td>
 <td><code>str</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/pedestrian_attribute_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/pedestrian_attribute_recognition.en.md
@@ -241,23 +241,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device used for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, such as <code>cpu</code>.</li>
-<li><b>GPU</b>: Use the specified GPU for inference, such as <code>gpu:0</code> for the first GPU.</li>
-<li><b>NPU</b>: Use the specified NPU for inference, such as <code>npu:0</code> for the first NPU.</li>
-<li><b>XPU</b>: Use the specified XPU for inference, such as <code>xpu:0</code> for the first XPU.</li>
-<li><b>MLU</b>: Use the specified MLU for inference, such as <code>mlu:0</code> for the first MLU.</li>
-<li><b>DCU</b>: Use the specified DCU for inference, such as <code>dcu:0</code> for the first DCU.</li>
-<li><b>None</b>: If set to <code>None</code>, the default value from the pipeline initialization will be used. During initialization, it will prioritize the local GPU device 0; if unavailable, it will use the CPU.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>det_threshold</code></td>
 <td>Threshold for pedestrian detection visualization.</td>
 <td><code>float | None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/pedestrian_attribute_recognition.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/pedestrian_attribute_recognition.md
@@ -238,23 +238,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>det_threshold</code></td>
 <td>行人检测可视化阈值</td>
 <td><code>float | None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/rotated_object_detection.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/rotated_object_detection.en.md
@@ -197,23 +197,6 @@ In the above Python script, the following steps were executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device used for pipeline inference</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: e.g., <code>cpu</code> indicates using CPU for inference;</li>
-  <li><b>GPU</b>: e.g., <code>gpu:0</code> indicates using the 1st GPU for inference;</li>
-  <li><b>NPU</b>: e.g., <code>npu:0</code> indicates using the 1st NPU for inference;</li>
-  <li><b>XPU</b>: e.g., <code>xpu:0</code> indicates using the 1st XPU for inference;</li>
-  <li><b>MLU</b>: e.g., <code>mlu:0</code> indicates using the 1st MLU for inference;</li>
-  <li><b>DCU</b>: e.g., <code>dcu:0</code> indicates using the 1st DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, the local GPU 0 will be prioritized; if unavailable, the CPU will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>threshold</code></td>
 <td>Filtering threshold for low-confidence object</td>
 <td><code>None|float|dict[int, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/rotated_object_detection.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/rotated_object_detection.md
@@ -194,23 +194,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>threshold</code></td>
 <td>低分object过滤阈值</td>
 <td><code>None|float|dict[int, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/semantic_segmentation.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/semantic_segmentation.en.md
@@ -363,23 +363,6 @@ In the above Python script, the following steps are executed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>Pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: For example, <code>cpu</code> indicates using CPU for inference;</li>
-<li><b>GPU</b>: For example, <code>gpu:0</code> indicates using the first GPU for inference;</li>
-<li><b>NPU</b>: For example, <code>npu:0</code> indicates using the first NPU for inference;</li>
-<li><b>XPU</b>: For example, <code>xpu:0</code> indicates using the first XPU for inference;</li>
-<li><b>MLU</b>: For example, <code>mlu:0</code> indicates using the first MLU for inference;</li>
-<li><b>DCU</b>: For example, <code>dcu:0</code> indicates using the first DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, it will use the parameter value initialized by the pipeline by default. During initialization, it will preferentially use the local GPU 0 device, if not available, it will use the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>target_size</code></td>
 <td>Image resolution actually used during model inference</td>
 <td><code>int|-1|None|tuple[int,int]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/semantic_segmentation.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/semantic_segmentation.md
@@ -367,23 +367,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>target_size</code></td>
 <td>模型推理时实际使用的图像分辨率</td>
 <td><code>int|-1|None|tuple[int,int]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/small_object_detection.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/small_object_detection.en.md
@@ -214,23 +214,6 @@ In the above Python script, the following steps are performed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>Pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Such as <code>cpu</code> indicates using CPU for inference;</li>
-<li><b>GPU</b>: Such as <code>gpu:0</code> indicates using the 1st GPU for inference;</li>
-<li><b>NPU</b>: Such as <code>npu:0</code> indicates using the 1st NPU for inference;</li>
-<li><b>XPU</b>: Such as <code>xpu:0</code> indicates using the 1st XPU for inference;</li>
-<li><b>MLU</b>: Such as <code>mlu:0</code> indicates using the 1st MLU for inference;</li>
-<li><b>DCU</b>: Such as <code>dcu:0</code> indicates using the 1st DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, it will preferentially use the local GPU 0 device, if not available, the CPU device will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>threshold</code></td>
 <td>Filtering threshold for low-confidence object</td>
 <td><code>None|float|dict[int, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/small_object_detection.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/small_object_detection.md
@@ -215,23 +215,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 <td><code>threshold</code></td>
 <td>低置信度object过滤阈值</td>
 <td><code>None|float|dict[int, float]</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/vehicle_attribute_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/vehicle_attribute_recognition.en.md
@@ -223,23 +223,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device used for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, such as <code>cpu</code>.</li>
-<li><b>GPU</b>: Use the specified GPU for inference, such as <code>gpu:0</code> for the first GPU.</li>
-<li><b>NPU</b>: Use the specified NPU for inference, such as <code>npu:0</code> for the first NPU.</li>
-<li><b>XPU</b>: Use the specified XPU for inference, such as <code>xpu:0</code> for the first XPU.</li>
-<li><b>MLU</b>: Use the specified MLU for inference, such as <code>mlu:0</code> for the first MLU.</li>
-<li><b>DCU</b>: Use the specified DCU for inference, such as <code>dcu:0</code> for the first DCU.</li>
-<li><b>None</b>: If set to <code>None</code>, the default value from the pipeline initialization will be used. During initialization, it will prioritize the local GPU device 0; if unavailable, it will use the CPU.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>det_threshold</code></td>
 <td>Threshold for vehicle detection visualization.</td>
 <td><code>float | None</code></td>

--- a/docs/pipeline_usage/tutorials/cv_pipelines/vehicle_attribute_recognition.md
+++ b/docs/pipeline_usage/tutorials/cv_pipelines/vehicle_attribute_recognition.md
@@ -236,23 +236,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>det_threshold</code></td>
 <td>车辆检测可视化阈值</td>
 <td><code>float | None</code></td>

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md
@@ -517,23 +517,6 @@ The following are the parameters and their descriptions for the `visual_predict(
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Such as <code>cpu</code> to use CPU for inference;</li>
-<li><b>GPU</b>: Such as <code>gpu:0</code> to use the first GPU for inference;</li>
-<li><b>NPU</b>: Such as <code>npu:0</code> to use the first NPU for inference;</li>
-<li><b>XPU</b>: Such as <code>xpu:0</code> to use the first XPU for inference;</li>
-<li><b>MLU</b>: Such as <code>mlu:0</code> to use the first MLU for inference;</li>
-<li><b>DCU</b>: Such as <code>dcu:0</code> to use the first DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, it will default to the value initialized by the pipeline. During initialization, it will prioritize using the local GPU 0 device, and if not available, it will use the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module.</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md
@@ -516,23 +516,6 @@ PP-ChatOCRv3-doc 预测的流程、API说明、产出说明如下：
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.en.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.en.md
@@ -594,23 +594,6 @@ The following are the parameters and descriptions of the `visual_predict()` meth
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Such as <code>cpu</code> to use CPU for inference;</li>
-  <li><b>GPU</b>: Such as <code>gpu:0</code> to use the first GPU for inference;</li>
-  <li><b>NPU</b>: Such as <code>npu:0</code> to use the first NPU for inference;</li>
-  <li><b>XPU</b>: Such as <code>xpu:0</code> to use the first XPU for inference;</li>
-  <li><b>MLU</b>: Such as <code>mlu:0</code> to use the first MLU for inference;</li>
-  <li><b>DCU</b>: Such as <code>dcu:0</code> to use the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, it will default to the value initialized by the pipeline. During initialization, it will prioritize using the local GPU 0 device, and if not available, it will use the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module.</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.md
@@ -764,23 +764,6 @@ PP-ChatOCRv4 预测的流程、API说明、产出说明如下：
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/OCR.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/OCR.en.md
@@ -670,23 +670,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The device used for inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, e.g., <code>cpu</code></li>
-<li><b>GPU</b>: Use the first GPU for inference, e.g., <code>gpu:0</code></li>
-<li><b>NPU</b>: Use the first NPU for inference, e.g., <code>npu:0</code></li>
-<li><b>XPU</b>: Use the first XPU for inference, e.g., <code>xpu:0</code></li>
-<li><b>MLU</b>: Use the first MLU for inference, e.g., <code>mlu:0</code></li>
-<li><b>DCU</b>: Use the first DCU for inference, e.g., <code>dcu:0</code></li>
-<li><b>None</b>: If set to <code>None</code>, the default value from the pipeline initialization will be used. During initialization, the local GPU 0 will be used if available; otherwise, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module.</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/OCR.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/OCR.md
@@ -679,23 +679,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
@@ -851,23 +851,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Production inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: <code>cpu</code> indicates using CPU for inference;</li>
-<li><b>GPU</b>: <code>gpu:0</code> indicates using the first GPU for inference;</li>
-<li><b>NPU</b>: <code>npu:0</code> indicates using the first NPU for inference;</li>
-<li><b>XPU</b>: <code>xpu:0</code> indicates using the first XPU for inference;</li>
-<li><b>MLU</b>: <code>mlu:0</code> indicates using the first MLU for inference;</li>
-<li><b>DCU</b>: <code>dcu:0</code> indicates using the first DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized in the pipeline will be used. During initialization, the local GPU device 0 will be prioritized; if unavailable, the CPU device will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
@@ -810,23 +810,6 @@ for item in markdown_images:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/doc_preprocessor.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/doc_preprocessor.en.md
@@ -231,23 +231,6 @@ In the above Python script, the following steps were executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Like <code>cpu</code>, indicating inference using CPU;</li>
-  <li><b>GPU</b>: Like <code>gpu:0</code>, indicating inference using the first GPU;</li>
-  <li><b>NPU</b>: Like <code>npu:0</code>, indicating inference using the first NPU;</li>
-  <li><b>XPU</b>: Like <code>xpu:0</code>, indicating inference using the first XPU;</li>
-  <li><b>MLU</b>: Like <code>mlu:0</code>, indicating inference using the first MLU;</li>
-  <li><b>DCU</b>: Like <code>dcu:0</code>, indicating inference using the first DCU;</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, it will preferentially use the local GPU device 0, if none, then the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/doc_preprocessor.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/doc_preprocessor.md
@@ -231,23 +231,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/formula_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/formula_recognition.en.md
@@ -516,23 +516,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>pipeline inference device</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: e.g., <code>cpu</code> indicates using CPU for inference;</li>
-<li><b>GPU</b>: e.g., <code>gpu:0</code> indicates using the 1st GPU for inference;</li>
-<li><b>NPU</b>: e.g., <code>npu:0</code> indicates using the 1st NPU for inference;</li>
-<li><b>XPU</b>: e.g., <code>xpu:0</code> indicates using the 1st XPU for inference;</li>
-<li><b>MLU</b>: e.g., <code>mlu:0</code> indicates using the 1st MLU for inference;</li>
-<li><b>DCU</b>: e.g., <code>dcu:0</code> indicates using the 1st DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized by the pipeline will be used. During initialization, the local GPU 0 will be prioritized; if unavailable, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_layout_detection</code></td>
 <td>Whether to use the document layout detection module</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/formula_recognition.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/formula_recognition.md
@@ -516,23 +516,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_layout_detection</code></td>
 <td>是否使用文档区域检测模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/layout_parsing.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/layout_parsing.en.md
@@ -706,23 +706,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Such as <code>cpu</code> to use CPU for inference;</li>
-<li><b>GPU</b>: Such as <code>gpu:0</code> to use the first GPU for inference;</li>
-<li><b>NPU</b>: Such as <code>npu:0</code> to use the first NPU for inference;</li>
-<li><b>XPU</b>: Such as <code>xpu:0</code> to use the first XPU for inference;</li>
-<li><b>MLU</b>: Such as <code>mlu:0</code> to use the first MLU for inference;</li>
-<li><b>DCU</b>: Such as <code>dcu:0</code> to use the first DCU for inference;</li>
-<li><b>None</b>: If set to <code>None</code>, it will default to the value initialized by the pipeline. During initialization, it will prioritize using the local GPU 0 device, and if not available, it will use the CPU device;</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/layout_parsing.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/layout_parsing.md
@@ -743,23 +743,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/seal_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/seal_recognition.en.md
@@ -790,23 +790,6 @@ In the above Python script, the following steps were executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: e.g., <code>cpu</code> for CPU inference;</li>
-<li><b>GPU</b>: e.g., <code>gpu:0</code> for inference using the first GPU;</li>
-<li><b>NPU</b>: e.g., <code>npu:0</code> for inference using the first NPU;</li>
-<li><b>XPU</b>: e.g., <code>xpu:0</code> for inference using the first XPU;</li>
-<li><b>MLU</b>: e.g., <code>mlu:0</code> for inference using the first MLU;</li>
-<li><b>DCU</b>: e.g., <code>dcu:0</code> for inference using the first DCU;</li>
-<li><b>None</b>: If set to <code>None</code>, the default value from the pipeline initialization will be used. During initialization, the local GPU device 0 will be prioritized; if unavailable, the CPU device will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/seal_recognition.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/seal_recognition.md
@@ -762,23 +762,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition.en.md
@@ -788,23 +788,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Inference device.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, e.g., <code>cpu</code>.</li>
-<li><b>GPU</b>: Use the first GPU for inference, e.g., <code>gpu:0</code>.</li>
-<li><b>NPU</b>: Use the first NPU for inference, e.g., <code>npu:0</code>.</li>
-<li><b>XPU</b>: Use the first XPU for inference, e.g., <code>xpu:0</code>.</li>
-<li><b>MLU</b>: Use the first MLU for inference, e.g., <code>mlu:0</code>.</li>
-<li><b>DCU</b>: Use the first DCU for inference, e.g., <code>dcu:0</code>.</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized by the production line will be used. During initialization, the local GPU 0 will be prioritized; if unavailable, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module.</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition.md
@@ -741,23 +741,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition_v2.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition_v2.en.md
@@ -865,23 +865,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>Inference device.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>: Use CPU for inference, e.g., <code>cpu</code>.</li>
-<li><b>GPU</b>: Use the first GPU for inference, e.g., <code>gpu:0</code>.</li>
-<li><b>NPU</b>: Use the first NPU for inference, e.g., <code>npu:0</code>.</li>
-<li><b>XPU</b>: Use the first XPU for inference, e.g., <code>xpu:0</code>.</li>
-<li><b>MLU</b>: Use the first MLU for inference, e.g., <code>mlu:0</code>.</li>
-<li><b>DCU</b>: Use the first DCU for inference, e.g., <code>dcu:0</code>.</li>
-<li><b>None</b>: If set to <code>None</code>, the default value initialized by the production line will be used. During initialization, the local GPU 0 will be prioritized; if unavailable, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>Whether to use the document orientation classification module.</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition_v2.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/table_recognition_v2.md
@@ -878,23 +878,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-<li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-<li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-<li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-<li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-<li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-<li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-<li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>use_doc_orientation_classify</code></td>
 <td>是否使用文档方向分类模块</td>
 <td><code>bool|None</code></td>

--- a/docs/pipeline_usage/tutorials/speech_pipelines/multilingual_speech_recognition.en.md
+++ b/docs/pipeline_usage/tutorials/speech_pipelines/multilingual_speech_recognition.en.md
@@ -164,23 +164,6 @@ In the above Python script, the following steps are executed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: such as <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: such as <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: such as <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: such as <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: such as <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: such as <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value initialized for the pipeline will be used. During initialization, the local GPU device 0 will be prioritized. If it is not available, the CPU device will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/speech_pipelines/multilingual_speech_recognition.md
+++ b/docs/pipeline_usage/tutorials/speech_pipelines/multilingual_speech_recognition.md
@@ -164,23 +164,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_anomaly_detection.en.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_anomaly_detection.en.md
@@ -231,23 +231,6 @@ In the above Python script, the following steps are performed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the value initialized for the pipeline will be used by default. During initialization, the local GPU device 0 will be prioritized. If not available, the CPU device will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_anomaly_detection.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_anomaly_detection.md
@@ -239,23 +239,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_classification.en.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_classification.en.md
@@ -202,23 +202,6 @@ In the above Python script, the following steps are executed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>The device used for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Use CPU for inference, such as <code>cpu</code>.</li>
-  <li><b>GPU</b>: Use the first GPU for inference, such as <code>gpu:0</code>.</li>
-  <li><b>NPU</b>: Use the first NPU for inference, such as <code>npu:0</code>.</li>
-  <li><b>XPU</b>: Use the first XPU for inference, such as <code>xpu:0</code>.</li>
-  <li><b>MLU</b>: Use the first MLU for inference, such as <code>mlu:0</code>.</li>
-  <li><b>DCU</b>: Use the first DCU for inference, such as <code>dcu:0</code>.</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value used during pipeline initialization will be applied. During initialization, it will prioritize using the local GPU device 0. If unavailable, it will fall back to the CPU.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_classification.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_classification.md
@@ -199,23 +199,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_forecasting.en.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_forecasting.en.md
@@ -254,23 +254,6 @@ In the above Python script, the following steps are executed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>The device for pipeline inference.</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: Use CPU for inference (e.g., <code>cpu</code>).</li>
-  <li><b>GPU</b>: Use the specified GPU for inference (e.g., <code>gpu:0</code> for the first GPU).</li>
-  <li><b>NPU</b>: Use the specified NPU for inference (e.g., <code>npu:0</code> for the first NPU).</li>
-  <li><b>XPU</b>: Use the specified XPU for inference (e.g., <code>xpu:0</code> for the first XPU).</li>
-  <li><b>MLU</b>: Use the specified MLU for inference (e.g., <code>mlu:0</code> for the first MLU).</li>
-  <li><b>DCU</b>: Use the specified DCU for inference (e.g., <code>dcu:0</code> for the first DCU).</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value used during pipeline initialization will be applied. During initialization, the local GPU 0 will be prioritized; if unavailable, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_forecasting.md
+++ b/docs/pipeline_usage/tutorials/time_series_pipelines/time_series_forecasting.md
@@ -264,23 +264,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
 </tbody>
 </table>
 

--- a/docs/pipeline_usage/tutorials/video_pipelines/video_classification.en.md
+++ b/docs/pipeline_usage/tutorials/video_pipelines/video_classification.en.md
@@ -211,23 +211,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: For example, <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: For example, <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: For example, <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: For example, <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: For example, <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: For example, <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the value initialized for the pipeline will be used by default. During initialization, the local GPU 0 will be prioritized. If it is not available, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>topk</code></td>
 <td>The top <code>topk</code> classes and their corresponding classification probabilities in the prediction results.</td>
 <td><code>int|None</code></td>

--- a/docs/pipeline_usage/tutorials/video_pipelines/video_classification.md
+++ b/docs/pipeline_usage/tutorials/video_pipelines/video_classification.md
@@ -212,23 +212,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code> topk</code></td>
 <td>预测结果的前 <code>topk</code> 个类别和对应的分类概率</td>
 <td><code>int|None</code></td>

--- a/docs/pipeline_usage/tutorials/video_pipelines/video_detection.en.md
+++ b/docs/pipeline_usage/tutorials/video_pipelines/video_detection.en.md
@@ -159,23 +159,6 @@ In the above Python script, the following steps are executed:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>The inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: For example, <code>cpu</code> indicates using the CPU for inference;</li>
-  <li><b>GPU</b>: For example, <code>gpu:0</code> indicates using the first GPU for inference;</li>
-  <li><b>NPU</b>: For example, <code>npu:0</code> indicates using the first NPU for inference;</li>
-  <li><b>XPU</b>: For example, <code>xpu:0</code> indicates using the first XPU for inference;</li>
-  <li><b>MLU</b>: For example, <code>mlu:0</code> indicates using the first MLU for inference;</li>
-  <li><b>DCU</b>: For example, <code>dcu:0</code> indicates using the first DCU for inference;</li>
-  <li><b>None</b>: If set to <code>None</code>, the value initialized for the pipeline will be used by default. During initialization, the local GPU 0 will be prioritized. If it is not available, the CPU will be used.</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>nms_thresh</code></td>
 <td>The IoU threshold parameter in the Non-Maximum Suppression (NMS) process</td>
 <td><code>float|None</code></td>

--- a/docs/pipeline_usage/tutorials/video_pipelines/video_detection.md
+++ b/docs/pipeline_usage/tutorials/video_pipelines/video_detection.md
@@ -161,23 +161,6 @@ for res in output:
 <td><code>None</code></td>
 </tr>
 <tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
-</tr>
-<tr>
 <td><code>nms_thresh</code></td>
 <td>非极大值抑制（Non-Maximum Suppression, NMS）过程中的IoU阈值参数</td>
 <td><code>float|None</code></td>

--- a/docs/pipeline_usage/tutorials/vlm_pipelines/doc_understanding.en.md
+++ b/docs/pipeline_usage/tutorials/vlm_pipelines/doc_understanding.en.md
@@ -137,22 +137,6 @@ In the above Python script, the following steps are performed:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>Inference device for the pipeline</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>: e.g., <code>cpu</code> for CPU inference;</li>
-  <li><b>GPU</b>: e.g., <code>gpu:0</code> for inference on the first GPU;</li>
-  <li><b>NPU</b>: e.g., <code>npu:0</code> for inference on the first NPU;</li>
-  <li><b>XPU</b>: e.g., <code>xpu:0</code> for inference on the first XPU;</li>
-  <li><b>MLU</b>: e.g., <code>mlu:0</code> for inference on the first MLU;</li>
-  <li><b>DCU</b>: e.g., <code>dcu:0</code> for inference on the first DCU;</li>
-  <li><b>None</b>: If set to <code>None</code>, the default value of this parameter initialized by the pipeline will be used. During initialization, it will preferentially use the local GPU 0 device if available, otherwise the CPU device will be used;</li>
-</ul>
-</td>
-<td><code>None</code></td>
 </table>
 
 3. Process the prediction results. The prediction result for each sample is a corresponding Result object, and supports operations such as printing and saving as a `json` file:

--- a/docs/pipeline_usage/tutorials/vlm_pipelines/doc_understanding.md
+++ b/docs/pipeline_usage/tutorials/vlm_pipelines/doc_understanding.md
@@ -138,22 +138,6 @@ for res in output:
 </td>
 <td><code>None</code></td>
 </tr>
-<tr>
-<td><code>device</code></td>
-<td>产线推理设备</td>
-<td><code>str|None</code></td>
-<td>
-<ul>
-  <li><b>CPU</b>：如 <code>cpu</code> 表示使用 CPU 进行推理；</li>
-  <li><b>GPU</b>：如 <code>gpu:0</code> 表示使用第 1 块 GPU 进行推理；</li>
-  <li><b>NPU</b>：如 <code>npu:0</code> 表示使用第 1 块 NPU 进行推理；</li>
-  <li><b>XPU</b>：如 <code>xpu:0</code> 表示使用第 1 块 XPU 进行推理；</li>
-  <li><b>MLU</b>：如 <code>mlu:0</code> 表示使用第 1 块 MLU 进行推理；</li>
-  <li><b>DCU</b>：如 <code>dcu:0</code> 表示使用第 1 块 DCU 进行推理；</li>
-  <li><b>None</b>：如果设置为 <code>None</code>, 将默认使用产线初始化的该参数值，初始化时，会优先使用本地的 GPU 0号设备，如果没有，则使用 CPU 设备；</li>
-</ul>
-</td>
-<td><code>None</code></td>
 </table>
 
 （3）对预测结果进行处理，每个样本的预测结果均为对应的Result对象，且支持打印、保存为`json`文件的操作:


### PR DESCRIPTION
1. 去除`predict`方法API文档中的`device`参数说明（实际不支持）。
2. 修正`device`参数说明，使其更准确地描述代码的实际行为。