### PR TITLE
Fix OpenAPI schema generation failure with FastAPI >= 0.124.1

### DIFF
--- a/paddlex/inference/serving/infra/models.py
+++ b/paddlex/inference/serving/infra/models.py
@@ -14,8 +14,8 @@
 
 from typing import Dict, Generic, List, Tuple, TypeVar, Union
 
-from pydantic import BaseModel, Discriminator
-from typing_extensions import Annotated, Literal, TypeAlias
+from pydantic import BaseModel
+from typing_extensions import Literal, TypeAlias
 
 from ....utils.deps import is_dep_available
 
@@ -73,7 +73,7 @@ class PDFInfo(BaseModel):
     type: Literal["pdf"] = "pdf"
 
 
-DataInfo: TypeAlias = Annotated[Union[ImageInfo, PDFInfo], Discriminator("type")]
+DataInfo: TypeAlias = Union[ImageInfo, PDFInfo]
 
 # Should we use generics?
 PrimaryOperations: TypeAlias = Dict[str, Tuple[str, BaseModel, BaseModel]]


### PR DESCRIPTION
Remove `Annotated[..., Discriminator("type")]` wrapper from `DataInfo` type alias to fix OpenAPI schema generation error.

## Problem
FastAPI 0.124.1 introduced a change that unpacks `field_info.metadata` when constructing `TypeAdapter`, which causes nested `Annotated` types when using `Annotated[Union[...], Discriminator(...)]` as a type alias. This triggers:

```
TypeError: Discriminator must be used with a Union type, not typing.Annotated[...]
```

## Root Cause
FastAPI commit 42b250d modified `fastapi/_compat/v2.py` to unpack metadata, creating duplicate `Discriminator` in nested `Annotated` wrappers.

## Solution
Remove the `Annotated` and `Discriminator` wrapper. Pydantic can still correctly discriminate between `ImageInfo` and `PDFInfo` based on the `type` field's `Literal` values without explicit discriminator annotation.

## Impact
- `/openapi.json` now returns 200 instead of 500
- `/docs` (Swagger UI) loads correctly
- API endpoints continue to work as before

Fixes: PaddlePaddle/PaddleOCR#17359
Fixes: PaddlePaddle/PaddleOCR#17496
Fixes: PaddlePaddle/PaddleOCR#17507

