### PR TITLE
Fix/chart recognition init guard

### DIFF
--- a/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
@@ -92,7 +92,7 @@ class _LayoutParsingPipelineV2(BasePipeline):
         self.img_reader = ReadImage(format="BGR")
 
     def close(self):
-        if getattr(self, "chart_recognition_model"):
+        if getattr(self, "chart_recognition_model", None):
             self.chart_recognition_model.close()
 
     def inintial_predictor(self, config: dict) -> None:
@@ -213,13 +213,14 @@ class _LayoutParsingPipelineV2(BasePipeline):
             )
 
         # TODO(gaotingquan): init the model at any time
-        chart_recognition_config = config.get("SubModules", {}).get(
-            "ChartRecognition",
-            {"model_config_error": "config error for block_region_detection_model!"},
-        )
-        self.chart_recognition_model = self.create_model(
-            chart_recognition_config,
-        )
+        if self.use_chart_recognition:
+            chart_recognition_config = config.get("SubModules", {}).get(
+                "ChartRecognition",
+                {"model_config_error": "config error for chart_recognition_model!"},
+            )
+            self.chart_recognition_model = self.create_model(
+                chart_recognition_config,
+            )
         self.markdown_ignore_labels = config.get(
             "markdown_ignore_labels",
             [


### PR DESCRIPTION
## Summary

- Fix #4986
- Add `if self.use_chart_recognition` guard around `chart_recognition_model` initialization in
  `_LayoutParsingPipelineV2.inintial_predictor()`, consistent with other optional components (`region_detection`,
  `seal_recognition`, `table_recognition`, `formula_recognition`)
- Fix copy-paste error in fallback error message: `"block_region_detection_model"` →
  `"chart_recognition_model"`
- Fix `getattr` in `close()` to use default `None`, preventing `AttributeError` when chart recognition is
  disabled

## Root Cause

When users set `use_chart_recognition: False` and remove the `ChartRecognition` SubModule from their YAML
config, `chart_recognition_model` was still unconditionally initialized, causing:
```
ValueError: config error for block_region_detection_model!
```

The error message itself was also misleading due to a copy-paste bug.

## Test Plan

- [x] Run PP-StructureV3 pipeline with `use_chart_recognition: False` and no `ChartRecognition` SubModule in config — no longer raises `ValueError`
- [x] Run PP-StructureV3 pipeline with default config (`use_chart_recognition: False` with `ChartRecognition` SubModule present) — works as before
- [x] Call `close()` on pipeline instance when chart recognition is disabled — no `AttributeError`