### PR TITLE
[Fix] allow enable_hpi=1 for cyrillic_PP-OCRv5_mobile_rec on GPU

### DIFF
--- a/paddlex/inference/utils/hpi_model_info_collection.json
+++ b/paddlex/inference/utils/hpi_model_info_collection.json
@@ -11844,6 +11844,10 @@
         "onnxruntime",
         "paddle"
       ],
+      "eslav_PP-OCRv5_mobile_rec": [
+        "onnxruntime",
+        "paddle"
+      ],
       "arabic_PP-OCRv5_mobile_rec": [
         "onnxruntime",
         "paddle"


### PR DESCRIPTION
Export to ONNX for eslav_PP-OCRv5_mobile_rec did not work then option enable_hpi=1 was set (tested on nvidia GPU, paddle 3.2.0).
Similar issue: https://github.com/PaddlePaddle/PaddleOCR/issues/16450
