### PR TITLE
[Fix] Fix HPI bugs

### DIFF
--- a/paddlex/inference/models/common/static_infer.py
+++ b/paddlex/inference/models/common/static_infer.py
@@ -407,15 +407,15 @@ class PaddleInfer(StaticInfer):
                 assert self._option.device_type == "cpu"
                 config.disable_gpu()
                 if "mkldnn" in self._option.run_mode:
-                    try:
+                    if hasattr(config, "set_mkldnn_cache_capacity"):
                         config.enable_mkldnn()
                         if "bf16" in self._option.run_mode:
                             config.enable_mkldnn_bfloat16()
-                    except Exception:
+                        config.set_mkldnn_cache_capacity(-1)
+                    else:
                         logging.warning(
                             "MKL-DNN is not available. We will disable MKL-DNN."
                         )
-                    config.set_mkldnn_cache_capacity(-1)
                 else:
                     if hasattr(config, "disable_mkldnn"):
                         config.disable_mkldnn()

--- a/paddlex/inference/utils/hpi.py
+++ b/paddlex/inference/utils/hpi.py
@@ -236,11 +236,14 @@ def suggest_inference_backend_and_config(
         assert pseudo_backend in (
             "paddle",
             "paddle_fp16",
+            "paddle_mkldnn",
             "paddle_tensorrt",
             "paddle_tensorrt_fp16",
         ), pseudo_backend
         if pseudo_backend == "paddle_fp16":
             suggested_backend_config.update({"run_mode": "paddle_fp16"})
+        elif pseudo_backend == "paddle_mkldnn":
+            suggested_backend_config.update({"run_mode": "mkldnn"})
         elif pseudo_backend == "paddle_tensorrt":
             suggested_backend_config.update({"run_mode": "trt_fp32"})
         elif pseudo_backend == "paddle_tensorrt_fp16":

--- a/paddlex/inference/utils/hpi_model_info_collection.json
+++ b/paddlex/inference/utils/hpi_model_info_collection.json
@@ -3,7 +3,7 @@
     "PP-LCNet_x1_0_doc_ori": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet_LCNet_x2_5_face": [
       "openvino",
@@ -443,23 +443,23 @@
     ],
     "PP-DocLayout-L": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-DocLayout_plus-L": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-DocBlockLayout": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "RT-DETR-H_layout_17cls": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "RT-DETR-H_layout_3cls": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-ShiTuV2_det": [
       "openvino",
@@ -494,12 +494,12 @@
     "PP-OCRv4_mobile_seal_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv4_server_seal_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "Deeplabv3-R101": [
       "openvino",
@@ -552,131 +552,131 @@
     ],
     "RT-DETR-L_wired_table_cell_det": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "RT-DETR-L_wireless_table_cell_det": [
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-LCNet_x1_0_table_cls": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv3_mobile_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv3_server_det": [
       "openvino",
-      "paddle",
+      "paddle_mkldnn",
       "onnxruntime"
     ],
     "PP-OCRv4_mobile_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv4_server_det": [
-      "paddle",
+      "paddle_mkldnn",
       "openvino",
       "onnxruntime"
     ],
     "PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv4_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv4_server_rec_doc": [
-      "paddle",
+      "paddle_mkldnn",
       "openvino",
       "onnxruntime"
     ],
     "PP-OCRv4_server_rec": [
-      "paddle",
+      "paddle_mkldnn",
       "openvino",
       "onnxruntime"
     ],
     "arabic_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "ch_RepSVTR_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "ch_SVTRv2_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "chinese_cht_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "cyrillic_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "devanagari_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "en_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "en_PP-OCRv4_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "japan_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "ka_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "korean_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "latin_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "ta_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "te_PP-OCRv3_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-LCNet_x0_25_textline_ori": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "AutoEncoder_ad": [
       "onnxruntime",
@@ -815,42 +815,42 @@
     "PP-DocLayout-M": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-DocLayout-S": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet-L_layout_17cls": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet-L_layout_3cls": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet-S_layout_17cls": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet-S_layout_3cls": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet_layout_1x_table": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PicoDet_layout_1x": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "Cascade-FasterRCNN-ResNet50-FPN": [
       "paddle"
@@ -1146,24 +1146,24 @@
       "paddle"
     ],
     "PP-OCRv5_server_rec": [
-      "paddle",
+      "paddle_mkldnn",
       "openvino",
       "onnxruntime"
     ],
     "PP-OCRv5_mobile_rec": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv5_server_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-OCRv5_mobile_det": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ],
     "PP-FormulaNet_plus-L": [
       "onnxruntime",
@@ -1180,7 +1180,7 @@
     "PP-LCNet_x1_0_textline_ori": [
       "openvino",
       "onnxruntime",
-      "paddle"
+      "paddle_mkldnn"
     ]
   },
   "gpu_cuda118_cudnn89": {

--- a/paddlex/inference/utils/hpi_model_info_collection.json
+++ b/paddlex/inference/utils/hpi_model_info_collection.json
@@ -1176,6 +1176,11 @@
     "PP-FormulaNet_plus-S": [
       "onnxruntime",
       "paddle"
+    ],
+    "PP-LCNet_x1_0_textline_ori": [
+      "openvino",
+      "onnxruntime",
+      "paddle"
     ]
   },
   "gpu_cuda118_cudnn89": {
@@ -2326,6 +2331,11 @@
     ],
     "PP-FormulaNet_plus-S": [
       "paddle"
+    ],
+    "PP-LCNet_x1_0_textline_ori": [
+      "tensorrt_fp16",
+      "paddle_tensorrt",
+      "onnxruntime"
     ]
   }
 }

--- a/paddlex/inference/utils/mkldnn_blocklist.py
+++ b/paddlex/inference/utils/mkldnn_blocklist.py
@@ -22,4 +22,6 @@ MKLDNN_BLOCKLIST = [
     "PP-FormulaNet_plus-L",
     "PP-FormulaNet_plus-M",
     "PP-FormulaNet_plus-S",
+    "SLANet",
+    "SLANet_plus",
 ]


### PR DESCRIPTION
1. 补充新增的textline orientation模型的高性能推理信息；
2. OCR类模型如果支持mkldnn，使用高性能推理时，CPU也默认开启MKLDNN。因为PaddleOCR默认是开启MKLDNN的，这样改完后PaddleOCR不至于出现开高性能后速度掉了的情况；
3. 如果框架不支持MKL-DNN，fall back到CPU原生推理。