### PR TITLE
[cherry-pick] Bugfix: Add missing Arch.pretrained=False for custom pr…

### DIFF
--- a/paddlex/repo_apis/PaddleClas_api/cls/config.py
+++ b/paddlex/repo_apis/PaddleClas_api/cls/config.py
@@ -172,6 +172,7 @@ indicating that no pretrained model to be used."
                         pretrained_model.replace(".pdparams", "")
                     )
                 self.update([f"Global.pretrained_model={pretrained_model}"])
+                self.update(["Arch.pretrained=False"])
 
     def update_num_classes(self, num_classes: int):
         """update classes number


### PR DESCRIPTION
- Add missing Arch.pretrained=False setting when using custom pretrained weight paths
- Prevents configuration conflicts between Global.pretrained_model and Arch.pretrained
- Makes image classification behavior consistent with detection models
- Fixes issue where custom weights might conflict with auto-download mechanism"

