### PR TITLE
Fix pypdfium2 thread safety issues causing memory corruption

### DIFF
--- a/paddlex/inference/models/formula_recognition/result.py
+++ b/paddlex/inference/models/formula_recognition/result.py
@@ -34,6 +34,7 @@ if is_dep_available("opencv-contrib-python"):
     import cv2
 if is_dep_available("pypdfium2"):
     import pypdfium2 as pdfium
+    from ...utils.pdfium_lock import PDFIUM_LOCK
 
 
 class FormulaRecResult(BaseCVResult):
@@ -276,26 +277,28 @@ def pdf2img(pdf_path: str, img_path: str, is_padding: bool = False):
     Returns:
         np.ndarray: The resulting image as a NumPy array, or None if the PDF is not single-page.
     """
-    pdfDoc = pdfium.PdfDocument(pdf_path)
-    try:
-        if len(pdfDoc) != 1:
-            return None
-        for page in pdfDoc:
-            rotate = int(0)
-            zoom = 2
-            img = page.render(scale=zoom, rotation=rotate).to_numpy()
-            xywh = crop_white_area(img)
+    with PDFIUM_LOCK:
+        pdfDoc = pdfium.PdfDocument(pdf_path)
+        try:
+            if len(pdfDoc) != 1:
+                return None
+            for page in pdfDoc:
+                rotate = int(0)
+                zoom = 2
+                img = page.render(scale=zoom, rotation=rotate).to_numpy()
+                page.close()
+                xywh = crop_white_area(img)
 
-            if xywh is not None:
-                x, y, w, h = xywh
-                img = img[y : y + h, x : x + w]
-                if is_padding:
-                    img = cv2.copyMakeBorder(
-                        img, 30, 30, 30, 30, cv2.BORDER_CONSTANT, value=(255, 255, 255)
-                    )
-                return img
-    finally:
-        pdfDoc.close()
+                if xywh is not None:
+                    x, y, w, h = xywh
+                    img = img[y : y + h, x : x + w]
+                    if is_padding:
+                        img = cv2.copyMakeBorder(
+                            img, 30, 30, 30, 30, cv2.BORDER_CONSTANT, value=(255, 255, 255)
+                        )
+                    return img
+        finally:
+            pdfDoc.close()
     return None
 
 

--- a/paddlex/inference/models/formula_recognition/result.py
+++ b/paddlex/inference/models/formula_recognition/result.py
@@ -34,7 +34,7 @@ if is_dep_available("opencv-contrib-python"):
     import cv2
 if is_dep_available("pypdfium2"):
     import pypdfium2 as pdfium
-    from ...utils.pdfium_lock import PDFIUM_LOCK
+    from ...utils.pdfium_lock import pdfium_lock
 
 
 class FormulaRecResult(BaseCVResult):
@@ -277,7 +277,7 @@ def pdf2img(pdf_path: str, img_path: str, is_padding: bool = False):
     Returns:
         np.ndarray: The resulting image as a NumPy array, or None if the PDF is not single-page.
     """
-    with PDFIUM_LOCK:
+    with pdfium_lock:
         pdfDoc = pdfium.PdfDocument(pdf_path)
         try:
             if len(pdfDoc) != 1:

--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -726,6 +726,9 @@ class _PaddleOCRVLPipeline(BasePipeline):
         finally:
             if use_queues:
                 event_shutdown.set()
+                thread_input.join(timeout=5)
+                if thread_input.is_alive():
+                    logging.warning("Input worker did not terminate in time")
                 thread_cv.join(timeout=5)
                 if thread_cv.is_alive():
                     logging.warning("CV worker did not terminate in time")

--- a/paddlex/inference/serving/infra/utils.py
+++ b/paddlex/inference/serving/infra/utils.py
@@ -18,7 +18,6 @@ import io
 import mimetypes
 import re
 import tempfile
-import threading
 import uuid
 from functools import partial
 from typing import Awaitable, Callable, List, Optional, Tuple, TypeVar, Union, overload
@@ -31,6 +30,7 @@ from PIL import Image
 from typing_extensions import Literal, ParamSpec, TypeAlias, assert_never
 
 from ....utils.deps import function_requires_deps, is_dep_available
+from ...utils.pdfium_lock import PDFIUM_LOCK
 from .models import ImageInfo, PDFInfo, PDFPageInfo
 
 if is_dep_available("aiohttp"):
@@ -177,21 +177,19 @@ def base64_encode(data: bytes) -> str:
     return base64.b64encode(data).decode("ascii")
 
 
-_lock = threading.Lock()
-
-
 @function_requires_deps("pypdfium2", "opencv-contrib-python")
 def read_pdf(
     bytes_: bytes, max_num_imgs: Optional[int] = None
 ) -> Tuple[List[np.ndarray], PDFInfo]:
     images: List[np.ndarray] = []
     page_info_list: List[PDFPageInfo] = []
-    with _lock:
+    with PDFIUM_LOCK:
         doc = pdfium.PdfDocument(bytes_)
         doc.init_forms()
         try:
             for page in doc:
                 if max_num_imgs is not None and len(images) >= max_num_imgs:
+                    page.close()
                     break
                 # TODO: Do not always use zoom=2.0
                 zoom = 2.0
@@ -203,6 +201,7 @@ def read_pdf(
                     height=image.shape[0],
                 )
                 page_info_list.append(page_info)
+                page.close()
         finally:
             doc.close()
     pdf_info = PDFInfo(

--- a/paddlex/inference/serving/infra/utils.py
+++ b/paddlex/inference/serving/infra/utils.py
@@ -30,7 +30,7 @@ from PIL import Image
 from typing_extensions import Literal, ParamSpec, TypeAlias, assert_never
 
 from ....utils.deps import function_requires_deps, is_dep_available
-from ...utils.pdfium_lock import PDFIUM_LOCK
+from ...utils.pdfium_lock import pdfium_lock
 from .models import ImageInfo, PDFInfo, PDFPageInfo
 
 if is_dep_available("aiohttp"):
@@ -183,7 +183,7 @@ def read_pdf(
 ) -> Tuple[List[np.ndarray], PDFInfo]:
     images: List[np.ndarray] = []
     page_info_list: List[PDFPageInfo] = []
-    with PDFIUM_LOCK:
+    with pdfium_lock:
         doc = pdfium.PdfDocument(bytes_)
         doc.init_forms()
         try:

--- a/paddlex/inference/utils/io/readers.py
+++ b/paddlex/inference/utils/io/readers.py
@@ -28,6 +28,7 @@ if is_dep_available("opencv-contrib-python"):
     import cv2
 if is_dep_available("pypdfium2"):
     import pypdfium2 as pdfium
+    from ..pdfium_lock import PDFIUM_LOCK
 if is_dep_available("soundfile"):
     import soundfile
 
@@ -301,15 +302,18 @@ class PDFReaderBackend(_BaseReaderBackend):
         return doc
 
     def read_file(self, in_path):
-        if isinstance(in_path, pdfium.PdfDocument):
-            doc = in_path
-        else:
-            doc = self.load_file(str(in_path))
-        try:
-            for page in doc:
-                yield page.render(scale=self._scale, rotation=self._rotation).to_numpy()
-        finally:
-            doc.close()
+        with PDFIUM_LOCK:
+            if isinstance(in_path, pdfium.PdfDocument):
+                doc = in_path
+            else:
+                doc = self.load_file(str(in_path))
+            try:
+                for page in doc:
+                    image = page.render(scale=self._scale, rotation=self._rotation).to_numpy()
+                    page.close()
+                    yield image
+            finally:
+                doc.close()
 
 
 class TXTReaderBackend(_BaseReaderBackend):

--- a/paddlex/inference/utils/io/readers.py
+++ b/paddlex/inference/utils/io/readers.py
@@ -28,7 +28,7 @@ if is_dep_available("opencv-contrib-python"):
     import cv2
 if is_dep_available("pypdfium2"):
     import pypdfium2 as pdfium
-    from ..pdfium_lock import PDFIUM_LOCK
+    from ..pdfium_lock import pdfium_lock
 if is_dep_available("soundfile"):
     import soundfile
 
@@ -302,7 +302,7 @@ class PDFReaderBackend(_BaseReaderBackend):
         return doc
 
     def read_file(self, in_path):
-        with PDFIUM_LOCK:
+        with pdfium_lock:
             if isinstance(in_path, pdfium.PdfDocument):
                 doc = in_path
             else:

--- a/paddlex/inference/utils/io/readers.py
+++ b/paddlex/inference/utils/io/readers.py
@@ -297,9 +297,10 @@ class PDFReaderBackend(_BaseReaderBackend):
 
     def load_file(self, in_path):
         """load pdf file"""
-        doc = pdfium.PdfDocument(in_path)
-        doc.init_forms()
-        return doc
+        with pdfium_lock:
+            doc = pdfium.PdfDocument(in_path)
+            doc.init_forms()
+            return doc
 
     def read_file(self, in_path):
         with pdfium_lock:

--- a/paddlex/inference/utils/pdfium_lock.py
+++ b/paddlex/inference/utils/pdfium_lock.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Global lock for pypdfium2 operations.
+
+PDFium is inherently not thread-safe. It is not allowed to call pdfium
+functions simultaneously across different threads, not even with different
+documents. Simultaneous pdfium calls across threads will crash or corrupt
+the process.
+
+See: https://pypdfium2.readthedocs.io/en/stable/python_api.html
+
+This module provides a global lock that must be used to serialize all
+pypdfium2 operations across the application.
+"""
+
+import threading
+
+PDFIUM_LOCK = threading.Lock()

--- a/paddlex/inference/utils/pdfium_lock.py
+++ b/paddlex/inference/utils/pdfium_lock.py
@@ -28,4 +28,4 @@ pypdfium2 operations across the application.
 
 import threading
 
-PDFIUM_LOCK = threading.Lock()
+pdfium_lock = threading.Lock()


### PR DESCRIPTION
This commit fixes the "corrupted double-linked list" error (Issue [#17145](https://github.com/PaddlePaddle/PaddleOCR/issues/17145)) that occurs when processing PDFs concurrently in PaddleOCR-VL.

Root cause:
- PDFium is inherently not thread-safe
- Multiple threads calling pypdfium2 functions simultaneously causes heap memory corruption
- Page objects not being explicitly closed leads to GC assertion errors

Changes:
1. Add global PDFIUM_LOCK to serialize all pypdfium2 operations
   - New file: paddlex/inference/utils/pdfium_lock.py

2. Apply lock and add page.close() to all pypdfium2 usage locations:
   - paddlex/inference/serving/infra/utils.py (read_pdf)
   - paddlex/inference/utils/io/readers.py (PDFReaderBackend)
   - paddlex/inference/models/formula_recognition/result.py (pdf2img)


