### PR TITLE
feat(hps-client): add async interface for Triton requests

### DIFF
--- a/deploy/hps/sdk/paddlex-hps-client/pyproject.toml
+++ b/deploy/hps/sdk/paddlex-hps-client/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 dependencies = [
     "numpy >= 1.24",
     # XXX: Not sure about the backward compatibility
-    "tritonclient [grpc] >= 2.15.0",
+    "tritonclient [grpc] >= 2.30.0",
 ]
 
 [tool.isort]

--- a/deploy/hps/sdk/paddlex-hps-client/pyproject.toml
+++ b/deploy/hps/sdk/paddlex-hps-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paddlex-hps-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
     "numpy >= 1.24",
     # XXX: Not sure about the backward compatibility

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/__init__.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/__init__.py
@@ -14,9 +14,9 @@
 
 from importlib import metadata as _metadata
 
-from .request import triton_request
+from .request import triton_request, triton_request_async
 
-__all__ = ["__version__", "triton_request"]
+__all__ = ["__version__", "triton_request", "triton_request_async"]
 
 # Ref: https://github.com/langchain-ai/langchain/blob/493e474063817b9a4c2521586b2dbc34d20b4cf1/libs/core/langchain_core/__init__.py
 try:

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
@@ -16,6 +16,7 @@ import json
 
 import numpy as np
 from tritonclient import grpc as triton_grpc
+from tritonclient.grpc import aio as triton_grpc_aio
 
 from . import constants
 
@@ -36,10 +37,48 @@ def _parse_triton_output(data):
 
 
 def triton_request(client, model_name, data, *, request_kwargs=None):
+    """
+    Make a synchronous request to Triton Inference Server.
+
+    Args:
+        client: Triton gRPC client (tritonclient.grpc.InferenceServerClient)
+        model_name: Name of the model to call
+        data: Request payload dict
+        request_kwargs: Additional kwargs passed to client.infer()
+
+    Returns:
+        Response dict from Triton
+    """
     if request_kwargs is None:
         request_kwargs = {}
     input_ = triton_grpc.InferInput(constants.INPUT_NAME, [1, 1], "BYTES")
     input_.set_data_from_numpy(_create_triton_input(data))
     results = client.infer(model_name, inputs=[input_], **request_kwargs)
+    output = results.as_numpy(constants.OUTPUT_NAME)
+    return _parse_triton_output(output)
+
+
+async def triton_request_async(client, model_name, data, *, timeout=None):
+    """
+    Make an async request to Triton Inference Server.
+
+    Args:
+        client: Async Triton gRPC client (tritonclient.grpc.aio.InferenceServerClient)
+        model_name: Name of the model to call
+        data: Request payload dict
+        timeout: Request timeout in seconds
+
+    Returns:
+        Response dict from Triton
+    """
+    input_ = triton_grpc_aio.InferInput(constants.INPUT_NAME, [1, 1], "BYTES")
+    input_.set_data_from_numpy(_create_triton_input(data))
+
+    infer_kwargs = {}
+    if timeout is not None:
+        infer_kwargs["timeout"] = timeout
+        infer_kwargs["client_timeout"] = timeout
+
+    results = await client.infer(model_name, inputs=[input_], **infer_kwargs)
     output = results.as_numpy(constants.OUTPUT_NAME)
     return _parse_triton_output(output)

--- a/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
+++ b/deploy/hps/sdk/paddlex-hps-client/src/paddlex_hps_client/request.py
@@ -36,7 +36,7 @@ def _parse_triton_output(data):
     return data
 
 
-def triton_request(client, model_name, data, *, request_kwargs=None):
+def triton_request(client, model_name, data, *, timeout=None, request_kwargs=None):
     """
     Make a synchronous request to Triton Inference Server.
 
@@ -44,6 +44,7 @@ def triton_request(client, model_name, data, *, request_kwargs=None):
         client: Triton gRPC client (tritonclient.grpc.InferenceServerClient)
         model_name: Name of the model to call
         data: Request payload dict
+        timeout: Request timeout in seconds
         request_kwargs: Additional kwargs passed to client.infer()
 
     Returns:
@@ -51,6 +52,9 @@ def triton_request(client, model_name, data, *, request_kwargs=None):
     """
     if request_kwargs is None:
         request_kwargs = {}
+    if timeout is not None:
+        request_kwargs.setdefault("timeout", timeout)
+        request_kwargs.setdefault("client_timeout", timeout)
     input_ = triton_grpc.InferInput(constants.INPUT_NAME, [1, 1], "BYTES")
     input_.set_data_from_numpy(_create_triton_input(data))
     results = client.infer(model_name, inputs=[input_], **request_kwargs)
@@ -58,7 +62,7 @@ def triton_request(client, model_name, data, *, request_kwargs=None):
     return _parse_triton_output(output)
 
 
-async def triton_request_async(client, model_name, data, *, timeout=None):
+async def triton_request_async(client, model_name, data, *, timeout=None, request_kwargs=None):
     """
     Make an async request to Triton Inference Server.
 
@@ -67,18 +71,18 @@ async def triton_request_async(client, model_name, data, *, timeout=None):
         model_name: Name of the model to call
         data: Request payload dict
         timeout: Request timeout in seconds
+        request_kwargs: Additional kwargs passed to client.infer()
 
     Returns:
         Response dict from Triton
     """
+    if request_kwargs is None:
+        request_kwargs = {}
+    if timeout is not None:
+        request_kwargs.setdefault("timeout", timeout)
+        request_kwargs.setdefault("client_timeout", timeout)
     input_ = triton_grpc_aio.InferInput(constants.INPUT_NAME, [1, 1], "BYTES")
     input_.set_data_from_numpy(_create_triton_input(data))
-
-    infer_kwargs = {}
-    if timeout is not None:
-        infer_kwargs["timeout"] = timeout
-        infer_kwargs["client_timeout"] = timeout
-
-    results = await client.infer(model_name, inputs=[input_], **infer_kwargs)
+    results = await client.infer(model_name, inputs=[input_], **request_kwargs)
     output = results.as_numpy(constants.OUTPUT_NAME)
     return _parse_triton_output(output)


### PR DESCRIPTION
Add triton_request_async() function to support async gateways. This consolidates Triton communication logic in one place.

