### PR TITLE
[CustomDevice] Fix some infer errors on CustomDevice

### DIFF
--- a/paddlex/inference/models/open_vocabulary_detection/processors/groundingdino_processors.py
+++ b/paddlex/inference/models/open_vocabulary_detection/processors/groundingdino_processors.py
@@ -199,6 +199,9 @@ class GroundingDINOPostProcessor(object):
         tokenized = self.tokenizer(prompt)
         if posmap.dim() == 1:
             non_zero_idx = posmap.nonzero(as_tuple=True)[0].squeeze(-1).tolist()
+            non_zero_idx = (
+                [non_zero_idx] if not isinstance(non_zero_idx, list) else non_zero_idx
+            )
             token_ids = [tokenized["input_ids"][i] for i in non_zero_idx]
             return self.tokenizer.decode(token_ids)
         else:

--- a/paddlex/utils/device.py
+++ b/paddlex/utils/device.py
@@ -132,7 +132,10 @@ def set_env_for_device_type(device_type):
         }
         _set(envs)
     if device_type.lower() == "mlu":
-        envs = {"FLAGS_use_stride_kernel": "0"}
+        envs = {
+            "FLAGS_use_stride_kernel": "0",
+            "FLAGS_use_stream_safe_cuda_allocator": "0",
+        }
         _set(envs)
     if device_type.lower() == "gcu":
         envs = {"FLAGS_use_stride_kernel": "0"}

--- a/paddlex/utils/device.py
+++ b/paddlex/utils/device.py
@@ -118,9 +118,7 @@ def set_env_for_device_type(device_type):
             "FLAGS_npu_jit_compile": "0",
             "FLAGS_use_stride_kernel": "0",
             "FLAGS_allocator_strategy": "auto_growth",
-            # Disable slice for unknown reason infer error on PP-formulaNet series models.
-            # Disable roi_align for NPU kernel do not support attribute aligned==True required by Cascade-MaskRCNN-ResNet50-FPN.
-            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor,slice,roi_align",
+            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor",
             "FLAGS_npu_scale_aclnn": "True",
             "FLAGS_npu_split_aclnn": "True",
         }

--- a/paddlex/utils/device.py
+++ b/paddlex/utils/device.py
@@ -118,7 +118,7 @@ def set_env_for_device_type(device_type):
             "FLAGS_npu_jit_compile": "0",
             "FLAGS_use_stride_kernel": "0",
             "FLAGS_allocator_strategy": "auto_growth",
-            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor",
+            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor,slice",
             "FLAGS_npu_scale_aclnn": "True",
             "FLAGS_npu_split_aclnn": "True",
         }

--- a/paddlex/utils/device.py
+++ b/paddlex/utils/device.py
@@ -118,7 +118,9 @@ def set_env_for_device_type(device_type):
             "FLAGS_npu_jit_compile": "0",
             "FLAGS_use_stride_kernel": "0",
             "FLAGS_allocator_strategy": "auto_growth",
-            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor,slice",
+            # Disable slice for unknown reason infer error on PP-formulaNet series models.
+            # Disable roi_align for NPU kernel do not support attribute aligned==True required by Cascade-MaskRCNN-ResNet50-FPN.
+            "CUSTOM_DEVICE_BLACK_LIST": "pad3d,pad3d_grad,set_value,set_value_with_tensor,slice,roi_align",
             "FLAGS_npu_scale_aclnn": "True",
             "FLAGS_npu_split_aclnn": "True",
         }


### PR DESCRIPTION
1. 修复 MLU 上MaskRcnn 系列报错。怀疑是op异步提交后被过早地垃圾回收了。
```text
2025-06-06 06:40:08.022089: [cnrtError] [52146] [Card: 0] Error occurred during calling 'cnQueueSync' in CNDrv interface.
2025-06-06 06:40:08.022152: [cnrtError] [52146] [Card: 0] Return value is 100124, CN_INVOKE_ERROR_ADDRESS_SPACE.
2025-06-06 06:40:08.022159: [cnrtError] [52146] [Card: 0] cnrtQueueSync: MLU queue sync failed.
Traceback (most recent call last):
  File "/paddle/jelly/PaddleX/paddlex/utils/result_saver.py", line 28, in wrap
    result = func(self, *args, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/engine.py", line 49, in run
    for res in self._model.predict():
  File "/paddle/jelly/PaddleX/paddlex/model.py", line 131, in predict
    yield from predictor(**predict_kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/base/predictor/base_predictor.py", line 211, in __call__
    yield from self.apply(input, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/base/predictor/base_predictor.py", line 267, in apply
    prediction = self.process(batch_data, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/instance_segmentation/predictor.py", line 130, in process
    batch_preds = self.infer(batch_inputs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/common/static_infer.py", line 287, in __call__
    pred = self.infer(x)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/common/static_infer.py", line 252, in __call__
    self.predictor.run()
paddle.base.libpaddle.EnforceNotMet: In user code:


    MLU CNRT error(632015), cnrtErrorCndrvFuncCall: failed to call the driver-api function. (at /paddle/backends/mlu/runtime/runtime.cc:229)
      [operator < pd_op.if > error]
```

2. 修复 GroundingDINO-T: TypeError: 'int' object is not iterable。原因是 `tensor.tolist` 方法可能返回标量。
```text
Traceback (most recent call last):
  File "/paddle/jelly/PaddleX/paddlex/utils/result_saver.py", line 28, in wrap
    result = func(self, *args, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/engine.py", line 49, in run
    for res in self._model.predict():
  File "/paddle/jelly/PaddleX/paddlex/model.py", line 131, in predict
    yield from predictor(**predict_kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/base/predictor/base_predictor.py", line 211, in __call__
    yield from self.apply(input, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/base/predictor/base_predictor.py", line 267, in apply
    prediction = self.process(batch_data, **kwargs)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/open_vocabulary_detection/predictor.py", line 113, in process
    boxes = self.post_op(
  File "/paddle/jelly/PaddleX/paddlex/inference/models/open_vocabulary_detection/processors/groundingdino_processors.py", line 144, in __call__
    self.postprocess(
  File "/paddle/jelly/PaddleX/paddlex/inference/models/open_vocabulary_detection/processors/groundingdino_processors.py", line 182, in postprocess
    pred_phrase = self.decode(logit > text_threshold, src_prompt)
  File "/paddle/jelly/PaddleX/paddlex/inference/models/open_vocabulary_detection/processors/groundingdino_processors.py", line 202, in decode
    token_ids = [tokenized["input_ids"][i] for i in non_zero_idx]
TypeError: 'int' object is not iterable
```