### PR TITLE
Improve robustness and error handling in image cropping and polygon rectification

### DIFF
--- a/paddlex/inference/models/formula_recognition/processors.py
+++ b/paddlex/inference/models/formula_recognition/processors.py
@@ -117,8 +117,12 @@ class MinMaxResize:
             ]
             if padded_size != list(img.size):  # assert hypothesis
                 padded_im = Image.new("L", padded_size, 255)
-                padded_im.paste(img, img.getbbox())
-                img = padded_im
+                bbox = img.getbbox()
+                if bbox is None:
+                    padded_im.paste(img, (0, 0))
+                else:
+                    padded_im.paste(img, (0, 0, img.size[0], img.size[1]))
+                img = padded_img
         return img
 
     def resize(self, img: np.ndarray) -> np.ndarray:

--- a/paddlex/inference/models/formula_recognition/processors.py
+++ b/paddlex/inference/models/formula_recognition/processors.py
@@ -77,6 +77,8 @@ class MinMaxResize:
             data = 255 - data
 
         coords = cv2.findNonZero(gray)  # Find all non-zero points (text)
+        if coords is None:
+            return img
         a, b, w, h = cv2.boundingRect(coords)  # Find minimum spanning bounding box
         rect = data[b : b + h, a : a + w]
         im = Image.fromarray(rect).convert("L")

--- a/paddlex/inference/pipelines/components/common/crop_image_regions.py
+++ b/paddlex/inference/pipelines/components/common/crop_image_regions.py
@@ -565,4 +565,8 @@ class CropByPolys(BaseOperator):
         if len(img.shape) == 2:
             img = np.stack((img,) * 3, axis=-1)
         img_crop, image = rectifier.run(img, new_points_list, mode="homography")
-        return np.array(img_crop[0], dtype=np.uint8)
+        img_crop = np.array(img_crop[0], dtype=np.uint8)
+        if img_crop.size == 0:
+            return img.copy()
+        return img_crop
+

--- a/paddlex/inference/pipelines/components/common/crop_image_regions.py
+++ b/paddlex/inference/pipelines/components/common/crop_image_regions.py
@@ -59,6 +59,12 @@ class CropByBoxes(BaseOperator):
             box = bbox_info["coordinate"]
             label = bbox_info.get("label", label_id)
             xmin, ymin, xmax, ymax = [int(i) for i in box]
+            xmin = max(0, min(xmin, img.shape[1]-1))
+            xmax = max(0, min(xmax, img.shape[1]-1))
+            ymin = max(0, min(ymin, img.shape[0]-1))
+            ymax = max(0, min(ymax, img.shape[0]-1))
+            if xmax <= xmin or ymax <= ymin:
+                continue
             img_crop = img[ymin:ymax, xmin:xmax].copy()
             output_list.append({"img": img_crop, "box": box, "label": label})
         return output_list
@@ -178,14 +184,18 @@ class CropByPolys(BaseOperator):
                 [0, img_crop_height],
             ]
         )
-        M = cv2.getPerspectiveTransform(points, pts_std)
-        dst_img = cv2.warpPerspective(
-            img,
-            M,
-            (img_crop_width, img_crop_height),
-            borderMode=cv2.BORDER_REPLICATE,
-            flags=cv2.INTER_CUBIC,
-        )
+        try:
+            M = cv2.getPerspectiveTransform(points, pts_std)
+            dst_img = cv2.warpPerspective(
+                img,
+                M,
+                (img_crop_width, img_crop_height),
+                borderMode=cv2.BORDER_REPLICATE,
+                flags=cv2.INTER_CUBIC,
+            )
+        except cv2.error:
+            return img
+
         dst_img_height, dst_img_width = dst_img.shape[0:2]
         if dst_img_height * 1.0 / dst_img_width >= 1.5:
             dst_img = np.rot90(dst_img)
@@ -514,6 +524,8 @@ class CropByPolys(BaseOperator):
         return： 矫正后的图片 ndarray格式
         """
         points = np.array(points).astype(np.int32).reshape(-1, 2)
+        if not Polygon(points).is_valid or Polygon(points).area < 1:
+            return img
         temp_crop_img, temp_box = self.get_minarea_rect(img, points)
 
         # 计算最小外接矩形与polygon的IoU


### PR DESCRIPTION
- Added bounding box existence and empty image checks in minmax_size_ to prevent paste errors on padded images.
- Wrapped cv2.getPerspectiveTransform and cv2.warpPerspective in try/except in get_rotate_crop_image to avoid OpenCV crashes.
- Added validation for polygon validity and area in get_poly_rect_crop to skip invalid or too-small polygons.
- Updated rectification return logic in get_poly_rect_crop to handle empty crops and ensure a valid image is returned.
- These changes improve stability for processing images with tables, irregular polygons, or edge cases that previously caused errors like "!ssize.empty() in resize".
