### PR TITLE
fix #4636

### DIFF
--- a/paddlex/inference/models/common/vlm/transformers/model_utils.py
+++ b/paddlex/inference/models/common/vlm/transformers/model_utils.py
@@ -1797,6 +1797,7 @@ class PretrainedModel(
         )
 
         init_args = config["init_args"] or ()
+        transpose_weight_keys = None
         with ContextManagers(init_contexts):
             model = cls(config, *init_args, **model_kwargs)
 


### PR DESCRIPTION
### 预防性的修复 [https://github.com/PaddlePaddle/PaddleX/issues/4636](https://github.com/PaddlePaddle/PaddleX/issues/4636)

虽然本地尚未成功复现该 issue 描述的报错场景，但在排查 `from_pretrained` 加载流程时发现确实存在潜在的未绑定变量使用风险：`transpose_weight_keys` 仅在部分分支被赋值，在未走入 `get_transpose_weight_keys()` 的情况下仍会于 `load_state_dict(..., transpose_weight_keys=...)` 中被引用，从而可能触发 `UnboundLocalError`。

### 变更说明

* 在 `paddlex/inference/models/common/vlm/transformers/model_utils.py:1800` 提前初始化：

  ```python
  transpose_weight_keys = None
  ```
* 保持原有逻辑：若模型实现 `get_transpose_weight_keys()`，则在后续分支中覆盖该值。
* 属于预防性修复，避免潜在路径下的未绑定变量错误，不改变现有行为。
