### PR TITLE
[Fix] Stop altering `run_mode` automatically

### DIFF
--- a/paddlex/inference/utils/pp_option.py
+++ b/paddlex/inference/utils/pp_option.py
@@ -137,8 +137,8 @@ class PaddlePredictorOption(object):
             )
 
         if run_mode.startswith("mkldnn") and not is_mkldnn_available():
-            logging.warning("MKL-DNN is not available. Using `paddle` instead.")
-            run_mode = "paddle"
+            raise ValueError("MKL-DNN is not available")
+
         self._update("run_mode", run_mode)
 
     @property


### PR DESCRIPTION
此前为了支持PaddleOCR实现通过`enable_mkldnn`开关控制是否启用MKL-DNN的功能，PaddleX的`PaddlePredictorOption`的行为被改造如下：

当设置 `pp_option.run_mode = "mkldnn"` 时，如果MKL-DNN不可用，则给出警告，然后将 `run_mode` 实际设置为 `"paddle"`。

这通常被视为一个不好的设计，因为当用户执行 `pp_option.run_mode = "mkldnn"` 时，期望的应该是 `run_mode` 被设置为 `"mkldnn"`，而这句代码成功执行完成后，`run_mode` 却有可能被设置为其他的值，这十分违反直觉。尽管代码中给出了警告，但在执行自动流水线等许多情况下，警告常常被忽略，而这段逻辑就成为了一个可能的陷阱——让用户误以为自己确实启用了 MKL-DNN。

经过 https://github.com/PaddlePaddle/PaddleX/pull/4312 的重构改造后，`PaddlePredictorOption`的整体行为已经更加清晰、更符合直觉，不再需要通过借助这个设计来满足PaddleOCR的需要。

因此，本PR旨在改造这个行为，对无效的情况予以显式拒绝。

如果希望保留fallback的功能，建议可以为`PaddlePredictorOption`暴露一个显式的方法作为API，例如：`pp_option.set_run_mode_with_fallback("mkldnn")`。