### PR TITLE
fix: add support for numpy integer types in JSON serialization

### DIFF
--- a/paddlex/configs/modules/text_to_speech_acoustic/fastspeech2_csmsc.yaml
+++ b/paddlex/configs/modules/text_to_speech_acoustic/fastspeech2_csmsc.yaml
@@ -1,11 +1,11 @@
 Global:
   model: fastspeech2_csmsc
   mode: predict # only support predict
+  device: gpu:0
   output: "output"
 
 Predict:
   batch_size: 1
-  device: gpu:0
   model_dir: "fastspeech2csmsc"
   input: [151, 120, 182, 82, 182, 82, 174, 75, 262, 51, 37, 186, 38, 233]
   lang: zh

--- a/paddlex/configs/modules/text_to_speech_acoustic/fastspeech2_csmsc.yaml
+++ b/paddlex/configs/modules/text_to_speech_acoustic/fastspeech2_csmsc.yaml
@@ -10,9 +10,5 @@ Predict:
   input: [151, 120, 182, 82, 182, 82, 174, 75, 262, 51, 37, 186, 38, 233]
   lang: zh
   speaker_id: 0
-  use_trt: False
-  use_mkldnn: False
-  cpu_threads: 1
-  precision: "fp32"
   kernel_option:
     run_mode: paddle

--- a/paddlex/configs/modules/text_to_speech_vocoder/pwgan_csmsc.yaml
+++ b/paddlex/configs/modules/text_to_speech_vocoder/pwgan_csmsc.yaml
@@ -1,17 +1,17 @@
 Global:
   model: pwgan_csmsc
   mode: predict # only support predict
+  device: gpu:0
   output: "output"
 
 Predict:
-  device: gpu:0
   use_trt: False
   use_mkldnn: False
   cpu_threads: 1
   precision: "fp32"
   batch_size: 1
   model_dir: "pwgan_csmsc"
-  input: "./mel.npy"
+  input: "https://paddlespeech.bj.bcebos.com/demos/paddlex/mel.npy"
   lang: zh
   speaker_id: 0
   kernel_option:

--- a/paddlex/configs/modules/text_to_speech_vocoder/pwgan_csmsc.yaml
+++ b/paddlex/configs/modules/text_to_speech_vocoder/pwgan_csmsc.yaml
@@ -5,10 +5,6 @@ Global:
   output: "output"
 
 Predict:
-  use_trt: False
-  use_mkldnn: False
-  cpu_threads: 1
-  precision: "fp32"
   batch_size: 1
   model_dir: "pwgan_csmsc"
   input: "https://paddlespeech.bj.bcebos.com/demos/paddlex/mel.npy"

--- a/paddlex/inference/common/result/mixin.py
+++ b/paddlex/inference/common/result/mixin.py
@@ -547,8 +547,10 @@ def _format_data(obj):
     Returns:
         Any: The formatted object.
     """
-    if isinstance(obj, np.float32):
+    if isinstance(obj, (np.float32, np.float64)):
         return float(obj)
+    elif isinstance(obj, (np.int32, np.int64)):
+        return int(obj)
     elif isinstance(obj, np.ndarray):
         return [_format_data(item) for item in obj.tolist()]
     elif isinstance(obj, pd.DataFrame):


### PR DESCRIPTION
修复 _format_data 函数未处理 numpy 整数类型（np.int32, np.int64）的问题， 防止 OCR 结果中包含 numpy 整数坐标时出现 JSON 序列化错误。

修复内容：
- 添加对 np.int32 和 np.int64 类型的支持
- 将 numpy 整数转换为 Python 原生 int 类型
- 扩展 np.float64 支持以保持类型处理一致性

Fixes JSON serialization errors when OCR results contain numpy integer coordinates.

🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored- Claude <noreply@anthropic.com>

