### PR TITLE
Add missing license header and update PP-StructureV3 server interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     -   id: isort
         args:
             - --profile=black
-        exclude: ^deploy/ultra-infer/python/ultra_infer/
+        files: ^paddlex/
 
 # check license
 -   repo: local

--- a/deploy/hps/README.md
+++ b/deploy/hps/README.md
@@ -12,7 +12,7 @@ comments: true
 
 - **操作系统**：Linux
 - **Docker 版本**：`>= 20.10.0`，用于镜像构建和部署
-- **CPU 架构**：x86-64 
+- **CPU 架构**：x86-64
 
 本文档主要介绍如何基于本项目提供的脚本完成高稳定性服务化部署环境搭建与物料打包。整体流程分为两个阶段：
 
@@ -85,7 +85,7 @@ comments: true
 对于 Triton Server，项目使用预先编译好的版本，将在构建镜像时自动下载，无需手动下载。以构建 GPU 镜像为例，在 `server_env` 目录下执行以下命令：
 
 ```bash
-./scripts/build_deployment_image.sh -k gpu -t latest-gpu 
+./scripts/build_deployment_image.sh -k gpu -t latest-gpu
 ```
 
 构建镜像的参数配置项包括
@@ -118,10 +118,10 @@ comments: true
 执行成功后，命令行会输出以下提示信息：
 
 ```text
- => => exporting to image                                                         
- => => exporting layers                                                      
- => => writing image  sha256:ba3d0b2b079d63ee0239a99043fec7e25f17bf2a7772ec2fc80503c1582b3459   
- => => naming to ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:latest-gpu   
+ => => exporting to image
+ => => exporting layers
+ => => writing image  sha256:ba3d0b2b079d63ee0239a99043fec7e25f17bf2a7772ec2fc80503c1582b3459
+ => => naming to ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:latest-gpu
 ```
 
 如需批量构建 GPU 和 CPU 镜像，可以执行以下命令：

--- a/deploy/hps/README_en.md
+++ b/deploy/hps/README_en.md
@@ -32,13 +32,13 @@ Image Building Steps:
 
 1. Build a requirement collection image. (Optional)
 2. Freeze requirement versions to improve the reproducibility of deployment image building. (Optional)
-3. Build the deployment image based on the frozen requirement information to generate the final deployment image and provide image support for subsequent pipeline execution. 
+3. Build the deployment image based on the frozen requirement information to generate the final deployment image and provide image support for subsequent pipeline execution.
 
 **If you do not need to modify requirement-related information, you can skip to [1.3 Building Image](./README_en.md#13-building-image) to build the deployment image using cached requirement information.**
 
 ## 1.1 Build the Requirement Collection Image (Optional)
 
-Navigate to the `server_env` directory and run follow script for building the requirement collection image in this directory. 
+Navigate to the `server_env` directory and run follow script for building the requirement collection image in this directory.
 
 ```bash
 ./scripts/prepare_rc_image.sh
@@ -121,10 +121,10 @@ If the basic image cannot be pulled, please refer to the solutions in the [FAQ](
 After run successfully, the command line will display the following message:
 
 ```text
- => => exporting to image                                                         
- => => exporting layers                                                      
- => => writing image  sha256:ba3d0b2b079d63ee0239a99043fec7e25f17bf2a7772ec2fc80503c1582b3459   
- => => naming to ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:latest-gpu   
+ => => exporting to image
+ => => exporting layers
+ => => writing image  sha256:ba3d0b2b079d63ee0239a99043fec7e25f17bf2a7772ec2fc80503c1582b3459
+ => => naming to ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:latest-gpu
 ```
 
 To build both GPU and CPU images  run the following command:

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/__init__.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/__init__.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from importlib import metadata as _metadata
 
 from .request import triton_request

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/constants.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/constants.py
@@ -1,2 +1,16 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 INPUT_NAME = "input"
 OUTPUT_NAME = "output"

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 
 import numpy as np

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/utils.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import base64
 import mimetypes
 import shutil

--- a/deploy/hps/sdk/pipelines/3d_bev_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/3d_bev_detection/client/client.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys
 
-from paddlex_hps_client import triton_request, utils
 from tritonclient import grpc as triton_grpc
+
+from paddlex_hps_client import triton_request, utils
 
 
 def main():

--- a/deploy/hps/sdk/pipelines/3d_bev_detection/server/model_repo/bev-3d-object-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/3d_bev_detection/server/model_repo/bev-3d-object-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Any, Dict, List
 

--- a/deploy/hps/sdk/pipelines/OCR/client/client.py
+++ b/deploy/hps/sdk/pipelines/OCR/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/OCR/server/model_repo/ocr/1/model.py
+++ b/deploy/hps/sdk/pipelines/OCR/server/model_repo/ocr/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/client/client.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-chat/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-chat/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas
 
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-vector/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-vector/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas
 
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-visual/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv3-doc/server/model_repo/chatocr-visual/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/client/client.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-chat/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-chat/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas
 
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-mllm/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-mllm/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-vector/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-vector/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas
 
 

--- a/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-visual/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ChatOCRv4-doc/server/model_repo/chatocr-visual/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/PP-DocTranslation/client/client.py
+++ b/deploy/hps/sdk/pipelines/PP-DocTranslation/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 from pathlib import Path

--- a/deploy/hps/sdk/pipelines/PP-DocTranslation/server/model_repo/doctrans-translate/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-DocTranslation/server/model_repo/doctrans-translate/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas

--- a/deploy/hps/sdk/pipelines/PP-DocTranslation/server/model_repo/doctrans-visual/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-DocTranslation/server/model_repo/doctrans-visual/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/client/client.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-add/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-add/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from operator import attrgetter
 
 from paddlex.inference.pipelines.components import IndexData

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-build/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-build/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import uuid
 from operator import attrgetter
 

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-remove/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-index-remove/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex.inference.pipelines.components import IndexData
 from paddlex_hps_server import schemas
 

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-infer/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/model_repo/shitu-infer/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex.inference.pipelines.components import IndexData
@@ -16,7 +30,11 @@ class TritonPythonModel(BaseShiTuModel):
     def run(self, input, log_id):
         image_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(image_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         if input.indexKey is not None:
             index_storage = self.context["index_storage"]

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/shared_mods/common/__init__.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/shared_mods/common/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/shared_mods/common/base_model.py
+++ b/deploy/hps/sdk/pipelines/PP-ShiTuV2/server/shared_mods/common/base_model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel
 from paddlex_hps_server.storage import create_storage
 

--- a/deploy/hps/sdk/pipelines/PP-StructureV3/client/client.py
+++ b/deploy/hps/sdk/pipelines/PP-StructureV3/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 from pathlib import Path

--- a/deploy/hps/sdk/pipelines/PP-StructureV3/server/model_repo/layout-parsing/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-StructureV3/server/model_repo/layout-parsing/1/model.py
@@ -112,7 +112,7 @@ class TritonPythonModel(BaseTritonPythonModel):
                 use_formula_recognition=input.useFormulaRecognition,
                 use_chart_recognition=input.useChartRecognition,
                 use_region_detection=input.useRegionDetection,
-                save_markdown_content=input.saveMarkdownContent,
+                format_block_content=input.formatBlockContent,
                 layout_threshold=input.layoutThreshold,
                 layout_nms=input.layoutNms,
                 layout_unclip_ratio=input.layoutUnclipRatio,

--- a/deploy/hps/sdk/pipelines/PP-StructureV3/server/model_repo/layout-parsing/1/model.py
+++ b/deploy/hps/sdk/pipelines/PP-StructureV3/server/model_repo/layout-parsing/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(
@@ -94,6 +112,7 @@ class TritonPythonModel(BaseTritonPythonModel):
                 use_formula_recognition=input.useFormulaRecognition,
                 use_chart_recognition=input.useChartRecognition,
                 use_region_detection=input.useRegionDetection,
+                save_markdown_content=input.saveMarkdownContent,
                 layout_threshold=input.layoutThreshold,
                 layout_nms=input.layoutNms,
                 layout_unclip_ratio=input.layoutUnclipRatio,

--- a/deploy/hps/sdk/pipelines/anomaly_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/anomaly_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/anomaly_detection/server/model_repo/anomaly-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/anomaly_detection/server/model_repo/anomaly-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 
@@ -17,7 +31,11 @@ class TritonPythonModel(BaseTritonPythonModel):
         pred = result["pred"][0].tolist()
         size = [len(pred), len(pred[0])]
         label_map = [item for sublist in pred for item in sublist]
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         if visualize_enabled:
             output_image_base64 = utils.base64_encode(

--- a/deploy/hps/sdk/pipelines/doc_preprocessor/client/client.py
+++ b/deploy/hps/sdk/pipelines/doc_preprocessor/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/doc_preprocessor/server/model_repo/document-preprocessing/1/model.py
+++ b/deploy/hps/sdk/pipelines/doc_preprocessor/server/model_repo/document-preprocessing/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -89,7 +103,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 use_doc_unwarping=input.useDocUnwarping,
             )
         )
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         doc_pp_results: List[Dict[str, Any]] = []
         for i, (img, item) in enumerate(zip(images, result)):

--- a/deploy/hps/sdk/pipelines/doc_understanding/client/client.py
+++ b/deploy/hps/sdk/pipelines/doc_understanding/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/doc_understanding/server/model_repo/document-understanding/1/model.py
+++ b/deploy/hps/sdk/pipelines/doc_understanding/server/model_repo/document-understanding/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 import time
 from typing import List

--- a/deploy/hps/sdk/pipelines/face_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-add/1/model.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-add/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from operator import attrgetter
 
 from paddlex.inference.pipelines.components import IndexData

--- a/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-build/1/model.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-build/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import uuid
 from operator import attrgetter
 

--- a/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-remove/1/model.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-index-remove/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex.inference.pipelines.components import IndexData
 from paddlex_hps_server import schemas
 

--- a/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-infer/1/model.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/model_repo/face-recognition-infer/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex.inference.pipelines.components import IndexData
@@ -23,7 +37,11 @@ class TritonPythonModel(BaseFaceRecognitionModel):
             index_data = IndexData.from_bytes(index_data_bytes)
         else:
             index_data = None
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline(

--- a/deploy/hps/sdk/pipelines/face_recognition/server/shared_mods/common/__init__.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/shared_mods/common/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/deploy/hps/sdk/pipelines/face_recognition/server/shared_mods/common/base_model.py
+++ b/deploy/hps/sdk/pipelines/face_recognition/server/shared_mods/common/base_model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel
 from paddlex_hps_server.storage import create_storage
 

--- a/deploy/hps/sdk/pipelines/formula_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/formula_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/formula_recognition/server/model_repo/formula-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/formula_recognition/server/model_repo/formula-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/human_keypoint_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/human_keypoint_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/human_keypoint_detection/server/model_repo/human-keypoint-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/human_keypoint_detection/server/model_repo/human-keypoint-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline.predict(

--- a/deploy/hps/sdk/pipelines/image_classification/client/client.py
+++ b/deploy/hps/sdk/pipelines/image_classification/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/image_classification/server/model_repo/image-classification/1/model.py
+++ b/deploy/hps/sdk/pipelines/image_classification/server/model_repo/image-classification/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, topk=input.topk))[0]
         if "label_names" in result:

--- a/deploy/hps/sdk/pipelines/image_multilabel_classification/client/client.py
+++ b/deploy/hps/sdk/pipelines/image_multilabel_classification/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/image_multilabel_classification/server/model_repo/multilabel-image-classification/1/model.py
+++ b/deploy/hps/sdk/pipelines/image_multilabel_classification/server/model_repo/multilabel-image-classification/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, threshold=input.threshold))[0]
 

--- a/deploy/hps/sdk/pipelines/instance_segmentation/client/client.py
+++ b/deploy/hps/sdk/pipelines/instance_segmentation/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/instance_segmentation/server/model_repo/instance-segmentation/1/model.py
+++ b/deploy/hps/sdk/pipelines/instance_segmentation/server/model_repo/instance-segmentation/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 import numpy as np
@@ -20,7 +34,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, threshold=input.threshold))[0]
 

--- a/deploy/hps/sdk/pipelines/layout_parsing/client/client.py
+++ b/deploy/hps/sdk/pipelines/layout_parsing/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/layout_parsing/server/model_repo/layout-parsing/1/model.py
+++ b/deploy/hps/sdk/pipelines/layout_parsing/server/model_repo/layout-parsing/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/multilingual_speech_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/multilingual_speech_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/multilingual_speech_recognition/server/model_repo/multilingual-speech-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/multilingual_speech_recognition/server/model_repo/multilingual-speech-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Any, Dict, List
 

--- a/deploy/hps/sdk/pipelines/object_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/object_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/object_detection/server/model_repo/object-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/object_detection/server/model_repo/object-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -15,7 +29,11 @@ class TritonPythonModel(BaseTritonPythonModel):
         image = utils.image_bytes_to_array(file_bytes)
 
         result = list(self.pipeline.predict(image, threshold=input.threshold))[0]
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         objects: List[Dict[str, Any]] = []
         for obj in result["boxes"]:

--- a/deploy/hps/sdk/pipelines/open_vocabulary_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/open_vocabulary_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/open_vocabulary_detection/server/model_repo/open-vocabulary-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/open_vocabulary_detection/server/model_repo/open-vocabulary-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline.predict(

--- a/deploy/hps/sdk/pipelines/open_vocabulary_segmentation/client/client.py
+++ b/deploy/hps/sdk/pipelines/open_vocabulary_segmentation/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/open_vocabulary_segmentation/server/model_repo/open-vocabulary-segmentation/1/model.py
+++ b/deploy/hps/sdk/pipelines/open_vocabulary_segmentation/server/model_repo/open-vocabulary-segmentation/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pycocotools.mask as mask_util
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -18,7 +32,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline.predict(

--- a/deploy/hps/sdk/pipelines/pedestrian_attribute_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/pedestrian_attribute_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/pedestrian_attribute_recognition/server/model_repo/pedestrian-attribute-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/pedestrian_attribute_recognition/server/model_repo/pedestrian-attribute-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline.predict(

--- a/deploy/hps/sdk/pipelines/rotated_object_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/rotated_object_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/rotated_object_detection/server/model_repo/rotated-object-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/rotated_object_detection/server/model_repo/rotated-object-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, threshold=input.threshold))[0]
 

--- a/deploy/hps/sdk/pipelines/seal_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/seal_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/seal_recognition/server/model_repo/seal-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/seal_recognition/server/model_repo/seal-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/semantic_segmentation/client/client.py
+++ b/deploy/hps/sdk/pipelines/semantic_segmentation/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/semantic_segmentation/server/model_repo/semantic-segmentation/1/model.py
+++ b/deploy/hps/sdk/pipelines/semantic_segmentation/server/model_repo/semantic-segmentation/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 
@@ -11,7 +25,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, target_size=input.targetSize))[0]
 

--- a/deploy/hps/sdk/pipelines/small_object_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/small_object_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/small_object_detection/server/model_repo/small-object-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/small_object_detection/server/model_repo/small-object-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(image, threshold=input.threshold))[0]
 

--- a/deploy/hps/sdk/pipelines/table_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/table_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/table_recognition/server/model_repo/table-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/table_recognition/server/model_repo/table-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/table_recognition_v2/client/client.py
+++ b/deploy/hps/sdk/pipelines/table_recognition_v2/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/table_recognition_v2/server/model_repo/table-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/table_recognition_v2/server/model_repo/table-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, Final, List, Tuple
 
 from paddlex_hps_server import (
@@ -74,7 +88,11 @@ class TritonPythonModel(BaseTritonPythonModel):
                 )
         else:
             file_type = "PDF" if input.fileType == 0 else "IMAGE"
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         file_bytes = utils.get_raw_bytes(input.file)
         images, data_info = utils.file_to_images(

--- a/deploy/hps/sdk/pipelines/ts_anomaly_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/ts_anomaly_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/ts_anomaly_detection/server/model_repo/time-series-anomaly-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/ts_anomaly_detection/server/model_repo/time-series-anomaly-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 
@@ -11,7 +25,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.csv)
         df = utils.csv_bytes_to_data_frame(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(df))[0]
 

--- a/deploy/hps/sdk/pipelines/ts_classification/client/client.py
+++ b/deploy/hps/sdk/pipelines/ts_classification/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/ts_classification/server/model_repo/time-series-classification/1/model.py
+++ b/deploy/hps/sdk/pipelines/ts_classification/server/model_repo/time-series-classification/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 
@@ -11,7 +25,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.csv)
         df = utils.csv_bytes_to_data_frame(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(df))[0]
 

--- a/deploy/hps/sdk/pipelines/ts_forecast/client/client.py
+++ b/deploy/hps/sdk/pipelines/ts_forecast/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 

--- a/deploy/hps/sdk/pipelines/ts_forecast/server/model_repo/time-series-forecasting/1/model.py
+++ b/deploy/hps/sdk/pipelines/ts_forecast/server/model_repo/time-series-forecasting/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
 
 
@@ -11,7 +25,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.csv)
         df = utils.csv_bytes_to_data_frame(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(self.pipeline.predict(df))[0]
 

--- a/deploy/hps/sdk/pipelines/vehicle_attribute_recognition/client/client.py
+++ b/deploy/hps/sdk/pipelines/vehicle_attribute_recognition/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/vehicle_attribute_recognition/server/model_repo/vehicle-attribute-recognition/1/model.py
+++ b/deploy/hps/sdk/pipelines/vehicle_attribute_recognition/server/model_repo/vehicle-attribute-recognition/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List
 
 from paddlex_hps_server import BaseTritonPythonModel, schemas, utils
@@ -13,7 +27,11 @@ class TritonPythonModel(BaseTritonPythonModel):
     def run(self, input, log_id):
         file_bytes = utils.get_raw_bytes(input.image)
         image = utils.image_bytes_to_array(file_bytes)
-        visualize_enabled = input.visualize if input.visualize is not None else self.app_config.visualize
+        visualize_enabled = (
+            input.visualize
+            if input.visualize is not None
+            else self.app_config.visualize
+        )
 
         result = list(
             self.pipeline.predict(

--- a/deploy/hps/sdk/pipelines/video_classification/client/client.py
+++ b/deploy/hps/sdk/pipelines/video_classification/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/video_classification/server/model_repo/video-classification/1/model.py
+++ b/deploy/hps/sdk/pipelines/video_classification/server/model_repo/video-classification/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Any, Dict, List
 

--- a/deploy/hps/sdk/pipelines/video_detection/client/client.py
+++ b/deploy/hps/sdk/pipelines/video_detection/client/client.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import pprint
 import sys

--- a/deploy/hps/sdk/pipelines/video_detection/server/model_repo/video-detection/1/model.py
+++ b/deploy/hps/sdk/pipelines/video_detection/server/model_repo/video-detection/1/model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Any, Dict, List
 

--- a/deploy/hps/sdk/scripts/assemble.py
+++ b/deploy/hps/sdk/scripts/assemble.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 import pathlib

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/__init__.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/__init__.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from importlib import metadata as _metadata
 
 from .base_model import BaseTritonPythonModel

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/app_common.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/app_common.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from typing import Dict, Optional, Tuple, Union
 

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/base_model.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/base_model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import time
 import uuid

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/config.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/config.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex.inference.serving.infra.config import (
     SERVING_CONFIG_KEY,
     AppConfig,

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/constants.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/constants.py
@@ -1,2 +1,16 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 INPUT_NAME = "input"
 OUTPUT_NAME = "output"

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/env.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/env.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 PIPELINE_CONFIG_PATH = os.getenv("PADDLEX_HPS_PIPELINE_CONFIG_PATH", "")

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/lazy_mods.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/lazy_mods.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import importlib
 
 

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/logging.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/logging.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import sys
 from contextvars import ContextVar

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/protocol.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/protocol.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/schemas.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/schemas.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from importlib import import_module
 
 

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/storage.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/storage.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex.inference.serving.infra.storage import (
     BOS,
     BOSConfig,

--- a/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/utils.py
+++ b/deploy/hps/server_env/paddlex-hps-server/src/paddlex_hps_server/utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddlex.inference.serving.infra.utils import (
     base64_encode,
     csv_bytes_to_data_frame,

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
@@ -2297,6 +2297,12 @@ To remove the page limit, please add the following configuration to the pipeline
 <td>No</td>
 </tr>
 <tr>
+<td><code>formatBlockContent</code></td>
+<td><code>boolean</code> | <code>null</code></td>
+<td>Please refer to the description of the <code>format_block_content</code> parameter of the pipeline object's <code>predict</code> method.</td>
+<td>No</td>
+</tr>
+<tr>
 <td><code>layoutThreshold</code></td>
 <td><code>number</code> | <code>object</code> | </code><code>null</code></td>
 <td>Please refer to the description of the <code>layout_threshold</code> parameter of the pipeline object's <code>predict</code> method.</td>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
@@ -2254,6 +2254,12 @@ for res in output:
 <td>否</td>
 </tr>
 <tr>
+<td><code>formatBlockContent</code></td>
+<td><code>boolean</code> | <code>null</code></td>
+<td>请参阅产线对象中 <code>predict</code> 方法的 <code>format_block_content</code> 参数相关说明。</td>
+<td>否</td>
+</tr>
+<tr>
 <td><code>layoutThreshold</code></td>
 <td><code>number</code> | <code>object</code> | </code><code>null</code></td>
 <td>请参阅产线对象中 <code>predict</code> 方法的 <code>layout_threshold</code> 参数相关说明。</td>

--- a/paddlex/inference/serving/basic_serving/_pipeline_apps/pp_structurev3.py
+++ b/paddlex/inference/serving/basic_serving/_pipeline_apps/pp_structurev3.py
@@ -61,6 +61,7 @@ def create_pipeline_app(pipeline: Any, app_config: AppConfig) -> "FastAPI":
             use_formula_recognition=request.useFormulaRecognition,
             use_chart_recognition=request.useChartRecognition,
             use_region_detection=request.useRegionDetection,
+            save_markdown_content=request.saveMarkdownContent,
             layout_threshold=request.layoutThreshold,
             layout_nms=request.layoutNms,
             layout_unclip_ratio=request.layoutUnclipRatio,

--- a/paddlex/inference/serving/basic_serving/_pipeline_apps/pp_structurev3.py
+++ b/paddlex/inference/serving/basic_serving/_pipeline_apps/pp_structurev3.py
@@ -61,7 +61,7 @@ def create_pipeline_app(pipeline: Any, app_config: AppConfig) -> "FastAPI":
             use_formula_recognition=request.useFormulaRecognition,
             use_chart_recognition=request.useChartRecognition,
             use_region_detection=request.useRegionDetection,
-            save_markdown_content=request.saveMarkdownContent,
+            format_block_content=request.formatBlockContent,
             layout_threshold=request.layoutThreshold,
             layout_nms=request.layoutNms,
             layout_unclip_ratio=request.layoutUnclipRatio,

--- a/paddlex/inference/serving/schemas/pp_structurev3.py
+++ b/paddlex/inference/serving/schemas/pp_structurev3.py
@@ -39,6 +39,7 @@ class InferRequest(ocr.BaseInferRequest):
     useFormulaRecognition: Optional[bool] = None
     useChartRecognition: Optional[bool] = None
     useRegionDetection: Optional[bool] = None
+    saveMarkdownContent: Optional[bool] = None
     layoutThreshold: Optional[Union[float, dict]] = None
     layoutNms: Optional[bool] = None
     layoutUnclipRatio: Optional[Union[float, Tuple[float, float], dict]] = None

--- a/paddlex/inference/serving/schemas/pp_structurev3.py
+++ b/paddlex/inference/serving/schemas/pp_structurev3.py
@@ -39,7 +39,7 @@ class InferRequest(ocr.BaseInferRequest):
     useFormulaRecognition: Optional[bool] = None
     useChartRecognition: Optional[bool] = None
     useRegionDetection: Optional[bool] = None
-    saveMarkdownContent: Optional[bool] = None
+    formatBlockContent: Optional[bool] = None
     layoutThreshold: Optional[Union[float, dict]] = None
     layoutNms: Optional[bool] = None
     layoutUnclipRatio: Optional[Union[float, Tuple[float, float], dict]] = None


### PR DESCRIPTION
1. 高稳定性服务化部署部分，补全缺失的header，用pre-commit修正格式。
2. PP-StructureV3服务支持`save_markdown_content`参数：https://github.com/PaddlePaddle/PaddleX/pull/4507