### PR TITLE
fix: convert numpy array to list to avoid AttributeError on append

### DIFF
--- a/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
@@ -493,6 +493,7 @@ class _LayoutParsingPipelineV2(BasePipeline):
         if len(layout_det_res["boxes"]) == 0 and len(overall_ocr_res["rec_boxes"]) > 0:
             for idx, ocr_rec_box in enumerate(overall_ocr_res["rec_boxes"]):
                 base_region_bbox = update_region_box(ocr_rec_box, base_region_bbox)
+                layout_det_res["boxes"] = list(layout_det_res["boxes"])
                 layout_det_res["boxes"].append(
                     {
                         "label": "text",


### PR DESCRIPTION
修复 https://github.com/PaddlePaddle/PaddleOCR/issues/17068

**问题现象**

```python
AttributeError: 'numpy.ndarray' object has no attribute 'append'
````

**问题原因**

`layout_det_res["boxes"]` 在前序流程中被包装成了 `ndarray`，但后续逻辑仍然按列表调用 `layout_det_res["boxes"].append(...)`，导致报错。

**解决方案**

在调用 `append` 之前，将 `layout_det_res["boxes"]` 从 `ndarray` 显式还原为 `list`，保证后续 append 调用正常执行。

