### PR TITLE
Fix memory leak when enabling mkldnn

### DIFF
--- a/paddlex/inference/models/common/static_infer.py
+++ b/paddlex/inference/models/common/static_infer.py
@@ -411,7 +411,7 @@ class PaddleInfer(StaticInfer):
                         config.enable_mkldnn()
                         if "bf16" in self._option.run_mode:
                             config.enable_mkldnn_bfloat16()
-                        config.set_mkldnn_cache_capacity(-1)
+                        config.set_mkldnn_cache_capacity(self._option.mkldnn_cache_capacity)
                     else:
                         logging.warning(
                             "MKL-DNN is not available. We will disable MKL-DNN."

--- a/paddlex/inference/utils/pp_option.py
+++ b/paddlex/inference/utils/pp_option.py
@@ -119,7 +119,7 @@ class PaddlePredictorOption(object):
             "trt_dynamic_shape_input_data": None,  # only for trt
             "trt_shape_range_info_path": None,  # only for trt
             "trt_allow_rebuild_at_runtime": True,  # only for trt
-            "mkldnn_cache_capacity": -1,
+            "mkldnn_cache_capacity": 10,
         }
         return default_config
 

--- a/paddlex/inference/utils/pp_option.py
+++ b/paddlex/inference/utils/pp_option.py
@@ -119,6 +119,7 @@ class PaddlePredictorOption(object):
             "trt_dynamic_shape_input_data": None,  # only for trt
             "trt_shape_range_info_path": None,  # only for trt
             "trt_allow_rebuild_at_runtime": True,  # only for trt
+            "mkldnn_cache_capacity": -1,
         }
         return default_config
 
@@ -293,6 +294,14 @@ class PaddlePredictorOption(object):
     @trt_allow_rebuild_at_runtime.setter
     def trt_allow_rebuild_at_runtime(self, trt_allow_rebuild_at_runtime):
         self._update("trt_allow_rebuild_at_runtime", trt_allow_rebuild_at_runtime)
+
+    @property
+    def mkldnn_cache_capacity(self):
+        return self._cfg["mkldnn_cache_capacity"]
+
+    @mkldnn_cache_capacity.setter
+    def mkldnn_cache_capacity(self, capacity: int):
+        self._update("mkldnn_cache_capacity", capacity)
 
     # For backward compatibility
     # TODO: Issue deprecation warnings


### PR DESCRIPTION
Currently the mkldnn cache is unlimited and not configurable via a config setting. This results in memory leaks when using for example PaddleOCR on a lot of images.
This PR makes this option configurable for tools like PaddleOCR to set a reasonable cache capacity.

Fixes https://github.com/PaddlePaddle/PaddleOCR/issues/15631

