### PR TITLE
【OSPP】为防止模型翻译中断，添加结束符<<END>>

### DIFF
--- a/paddlex/inference/pipelines/components/prompt_engineering/generate_translate_prompt.py
+++ b/paddlex/inference/pipelines/components/prompt_engineering/generate_translate_prompt.py
@@ -165,8 +165,9 @@ class GenerateTranslatePrompt(BaseGeneratePrompt):
         if few_shot_demo_key_value_list:
             few_shot_demo_key_value_list = f"\n这里是一些专业术语对照表,如果遇到对照表中单词要参考对照表翻译：\n{few_shot_demo_key_value_list}\n"
 
-        prompt = f"""{task_description}{rules_str}{output_format}{few_shot_demo_text_content}{few_shot_demo_key_value_list}"""
-
+        after_rule = "9. 请在翻译完成后添加特殊标记 <<END>>，确保翻译完整。"
+        prompt = f"""{task_description}{rules_str}{after_rule}{output_format}{few_shot_demo_text_content}{few_shot_demo_key_value_list}"""
+        
         language_name = language_map.get(language, language)
         task_type = self.task_type
         if task_type == "translate_prompt":

--- a/paddlex/inference/pipelines/pp_doctranslation/pipeline.py
+++ b/paddlex/inference/pipelines/pp_doctranslation/pipeline.py
@@ -437,8 +437,14 @@ class PP_DocTranslation_Pipeline(BasePipeline):
                 few_shot_demo_key_value_list=few_shot_demo_key_value_list,
             )
             translate = chat_bot.generate_chat_results(prompt=prompt).get("content", "")
+                        
+            if "<<END>>" not in translate:
+                raise Exception("The translation did not reach the end. "
+                                 "This may happen if your chunk_size is too large. Please reduce chunk_size and try again.")
             if translate is None:
                 raise Exception("The call to the large model failed.")
+            
+            translate = translate.replace("<<END>>", "").rstrip()
             return translate
 
         base_prompt_content = self.translate_pe.generate_prompt(


### PR DESCRIPTION
为防止用户设置的chunk_size大于模型翻译的上下文限制，现在设置结束符用以提醒用户模型中断