### PR TITLE
[cherry-pick] fix: add support for numpy integer types in JSON serialization

### DIFF
--- a/paddlex/inference/common/result/mixin.py
+++ b/paddlex/inference/common/result/mixin.py
@@ -546,8 +546,10 @@ def _format_data(obj):
     Returns:
         Any: The formatted object.
     """
-    if isinstance(obj, np.float32):
+    if isinstance(obj, (np.float32, np.float64)):
         return float(obj)
+    elif isinstance(obj, (np.int32, np.int64)):
+        return int(obj)
     elif isinstance(obj, np.ndarray):
         return [_format_data(item) for item in obj.tolist()]
     elif isinstance(obj, pd.DataFrame):


### PR DESCRIPTION
修复 _format_data 函数未处理 numpy 整数类型（np.int32, np.int64）的问题， 防止 OCR 结果中包含 numpy 整数坐标时出现 JSON 序列化错误。

修复内容：
- 添加对 np.int32 和 np.int64 类型的支持
- 将 numpy 整数转换为 Python 原生 int 类型
- 扩展 np.float64 支持以保持类型处理一致性

Fixes JSON serialization errors when OCR results contain numpy integer coordinates.

🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored- Claude <noreply@anthropic.com>

