### PR TITLE
在网上下载paddlex应用包,使用高性能推理时,报错:

### DIFF
--- a/paddlex/inference/utils/hpi.py
+++ b/paddlex/inference/utils/hpi.py
@@ -270,6 +270,8 @@ def suggest_inference_backend_and_config(
             "paddle_mkldnn",
             "paddle_tensorrt",
             "paddle_tensorrt_fp16",
+            "tensorrt",
+            "tensorrt_fp16"
         ), pseudo_backend
         if pseudo_backend == "paddle":
             suggested_backend_config.update({"run_mode": "paddle"})


### PR DESCRIPTION
.......
"/home/lidesheng/software/conda/envs/py39_paddlex/lib/python3.9/site-packages/paddlex/inference/utils/hpi.py", line 239, in suggest_inference_backend_and_config
    assert pseudo_backend in (
AssertionError: tensorrt

添加如下代码,修复启动报错。

