### PR TITLE
实现自定义产线加载

### DIFF
--- a/paddlex/inference/pipelines/__init__.py
+++ b/paddlex/inference/pipelines/__init__.py
@@ -164,6 +164,14 @@ def create_pipeline(
     else:
         config.pop("hpi_config", None)
 
+    # 支持自定义pipeline类的加载，根据pipeline_cls
+    pipeline_cls = config.pop("pipeline_cls", None)
+    if pipeline_cls and isinstance(pipeline_cls, str):
+        # 支持"module.submodule:ClassName"格式的字符串导入
+        if ":" in pipeline_cls:
+            module_path, class_name = pipeline_cls.rsplit(":", 1)
+            __import__(module_path, fromlist=[class_name])
+
     pipeline = BasePipeline.get(pipeline_name)(
         config=config,
         device=device,


### PR DESCRIPTION
在自定义产线yml配置文件中使用pipeline_cls属性声明"module.submodule:ClassName"格式的字符串自定义产线类路径即可。注意：此类需使用pip install提前注册到当前python环境中。

