### PR TITLE
support PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,6 +54,11 @@ A：可以：
 2. 设置全局预训练模型缓存路径，例如：`paddlex.pretrain_dir='/usrname/paddlex'`，已下载模型将不会重复下载。
 
 
+## <b>Q：每次导入`paddlex`都会卡住一会，为什么？</b>
+
+1. 因为每次启动，`paddlex`会默认自动测试模型托管平台的网络联通性（包括huggingface、aistudio、modelscope），以确定后续自动下载模型时选择哪个平台；
+2. 如果确定使用本地模型，不需要测试检查，可以设置环境变量`PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK=1`来禁用；
+
 
 ## <b>Q：当我在使用PaddleX的过程中遇到问题，应该怎样反馈呢？</b>
 

--- a/paddlex/inference/utils/official_models.py
+++ b/paddlex/inference/utils/official_models.py
@@ -31,7 +31,7 @@ from aistudio_sdk.snapshot_download import snapshot_download as aistudio_downloa
 from ...utils import logging
 from ...utils.cache import CACHE_DIR
 from ...utils.download import download_and_extract
-from ...utils.flags import MODEL_SOURCE
+from ...utils.flags import DISABLE_MODEL_SOURCE_CHECK, MODEL_SOURCE
 
 ALL_MODELS = [
     "ResNet18",
@@ -544,18 +544,35 @@ class _AIStudioModelHoster(_BaseModelHoster):
 class _ModelManager:
     model_list = ALL_MODELS
     _save_dir = Path(CACHE_DIR) / "official_models"
+    hoster_candidates = [
+        _HuggingFaceModelHoster,
+        _AIStudioModelHoster,
+        _ModelScopeModelHoster,
+        _BosModelHoster,
+    ]
 
     def __init__(self) -> None:
         self._hosters = self._build_hosters()
 
     def _build_hosters(self):
+
+        if DISABLE_MODEL_SOURCE_CHECK:
+            logging.warning(
+                f"Connectivity check to the model hoster has been skipped because `DISABLE_MODEL_SOURCE_CHECK` is enabled."
+            )
+            hosters = []
+            for hoster_cls in self.hoster_candidates:
+                if hoster_cls.alias == MODEL_SOURCE:
+                    hosters.insert(0, hoster_cls(self._save_dir))
+                else:
+                    hosters.append(hoster_cls(self._save_dir))
+            return hosters
+
+        logging.warning(
+            f"Checking connectivity to the model hosters, this may take a while. To bypass this check, set `DISABLE_MODEL_SOURCE_CHECK` to `True`."
+        )
         hosters = []
-        for hoster_cls in [
-            _HuggingFaceModelHoster,
-            _AIStudioModelHoster,
-            _ModelScopeModelHoster,
-            _BosModelHoster,
-        ]:
+        for hoster_cls in self.hoster_candidates:
             if hoster_cls.alias == MODEL_SOURCE:
                 if hoster_cls.is_available():
                     hosters.insert(0, hoster_cls(self._save_dir))
@@ -564,7 +581,7 @@ class _ModelManager:
                     hosters.append(hoster_cls(self._save_dir))
         if len(hosters) == 0:
             logging.warning(
-                f"No model hoster is available! Please check your network connection to one of the following model hosts: HuggingFace ({_HuggingFaceModelHoster.healthcheck_url}), ModelScope ({_ModelScopeModelHoster.healthcheck_url}), AIStudio ({_AIStudioModelHoster.healthcheck_url}), or BOS ({_BosModelHoster.healthcheck_url}). Otherwise, only local models can be used."
+                f"No model hoster is available! Please check your network connection to one of the following model hoster: HuggingFace ({_HuggingFaceModelHoster.healthcheck_url}), ModelScope ({_ModelScopeModelHoster.healthcheck_url}), AIStudio ({_AIStudioModelHoster.healthcheck_url}), or BOS ({_BosModelHoster.healthcheck_url}). Otherwise, only local models can be used."
             )
         return hosters
 

--- a/paddlex/utils/flags.py
+++ b/paddlex/utils/flags.py
@@ -66,6 +66,9 @@ DISABLE_DEVICE_FALLBACK = get_flag_from_env_var(
 )
 
 MODEL_SOURCE = os.environ.get("PADDLE_PDX_MODEL_SOURCE", "huggingface").lower()
+DISABLE_MODEL_SOURCE_CHECK = os.environ.get(
+    "PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK", False
+)
 
 
 # Inference Benchmark


### PR DESCRIPTION
1. support to disable model source availablity check by flag `PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK`
