### PR TITLE
Fix issue of linear memory increase

### DIFF
--- a/paddlex/inference/common/result/base_result.py
+++ b/paddlex/inference/common/result/base_result.py
@@ -15,12 +15,49 @@
 import inspect
 import random
 import time
+import weakref
+from collections import UserList
 from pathlib import Path
 
 import numpy as np
 
 from ....utils import logging
 from .mixin import JsonMixin, StrMixin
+
+
+class AutoWeakList(UserList):
+    """
+    A list that automatically removes weak references to items.
+    """
+
+    def append(self, item):
+        """
+        Append item to list.
+        If item is a bound method, append a weak reference to the method.
+        Otherwise, append the item itself.
+        """
+        if inspect.ismethod(item):
+            super().append(weakref.WeakMethod(item))
+        else:
+            super().append(item)
+
+    def __iter__(self):
+        """Iterate over items in the list."""
+        for item in super().__iter__():
+            if isinstance(item, weakref.WeakMethod):
+                func = item()
+                if func is not None:
+                    yield func
+            else:
+                yield item
+
+    def __getitem__(self, index):
+        """Get item at index."""
+        item = super().__getitem__(index)
+        if isinstance(item, weakref.WeakMethod):
+            func = item()
+            return func
+        return item
 
 
 class BaseResult(dict, JsonMixin, StrMixin):
@@ -36,7 +73,7 @@ class BaseResult(dict, JsonMixin, StrMixin):
             data (dict): The initial data.
         """
         super().__init__(data)
-        self._save_funcs = []
+        self._save_funcs = AutoWeakList()
         StrMixin.__init__(self)
         JsonMixin.__init__(self)
         np.set_printoptions(threshold=1, edgeitems=1)


### PR DESCRIPTION
 The original code directly stored strong references to instance methods in `self.fuc_list`, 
which prevented `BaseResult` objects from being properly garbage collected and could lead to mem
ory leaks, especially when many instances are created. This update uses `weakref.WeakMethod` to 
store weak references to the methods, effectively avoiding reference cycles and improving memo
ry management efficiency and program stability.