### PR TITLE
[NPU] Update pandas to 1.4.3

### DIFF
--- a/libs/ultra-infer/python/setup.py
+++ b/libs/ultra-infer/python/setup.py
@@ -436,7 +436,7 @@ if sys.version_info[0] == 3:
 
 extras_require["pyonly"] = [
     "pillow<10.0.0",
-    "pandas>=0.25.0,<=1.4.5",
+    "pandas>=0.25.0,<=1.4.3",
     "pycocotools",
     "matplotlib",
     "chinese_calendar",

--- a/libs/ultra-infer/python/setup.py
+++ b/libs/ultra-infer/python/setup.py
@@ -436,7 +436,7 @@ if sys.version_info[0] == 3:
 
 extras_require["pyonly"] = [
     "pillow<10.0.0",
-    "pandas>=0.25.0,<=1.3.5",
+    "pandas>=0.25.0,<=1.4.5",
     "pycocotools",
     "matplotlib",
     "chinese_calendar",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ DEP_SPECS = {
     "opencv-contrib-python": "== 4.10.0.84",
     "openpyxl": "",
     "packaging": "",
-    "pandas": ">= 1.4.5",
+    "pandas": ">= 1.4.3",
     "pillow": "",
     "premailer": "",
     "prettytable": "",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ DEP_SPECS = {
     "opencv-contrib-python": "== 4.10.0.84",
     "openpyxl": "",
     "packaging": "",
-    "pandas": ">= 1.3",
+    "pandas": ">= 1.4.5",
     "pillow": "",
     "premailer": "",
     "prettytable": "",


### PR DESCRIPTION
更新 pandas 版本至 1.4.3。

低于 1.4.3 的 pandas 会导致 `np.numeric.dtype` 为 `None` https://stackoverflow.com/a/71879536 ，该 API 被昇腾使用，从而导致 TimesNetAd 在NPU 上推理报错。