### PR TITLE
sort_table_cells_boxes update_v2

### DIFF
--- a/paddlex/inference/pipelines/table_recognition/table_recognition_post_processing_v2.py
+++ b/paddlex/inference/pipelines/table_recognition/table_recognition_post_processing_v2.py
@@ -262,7 +262,7 @@ def get_html_result(
     return html
 
 
-def sort_table_cells_boxes(boxes):
+def sort_table_cells_boxes(boxes, overlap_threshold=0.5):
     """
     Sort the input list of bounding boxes.
 
@@ -273,33 +273,37 @@ def sort_table_cells_boxes(boxes):
         sorted_boxes (list of lists): The list of bounding boxes sorted.
     """
 
+    def is_same_row(box1, box2):
+        _, y1a, _, y2a = box1
+        _, y1b, _, y2b = box2
+        overlap = max(0, min(y2a, y2b) - max(y1a, y1b))
+        min_height = min(y2a - y1a, y2b - y1b)
+        if min_height <= 0:
+            return False
+        return overlap / min_height >= overlap_threshold
+
     boxes_sorted_by_y = sorted(boxes, key=lambda box: box[1])
+
     rows = []
-    current_row = []
-    current_y = None
-    tolerance = 10
-    for box in boxes_sorted_by_y:
-        x1, y1, x2, y2 = box
-        if current_y is None:
+    current_row = [boxes_sorted_by_y[0]]
+
+    for box in boxes_sorted_by_y[1:]:
+        if is_same_row(current_row[-1], box):
             current_row.append(box)
-            current_y = y1
         else:
-            if abs(y1 - current_y) <= tolerance:
-                current_row.append(box)
-            else:
-                current_row.sort(key=lambda x: x[0])
-                rows.append(current_row)
-                current_row = [box]
-                current_y = y1
+            current_row.sort(key=lambda x: x[0])
+            rows.append(current_row)
+            current_row = [box]
     if current_row:
         current_row.sort(key=lambda x: x[0])
         rows.append(current_row)
+
     sorted_boxes = []
     flag = [0]
-    for i in range(len(rows)):
-        sorted_boxes.extend(rows[i])
-        if i < len(rows):
-            flag.append(flag[i] + len(rows[i]))
+    for row in rows:
+        sorted_boxes.extend(row)
+        flag.append(flag[-1] + len(row))
+
     return sorted_boxes, flag
 
 


### PR DESCRIPTION
发现一个表格，单元格顺序识别有问题，优化sort_table_cells_boxes方法后，单元格顺序正常

原图：
![45cc83b99f26573de8d1512f2b68942cbcc007e4b606f7e78015de571b101d1d](https://github.com/user-attachments/assets/f6502ecc-5dcd-4cc1-8c77-1bdacb0fdcb0)

优化前效果：
<div style="text-align: center;"><html><body><table border="1"><tbody><tr><td></td><td>货品名称</td><td>146238</td><td>厂商客户</td></tr><tr><td>进厂时间</td><td>COCC3</td><td>进厂日期</td><td>江苏纸联（扬州）</td></tr><tr><td>出厂时间</td><td>7:09</td><td>出厂日期</td><td>2024/1/29</td></tr><tr><td>进厂车牌</td><td>9:22</td><td>进厂重量</td><td>2024/1/29</td></tr><tr><td>出厂车牌</td><td>K9578</td><td>出厂重量</td><td>49340kg</td></tr><tr><td>货柜号码</td><td>K9578</td><td>过磅净重</td><td>16260 kg</td></tr><tr><td>打包名称</td><td>K9578</td><td>打包代号</td><td>33080 kg</td></tr><tr><td>陵产业园</td><td colspan="3">备注</td></tr><tr><td>承运人</td><td>小</td><td>过磅员</td><td>yz1613</td></tr></table></body></html></div>


优化后效果：
<div style="text-align: center;"><html><body><table border="1"><tbody><tr><td>厂商客户</td><td></td><td>货品名称</td><td>146238</td></tr><tr><td>进厂日期</td><td>江苏纸联（扬州）</td><td>进厂时间</td><td>COCC3</td></tr><tr><td>出厂日期</td><td>2024/1/29</td><td>出厂时间</td><td>7:09</td></tr><tr><td>进厂重量</td><td>2024/1/29</td><td>进厂车牌</td><td>9:22</td></tr><tr><td>出厂重量</td><td>49340kg</td><td>出厂车牌</td><td>K9578</td></tr><tr><td>过磅净重</td><td>16260 kg</td><td>货柜号码</td><td>K9578</td></tr><tr><td>打包代号</td><td>33080 kg</td><td>打包名称</td><td>K9578</td></tr><tr><td>备注</td><td colspan="3">陵产业园</td></tr><tr><td>过磅员</td><td>yz1613</td><td>承运人</td><td>小</td></tr></table></body></html></div>
