### PR TITLE
优化object detection的STATIC_SHAPE_MODEL_LIST

### DIFF
--- a/paddlex/inference/models/object_detection/utils.py
+++ b/paddlex/inference/models/object_detection/utils.py
@@ -50,6 +50,8 @@ STATIC_SHAPE_MODEL_LIST = [
     "RT-DETR-H_layout_3cls",
     "RT-DETR-H",
     "RT-DETR-L",
+    "RT-DETR-L_wired_table_cell_det",
+    "RT-DETR-L_wireless_table_cell_det",
     "RT-DETR-R18",
     "RT-DETR-R50",
     "RT-DETR-X",


### PR DESCRIPTION
根据：https://github.com/PaddlePaddle/PaddleX/issues/4730

将RT-DETR-L_wired_table_cell_det和RT-DETR-L_wireless_table_cell_det加入STATIC_SHAPE_MODEL_LIST，显式提醒无法修改输入大小。