### PR TITLE
Fix PyInstaller packaging: .version file not found error

### DIFF
--- a/paddlex/version.py
+++ b/paddlex/version.py
@@ -14,16 +14,30 @@
 
 
 import os
+import sys
 
 __all__ = ["get_pdx_version", "get_version_dict", "show_versions"]
 
 
+def _get_package_dir():
+    """Get the paddlex package directory, compatible with PyInstaller."""
+    # When running in a PyInstaller bundle, sys._MEIPASS points to the
+    # temporary folder where the bundled files are extracted
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return os.path.join(sys._MEIPASS, "paddlex")
+    return os.path.dirname(__file__)
+
+
 def get_pdx_version():
     """get_pdx_version"""
-    with open(
-        os.path.join(os.path.dirname(__file__), ".version"), "r", encoding="ascii"
-    ) as fv:
-        ver = fv.read().rstrip()
+    version_file = os.path.join(_get_package_dir(), ".version")
+    try:
+        with open(version_file, "r", encoding="ascii") as fv:
+            ver = fv.read().rstrip()
+    except FileNotFoundError:
+        # Fallback version if .version file is not found (e.g., in some
+        # PyInstaller configurations where the file wasn't included)
+        ver = "unknown"
     return ver
 
 


### PR DESCRIPTION
  ## 概述
  - 修复 PyInstaller 打包后运行时找不到 `.version` 文件的错误
  - 添加 `_get_package_dir()` 辅助函数来检测和处理 PyInstaller 冻结环境
  - 添加降级机制，当文件未找到时返回 "unknown" 版本

  ## 问题背景
https://github.com/PaddlePaddle/PaddleX/issues/4868

  当使用 PyInstaller 打包 PaddleX 应用时，`.version` 文件无法被定位，因为 `__file__` 指向临时解压目录，而原有的路径解析逻辑未考虑 PyInstaller 打包环境。

  ## 修改内容
  通过检测 `sys.frozen` 和 `sys._MEIPASS` 属性来识别 PyInstaller 环境，并据此构建正确的文件路径。

  **注意：** 用户仍需在 PyInstaller 打包时通过 `--add-data` 参数或 spec 文件中的 `datas` 配置将 `.version`
  文件包含进去：
  ```bash
  pyinstaller --add-data "path/to/paddlex/.version;paddlex" your_script.py
