### PR TITLE
Add PP-DocLayoutV3 layout_analyse module with complete training pipeline

### DIFF
--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
@@ -9,6 +9,8 @@ The layout analysis task builds upon layout area detection by further introducin
 
 The layout analysis module currently supports the PP-DocLayoutV3 model, which is based on the DETR architecture with PPHGNetV2-L as the backbone network. It adds a **reading order prediction** branch on top of the instance segmentation task, enabling end-to-end learning of reading order relationships among document elements.
 
+![layout analysis](https://raw.githubusercontent.com/cuicheng01/PaddleX_doc_images/refs/heads/main/images/modules/layout_analysis/layout_analysis.png)
+
 ## II. Supported Model List
 
 > The inference time only includes the model inference time and does not include the time for pre- or post-processing.
@@ -19,9 +21,7 @@ The layout analysis module currently supports the PP-DocLayoutV3 model, which is
 <thead>
 <tr>
 <th>Model</th><th>Model Download Link</th>
-<th>mAP(0.5) (%)</th>
-<th>GPU Inference Time (ms)<br/>[Normal Mode / High-Performance Mode]</th>
-<th>CPU Inference Time (ms)<br/>[Normal Mode / High-Performance Mode]</th>
+<th>GPU Inference Time (ms)<br/>A100 GPU</th>
 <th>Model Storage Size (MB)</th>
 <th>Introduction</th>
 </tr>
@@ -30,10 +30,8 @@ The layout analysis module currently supports the PP-DocLayoutV3 model, which is
 <tr>
 <td>PP-DocLayoutV3</td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayoutV3_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams">Training Model</a></td>
-<td>-</td>
-<td>- / -</td>
-<td>- / -</td>
-<td>-</td>
+<td>23.77</td>
+<td>126</td>
 <td>A layout analysis model trained on a self-built dataset containing Chinese and English papers, multi-column magazines, newspapers, PPT, contracts, books, exams, and research reports using DETR. It supports instance segmentation and reading order prediction for 25 layout element categories.</td>
 </tr>
 </tbody>
@@ -78,6 +76,10 @@ The meanings of the parameters are as follows:
   - `polygon_points`: List of instance segmentation contour points, in the format <code>[[x1, y1], [x2, y2], ...]</code>.
   - `order`: Reading order index, an integer indicating the reading order of the region in the document (starting from 0).
 </details>
+
+After running, the visualization result saved by `save_to_img()` is shown below, with each region annotated with its category, confidence score, instance segmentation mask, and reading order index:
+
+![Layout Analysis Visualization Result](https://raw.githubusercontent.com/cuicheng01/PaddleX_doc_images/refs/heads/main/images/modules/layout_analysis/layout_analysis_demo_res.jpg)
 
 Relevant methods, parameters, and explanations are as follows:
 
@@ -179,20 +181,6 @@ Relevant methods, parameters, and explanations are as follows:
 </ul>
 </td>
 <td>None</td>
-</tr>
-<tr>
-<td><code>use_hpip</code></td>
-<td>Whether to enable the high-performance inference plugin</td>
-<td><code>bool</code></td>
-<td>None</td>
-<td><code>False</code></td>
-</tr>
-<tr>
-<td><code>hpi_config</code></td>
-<td>High-performance inference configuration</td>
-<td><code>dict</code> | <code>None</code></td>
-<td>None</td>
-<td><code>None</code></td>
 </tr>
 </table>
 
@@ -605,10 +593,8 @@ The model can be directly integrated into PaddleX pipelines or into your own pro
 
 1. <b>Pipeline Integration</b>
 
-The layout analysis module can be integrated into PaddleX pipelines such as the [Document Scene Information Extraction Pipeline v3 (PP-ChatOCRv3-doc)](../../../pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md). Simply replace the model path to update the layout analysis module. In pipeline integration, you can use high-performance inference and serving deployment to deploy your model.
+The layout analysis module can be integrated into PaddleX pipelines such as the [Document Parsing Pipeline (PaddleOCR-VL)](../../../pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.en.md). Simply replace the model path to update the layout analysis module.
 
 2. <b>Module Integration</b>
 
 The weights you produce can be directly integrated into the layout analysis module. You can refer to the Python example code in the [Quick Integration](#quick) section, simply replacing the model with the path to your trained model.
-
-You can also use the PaddleX high-performance inference plugin to optimize the inference process of your model and further improve efficiency. For detailed procedures, please refer to the [PaddleX High-Performance Inference Guide](../../../pipeline_deploy/high_performance_inference.en.md).

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
@@ -1,0 +1,615 @@
+---
+comments: true
+---
+
+# Layout Analysis Module Tutorial
+
+## I. Overview
+The layout analysis task builds upon layout area detection by further introducing **instance segmentation** and **reading order prediction** capabilities. By analyzing input document images, it not only identifies various layout elements (such as text, charts, images, formulas, paragraph titles, abstracts, references, etc.) and outputs their bounding boxes, but also simultaneously outputs the **precise contour mask** and **reading order index** for each region, providing more complete structural information for document understanding and information extraction workflows.
+
+The layout analysis module currently supports the PP-DocLayoutV3 model, which is based on the DETR architecture with PPHGNetV2-L as the backbone network. It adds a **reading order prediction** branch on top of the instance segmentation task, enabling end-to-end learning of reading order relationships among document elements.
+
+## II. Supported Model List
+
+> The inference time only includes the model inference time and does not include the time for pre- or post-processing.
+
+* <b>The layout analysis model includes 25 common categories: abstract, algorithm, aside text, chart, content, display formula, document title, figure title, footer, footer image, footnote, formula number, header, header image, image, inline formula, number, paragraph title, reference, reference content, seal, table, text, vertical text, and vision footnote</b>
+
+<table>
+<thead>
+<tr>
+<th>Model</th><th>Model Download Link</th>
+<th>mAP(0.5) (%)</th>
+<th>GPU Inference Time (ms)<br/>[Normal Mode / High-Performance Mode]</th>
+<th>CPU Inference Time (ms)<br/>[Normal Mode / High-Performance Mode]</th>
+<th>Model Storage Size (MB)</th>
+<th>Introduction</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>PP-DocLayoutV3</td>
+<td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayoutV3_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams">Training Model</a></td>
+<td>-</td>
+<td>- / -</td>
+<td>- / -</td>
+<td>-</td>
+<td>A layout analysis model trained on a self-built dataset containing Chinese and English papers, multi-column magazines, newspapers, PPT, contracts, books, exams, and research reports using DETR. It supports instance segmentation and reading order prediction for 25 layout element categories.</td>
+</tr>
+</tbody>
+</table>
+
+<b>Note: The evaluation set for the above accuracy metrics is a self-built layout analysis dataset containing images from various Chinese and English document scenarios.</b>
+
+## III. Quick Integration  <a id="quick"> </a>
+> ❗ Before quick integration, please install the PaddleX wheel package. For detailed instructions, refer to [PaddleX Local Installation Tutorial](../../../installation/installation.en.md)
+
+After installing the wheel package, a few lines of code can complete the inference of the layout analysis module. You can switch models under this module freely, and you can also integrate the model inference of the layout analysis module into your project. Before running the following code, please download the [demo image](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg) to your local machine.
+
+```python
+from paddlex import create_model
+
+model_name = "PP-DocLayoutV3"
+model = create_model(model_name=model_name)
+output = model.predict("layout.jpg", batch_size=1)
+
+for res in output:
+    res.print()
+    res.save_to_img(save_path="./output/")
+    res.save_to_json(save_path="./output/res.json")
+```
+
+<b>Note: </b>The official models would be downloaded from HuggingFace by default. PaddleX also supports specifying the preferred source by setting the environment variable `PADDLE_PDX_MODEL_SOURCE`. The supported values are `huggingface`, `aistudio`, `bos`, and `modelscope`. For example, to prioritize using `bos`, set: `PADDLE_PDX_MODEL_SOURCE="bos"`.
+
+<details><summary>👉 <b>After running, the result is: (Click to expand)</b></summary>
+
+```bash
+{'res': {'input_path': 'layout.jpg', 'page_index': None, 'boxes': [{'cls_id': 22, 'label': 'text', 'score': 0.98, 'coordinate': [34.1, 349.8, 358.5, 611.0], 'polygon_points': [[34.1, 349.8], [358.5, 349.8], [358.5, 611.0], [34.1, 611.0]], 'order': 3}, ...]}}
+```
+
+The meanings of the parameters are as follows:
+- `input_path`: The path to the input image for prediction.
+- `page_index`: If the input is a PDF file, it indicates which page of the PDF it is; otherwise, it is `None`.
+- `boxes`: Information about the predicted bounding boxes, a list of dictionaries. Each dictionary represents a detected object and contains the following information:
+  - `cls_id`: Class ID, an integer.
+  - `label`: Class label, a string.
+  - `score`: Confidence score of the bounding box, a float.
+  - `coordinate`: Coordinates of the bounding box, a list of floats in the format <code>[xmin, ymin, xmax, ymax]</code>.
+  - `polygon_points`: List of instance segmentation contour points, in the format <code>[[x1, y1], [x2, y2], ...]</code>.
+  - `order`: Reading order index, an integer indicating the reading order of the region in the document (starting from 0).
+</details>
+
+Relevant methods, parameters, and explanations are as follows:
+
+* `create_model` instantiates a layout analysis model (here, `PP-DocLayoutV3` is used as an example). The detailed explanation is as follows:
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Description</th>
+<th>Type</th>
+<th>Options</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tr>
+<td><code>model_name</code></td>
+<td>Name of the model</td>
+<td><code>str</code></td>
+<td>None</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>model_dir</code></td>
+<td>Path to store the model</td>
+<td><code>str</code></td>
+<td>None</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>device</code></td>
+<td>The device used for model inference</td>
+<td><code>str</code></td>
+<td>It supports specifying specific GPU card numbers, such as "gpu:0", other hardware card numbers, such as "npu:0", or CPU, such as "cpu".</td>
+<td><code>gpu:0</code></td>
+</tr>
+<tr>
+<td><code>img_size</code></td>
+<td>Size of the input image; if not specified, the default PaddleX official model configuration will be used</td>
+<td><code>int/list/None</code></td>
+<td>
+<ul>
+<li><b>int</b>, e.g., 800, means resizing the input image to 800x800</li>
+<li><b>List</b>, e.g., [800, 800], means resizing the input image to a width of 800 and a height of 800</li>
+<li><b>None</b>, not specified, will use the default PaddleX official model configuration</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>threshold</code></td>
+<td>Threshold for filtering low-confidence prediction results; if not specified, the default PaddleX official model configuration will be used</td>
+<td><code>float/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>, e.g., 0.5, means filtering out all bounding boxes with a confidence score less than 0.5</li>
+<li><b>Dictionary</b>, with keys as <b>int</b> representing <code>cls_id</code> and values as <b>float</b> thresholds, e.g., <code>{0: 0.45, 2: 0.48}</code></li>
+<li><b>None</b>, not specified, will use the default PaddleX official model configuration</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_nms</code></td>
+<td>Whether to use NMS post-processing to filter overlapping boxes; if not specified, the default PaddleX official model configuration will be used</td>
+<td><code>bool/None</code></td>
+<td>
+<ul>
+<li><b>bool</b>, True/False, indicates whether to use NMS for post-processing to filter overlapping boxes</li>
+<li><b>None</b>, not specified, will use the default PaddleX official model configuration</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_unclip_ratio</code></td>
+<td>Scaling factor for the side length of the detection box; if not specified, the default PaddleX official model configuration will be used</td>
+<td><code>float/list/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>, a positive float number, e.g., 1.1, means expanding the width and height of the detection box by 1.1 times while keeping the center unchanged</li>
+<li><b>List</b>, e.g., [1.2, 1.5], means expanding the width by 1.2 times and the height by 1.5 times while keeping the center unchanged</li>
+<li><b>dict</b>, keys as <b>int</b> representing <code>cls_id</code>, values as <b>tuple</b>, e.g., <code>{0: (1.1, 2.0)}</code></li>
+<li><b>None</b>, not specified, will use the default PaddleX official model configuration</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_merge_bboxes_mode</code></td>
+<td>Merging mode for the detection boxes output by the model; if not specified, the default PaddleX official model configuration will be used</td>
+<td><code>string/dict/None</code></td>
+<td>
+<ul>
+<li><b>large</b>, when set to large, only the largest external box will be retained for overlapping detection boxes, and the internal overlapping boxes will be deleted</li>
+<li><b>small</b>, when set to small, only the smallest internal box will be retained for overlapping detection boxes, and the external overlapping boxes will be deleted</li>
+<li><b>union</b>, no filtering of boxes will be performed, and both internal and external boxes will be retained</li>
+<li><b>dict</b>, keys as <b>int</b> representing <code>cls_id</code> and values as merging modes, e.g., <code>{0: "large", 2: "small"}</code></li>
+<li><b>None</b>, not specified, will use the default PaddleX official model configuration</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>use_hpip</code></td>
+<td>Whether to enable the high-performance inference plugin</td>
+<td><code>bool</code></td>
+<td>None</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>hpi_config</code></td>
+<td>High-performance inference configuration</td>
+<td><code>dict</code> | <code>None</code></td>
+<td>None</td>
+<td><code>None</code></td>
+</tr>
+</table>
+
+* Note that `model_name` must be specified. After specifying `model_name`, the default PaddleX built-in model parameters will be used. If `model_dir` is specified, the user-defined model will be used.
+
+* The `predict()` method of the layout analysis model is called for inference prediction. The parameters of the `predict()` method are explained as follows:
+
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Description</th>
+<th>Type</th>
+<th>Options</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tr>
+<td><code>input</code></td>
+<td>Data for prediction, supporting multiple input types</td>
+<td><code>Python Var</code>/<code>str</code>/<code>list</code></td>
+<td>
+<ul>
+<li><b>Python Variable</b>, such as image data represented by <code>numpy.ndarray</code></li>
+<li><b>File Path</b>, such as the local path of an image file: <code>/root/data/img.jpg</code></li>
+<li><b>URL link</b>, such as the network URL of an image file</li>
+<li><b>Local Directory</b>, the directory should contain the data files to be predicted, such as the local path: <code>/root/data/</code></li>
+<li><b>List</b>, the elements of the list should be of the above-mentioned data types, such as <code>[numpy.ndarray, numpy.ndarray]</code>, <code>["/root/data/img1.jpg", "/root/data/img2.jpg"]</code></li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>batch_size</code></td>
+<td>Batch size</td>
+<td><code>int</code></td>
+<td>Any integer greater than 0</td>
+<td>1</td>
+</tr>
+<tr>
+<td><code>threshold</code></td>
+<td>Threshold for filtering low-confidence prediction results</td>
+<td><code>float/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>, e.g., 0.5, means filtering out all bounding boxes with a confidence score less than 0.5</li>
+<li><b>Dictionary</b>, with keys as <b>int</b> representing <code>cls_id</code> and values as <b>float</b> thresholds</li>
+<li><b>None</b>, not specified, will use the <code>threshold</code> parameter specified in <code>create_model</code>. If not specified in <code>create_model</code>, the default PaddleX official model configuration will be used</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+</table>
+
+* The prediction results for each sample can be printed, saved as images, or saved as `json` files:
+
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+<th>Parameter</th>
+<th>Parameter Type</th>
+<th>Parameter Description</th>
+<th>Default Value</th>
+</tr>
+</thead>
+<tr>
+<td rowspan="3"><code>print()</code></td>
+<td rowspan="3">Print results to the terminal</td>
+<td><code>format_json</code></td>
+<td><code>bool</code></td>
+<td>Whether to format the output using <code>JSON</code> indentation</td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>indent</code></td>
+<td><code>int</code></td>
+<td>Specifies the indentation level for prettifying the output <code>JSON</code> data, only effective when <code>format_json</code> is <code>True</code></td>
+<td>4</td>
+</tr>
+<tr>
+<td><code>ensure_ascii</code></td>
+<td><code>bool</code></td>
+<td>Controls whether non-<code>ASCII</code> characters are escaped to Unicode, only effective when <code>format_json</code> is <code>True</code></td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td rowspan="3"><code>save_to_json()</code></td>
+<td rowspan="3">Save results as a JSON file</td>
+<td><code>save_path</code></td>
+<td><code>str</code></td>
+<td>The file path for saving. When a directory is specified, the saved file is named consistently with the input file type</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>indent</code></td>
+<td><code>int</code></td>
+<td>Specifies the indentation level for prettifying the output <code>JSON</code> data, only effective when <code>format_json</code> is <code>True</code></td>
+<td>4</td>
+</tr>
+<tr>
+<td><code>ensure_ascii</code></td>
+<td><code>bool</code></td>
+<td>Controls whether non-<code>ASCII</code> characters are escaped to Unicode, only effective when <code>format_json</code> is <code>True</code></td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>save_to_img()</code></td>
+<td>Save results as an image file (the visualized image includes instance segmentation masks and reading order indices)</td>
+<td><code>save_path</code></td>
+<td><code>str</code></td>
+<td>The file path for saving. When a directory is specified, the saved file is named consistently with the input file type</td>
+<td>None</td>
+</tr>
+</table>
+
+* Additionally, it also supports obtaining the visualized image with results and the prediction results via attributes, as follows:
+
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Description</th>
+</tr>
+</thead>
+<tr>
+<td rowspan="1"><code>json</code></td>
+<td rowspan="1">Get the prediction result in <code>json</code> format</td>
+</tr>
+<tr>
+<td rowspan="1"><code>img</code></td>
+<td rowspan="1">Get the visualized image in <code>dict</code> format, with each region's category, confidence score, instance segmentation mask, and reading order index annotated</td>
+</tr>
+</table>
+
+For more information on using PaddleX's single-model inference API, refer to [PaddleX Single Model Python Script Usage Instructions](../../instructions/model_python_API.en.md).
+
+
+## IV. Custom Development
+If you seek higher accuracy from existing models, you can use PaddleX's custom development capabilities to develop better layout analysis models. Before developing a layout analysis model with PaddleX, ensure you have installed PaddleX's Detection-related model training capabilities. The installation process can be found in [PaddleX Local Installation Tutorial](../../../installation/installation.en.md).
+
+### 4.1 Data Preparation
+Before model training, you need to prepare the corresponding dataset for the task module. PaddleX provides a data validation function for each module, and <b>only data that passes the validation can be used for model training</b>. Additionally, PaddleX provides demo datasets for each module, which you can use to complete subsequent development based on the official demos. If you wish to use private datasets for subsequent model training, refer to the [PaddleX Object Detection Task Module Data Annotation Tutorial](../../../data_annotations/cv_modules/object_detection.en.md).
+
+#### 4.1.1 Demo Data Download
+You can use the following commands to download the demo dataset to a specified folder:
+
+```bash
+cd /path/to/paddlex
+wget https://paddle-model-ecology.bj.bcebos.com/paddlex/data/doclayoutv3_examples.tar -P ./dataset
+tar -xf ./dataset/doclayoutv3_examples.tar -C ./dataset/
+```
+
+#### 4.1.2 Dataset Format Description
+The layout analysis module uses the **COCOInstSegDataset** format, supplemented with reading order annotations. The dataset directory structure is as follows:
+
+```
+doclayoutv3_examples/
+├── images/               # Original image directory
+│   ├── train_0001.jpg
+│   ├── val_0001.jpg
+│   └── ...
+├── images_mask/          # Image directory for training (same content as images)
+│   └── ...
+└── annotations/
+    ├── instance_train.json   # Training set annotations (COCO instance segmentation format + read_order field)
+    └── instance_val.json     # Validation set annotations (COCO instance segmentation format + read_order field)
+```
+
+The annotation files follow the COCO instance segmentation format, with an added `read_order` field in each annotation to record the reading order of the region in the document (a non-negative integer starting from 0; the `read_order` values of all annotations within the same image should form a consecutive sequence). An example annotation is as follows:
+
+```json
+{
+  "annotations": [
+    {
+      "id": 1,
+      "image_id": 1,
+      "category_id": 22,
+      "bbox": [34.1, 349.8, 324.4, 261.2],
+      "segmentation": [[34.1, 349.8, 358.5, 349.8, 358.5, 611.0, 34.1, 611.0]],
+      "area": 84740.0,
+      "iscrowd": 0,
+      "read_order": 0
+    }
+  ]
+}
+```
+
+The 25 categories supported by the model and their descriptions are as follows:
+
+| Category Name (English) | Description |
+|---|---|
+| `abstract` | Abstract |
+| `algorithm` | Algorithm |
+| `aside_text` | Sidebar text |
+| `chart` | Chart |
+| `content` | Table of contents |
+| `display_formula` | Display formula |
+| `doc_title` | Document title |
+| `figure_title` | Figure title |
+| `footer` | Footer |
+| `footer_image` | Footer image |
+| `footnote` | Footnote |
+| `formula_number` | Formula number |
+| `header` | Header |
+| `header_image` | Header image |
+| `image` | Image |
+| `inline_formula` | Inline formula |
+| `number` | Page number |
+| `paragraph_title` | Paragraph title |
+| `reference` | Reference |
+| `reference_content` | Reference content |
+| `seal` | Seal |
+| `table` | Table |
+| `text` | Text |
+| `vertical_text` | Vertical text |
+| `vision_footnote` | Figure caption |
+
+#### 4.1.3 Data Validation
+A single command can complete data validation:
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+```
+
+After executing the above command, PaddleX will validate the dataset and collect its basic information. Upon successful execution, the log will print the message `Check dataset passed !`. The validation result file will be saved in `./output/check_dataset_result.json`, and related outputs will be saved in the `./output/check_dataset` directory of the current directory. The output directory includes visualized example images (with instance segmentation masks and reading order indices annotated) and histograms of sample distributions.
+
+<details><summary>👉 <b>Validation Result Details (Click to Expand)</b></summary>
+<p>The specific content of the validation result file is:</p>
+<pre><code class="language-bash">{
+  "done_flag": true,
+  "check_pass": true,
+  "attributes": {
+    "num_classes": 11,
+    "train_samples": 6351,
+    "train_sample_paths": [
+      "check_dataset\/demo_img\/train_4141.jpg",
+      "check_dataset\/demo_img\/train_3699.jpg",
+      "check_dataset\/demo_img\/train_3764.jpg",
+      "check_dataset\/demo_img\/train_2279.jpg",
+      "check_dataset\/demo_img\/train_4647.jpg",
+      "check_dataset\/demo_img\/train_4442.jpg",
+      "check_dataset\/demo_img\/train_2006.jpg",
+      "check_dataset\/demo_img\/train_1463.jpg",
+      "check_dataset\/demo_img\/train_3275.jpg",
+      "check_dataset\/demo_img\/train_4509.jpg"
+    ],
+    "val_samples": 945,
+    "val_sample_paths": [
+      "check_dataset\/demo_img\/val_0105.jpg",
+      "check_dataset\/demo_img\/val_0031.jpg",
+      "check_dataset\/demo_img\/val_0755.jpg",
+      "check_dataset\/demo_img\/val_0876.jpg",
+      "check_dataset\/demo_img\/val_0374.jpg",
+      "check_dataset\/demo_img\/val_0566.jpg",
+      "check_dataset\/demo_img\/val_0748.jpg",
+      "check_dataset\/demo_img\/val_0167.jpg",
+      "check_dataset\/demo_img\/val_0345.jpg",
+      "check_dataset\/demo_img\/val_0471.jpg"
+    ],
+    "read_order_validation": {
+      "instance_train": {
+        "total_images": 500,
+        "valid_images": 500,
+        "invalid_images": [],
+        "pass_rate": 1.0
+      },
+      "instance_val": {
+        "total_images": 100,
+        "valid_images": 100,
+        "invalid_images": [],
+        "pass_rate": 1.0
+      }
+    }
+  },
+  "analysis": {
+    "histogram": "check_dataset\/histogram.png"
+  },
+  "dataset_path": "doclayoutv3_examples",
+  "show_type": "image",
+  "dataset_type": "COCOInstSegDataset"
+}
+</code></pre>
+<p>The verification results mentioned above indicate that <code>check_pass</code> being <code>True</code> means the dataset format meets the requirements. Details of other indicators are as follows:</p>
+<ul>
+<li><code>attributes.num_classes</code>: The number of classes in this dataset is 11;</li>
+<li><code>attributes.train_samples</code>: The number of training samples in this dataset;</li>
+<li><code>attributes.val_samples</code>: The number of validation samples in this dataset;</li>
+<li><code>attributes.train_sample_paths</code>: The list of relative paths to the visualization images of training samples in this dataset;</li>
+<li><code>attributes.val_sample_paths</code>: The list of relative paths to the visualization images of validation samples in this dataset;</li>
+<li><code>attributes.read_order_validation</code>: Validation statistics for the <code>read_order</code> field, including the total number of images, number of valid images, and pass rate for both training and validation sets.</li>
+</ul>
+<p>The dataset verification also analyzes the distribution of sample numbers across all classes and generates a histogram (histogram.png).</p>
+
+<b>Note:</b> Layout analysis data validation additionally validates the <code>read_order</code> field in each image annotation:
+<ul>
+<li>Completeness: Each annotation must contain a <code>read_order</code> field;</li>
+<li>Type validity: <code>read_order</code> must be a non-negative integer;</li>
+<li>Consecutiveness: The <code>read_order</code> values of all annotations within the same image should form a consecutive integer sequence starting from 0 (a warning will be issued if non-consecutive).</li>
+</ul>
+</details>
+
+#### 4.1.4 Dataset Format Conversion/Dataset Splitting (Optional)
+
+After completing dataset verification, you can re-split the training/validation ratio by <b>modifying the configuration file</b> or <b>appending hyperparameters</b>.
+
+<details><summary>👉 <b>Details on Dataset Splitting (Click to Expand)</b></summary>
+<p><b>(1) Dataset Format Conversion</b></p>
+<p>Layout analysis does not support data format conversion. Please use the COCO instance segmentation format directly (with the <code>read_order</code> field).</p>
+<p><b>(2) Dataset Splitting</b></p>
+<p>Parameters for dataset splitting can be set by modifying the <code>CheckDataset</code> section in the configuration file:</p>
+<pre><code class="language-bash">CheckDataset:
+  split:
+    enable: True
+    train_percent: 90
+    val_percent: 10
+</code></pre>
+<p>Then execute the command:</p>
+<pre><code class="language-bash">python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+</code></pre>
+<p>After dataset splitting, the original annotation files will be renamed to <code>xxx.bak</code> in the original path.</p>
+<p>The above parameters can also be set by appending command-line arguments:</p>
+<pre><code>python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
+    -o CheckDataset.split.enable=True \
+    -o CheckDataset.split.train_percent=90 \
+    -o CheckDataset.split.val_percent=10
+</code></pre></details>
+
+### 4.2 Model Training
+
+A single command is sufficient to complete model training, taking the training of `PP-DocLayoutV3` as an example:
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=train \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
+    -o Train.num_classes=11
+```
+The steps required are:
+
+* Specify the path to the `.yaml` configuration file of the model (here it is `PP-DocLayoutV3.yaml`)
+* Specify the mode as model training: `-o Global.mode=train`
+* Specify the path to the training dataset: `-o Global.dataset_dir`
+* Other related parameters can be set by modifying the `Global` and `Train` fields in the `.yaml` configuration file, or adjusted by appending parameters in the command line. For example, to specify training on the first two GPUs: `-o Global.device=gpu:0,1`; to set the number of training epochs to 10: `-o Train.epochs_iters=10`. For more modifiable parameters and their detailed explanations, refer to the [PaddleX Common Configuration Parameters for Model Tasks](../../instructions/config_parameters_common.en.md).
+
+<details><summary>👉 <b>More Details (Click to Expand)</b></summary>
+<ul>
+<li>During model training, PaddleX automatically saves model weight files, defaulting to <code>output</code>. To specify a save path, use the <code>-o Global.output</code> field in the configuration file.</li>
+<li>PaddleX shields you from the concepts of dynamic graph weights and static graph weights. During model training, both dynamic and static graph weights are produced, and static graph weights are selected by default for model inference.</li>
+<li>
+<p>After completing the model training, all outputs are saved in the specified output directory (default is <code>./output/</code>), typically including:</p>
+</li>
+<li>
+<p><code>train_result.json</code>: Training result record file, recording whether the training task was completed normally, as well as the output weight metrics, related file paths, etc.;</p>
+</li>
+<li><code>train.log</code>: Training log file, recording changes in model metrics and loss during training;</li>
+<li><code>config.yaml</code>: Training configuration file, recording the hyperparameter configuration for this training session;</li>
+<li><code>.pdparams</code>, <code>.pdema</code>, <code>.pdopt.pdstate</code>, <code>.pdiparams</code>, <code>.json</code>: Model weight-related files, including network parameters, optimizer, EMA, static graph network parameters, static graph network structure, etc.;</li>
+<li>Note: The layout analysis model uses an <code>order_loss</code> branch during training (with a weight coefficient of 50). This loss term supervises the reading order prediction, and changes in <code>order_loss</code> can be observed in the training log.</li>
+</ul></details>
+
+### <b>4.3 Model Evaluation</b>
+After completing model training, you can evaluate the specified model weight file on the validation set to verify the model's accuracy. Using PaddleX for model evaluation, you can complete the evaluation with a single command:
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=evaluate \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+```
+Similar to model training, the process involves the following steps:
+
+* Specify the path to the `.yaml` configuration file for the model (here it's `PP-DocLayoutV3.yaml`)
+* Set the mode to model evaluation: `-o Global.mode=evaluate`
+* Specify the path to the validation dataset: `-o Global.dataset_dir`
+Other related parameters can be configured by modifying the fields under `Global` and `Evaluate` in the `.yaml` configuration file. For detailed information, please refer to [PaddleX Common Configuration Parameters for Models](../../instructions/config_parameters_common.en.md).
+
+<details><summary>👉 <b>More Details (Click to Expand)</b></summary>
+<p>When evaluating the model, you need to specify the model weights file path. Each configuration file has a default weight save path built-in. If you need to change it, simply set it by appending a command line parameter, such as <code>-o Evaluate.weight_path=./output/best_model/best_model/model.pdparams</code>.</p>
+<p>After completing the model evaluation, an <code>evaluate_result.json</code> file will be generated, which records the evaluation results, specifically whether the evaluation task was completed successfully, and the model's evaluation metrics, including AP.</p></details>
+
+### <b>4.4 Model Inference</b>
+After completing model training and evaluation, you can use the trained model weights for inference predictions. In PaddleX, model inference predictions can be achieved through two methods: command line and wheel package.
+
+#### 4.4.1 Model Inference
+* To perform inference predictions through the command line, simply use the following command. Before running the following code, please download the [demo image](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg) to your local machine.
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=predict \
+    -o Predict.model_dir="./output/best_model/inference" \
+    -o Predict.input="layout.jpg"
+```
+Similar to model training and evaluation, the following steps are required:
+
+* Specify the `.yaml` configuration file path of the model (here it is `PP-DocLayoutV3.yaml`)
+* Set the mode to model inference prediction: `-o Global.mode=predict`
+* Specify the model weights path: `-o Predict.model_dir="./output/best_model/inference"`
+* Specify the input data path: `-o Predict.input="..."`
+Other related parameters can be set by modifying the fields under `Global` and `Predict` in the `.yaml` configuration file. For details, please refer to [PaddleX Common Model Configuration File Parameter Description](../../instructions/config_parameters_common.en.md).
+
+* Alternatively, you can use the PaddleX wheel package for inference, easily integrating the model into your own project. To integrate, simply add the `model_dir="/output/best_model/inference"` parameter to the `create_model` function in the quick integration method from Step 3.
+
+#### 4.4.2 Model Integration
+The model can be directly integrated into PaddleX pipelines or into your own projects.
+
+1. <b>Pipeline Integration</b>
+
+The layout analysis module can be integrated into PaddleX pipelines such as the [Document Scene Information Extraction Pipeline v3 (PP-ChatOCRv3-doc)](../../../pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md). Simply replace the model path to update the layout analysis module. In pipeline integration, you can use high-performance inference and serving deployment to deploy your model.
+
+2. <b>Module Integration</b>
+
+The weights you produce can be directly integrated into the layout analysis module. You can refer to the Python example code in the [Quick Integration](#quick) section, simply replacing the model with the path to your trained model.
+
+You can also use the PaddleX high-performance inference plugin to optimize the inference process of your model and further improve efficiency. For detailed procedures, please refer to the [PaddleX High-Performance Inference Guide](../../../pipeline_deploy/high_performance_inference.en.md).

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.en.md
@@ -535,8 +535,7 @@ A single command is sufficient to complete model training, taking the training o
 ```bash
 python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
     -o Global.mode=train \
-    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
-    -o Train.num_classes=11
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
 ```
 The steps required are:
 

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
@@ -6,9 +6,9 @@ comments: true
 
 ## 一、概述
 
-版面分析任务在版面区域检测的基础上，进一步引入了**实例分割**与**阅读顺序预测**能力。通过对输入的文档图像进行内容解析与区域划分，模型不仅能识别各类版面元素（如文字、图表、图像、公式、段落标题、摘要、参考文献等）并输出其边界框，还能同时输出每个区域的**精确轮廓掩码**和**阅读顺序编号**，为文档理解与信息抽取流程提供更完整的结构化信息。
+版面分析任务在版面区域检测的基础上，进一步引入了**实例分割**与**阅读顺序预测**能力。通过对输入的文档图像进行分析，不仅能识别各类版面元素（如文字、图表、图像、公式、段落标题、摘要、参考文献等）并输出其边界框，还能同时输出每个区域的**精确轮廓掩码**和**阅读顺序编号**，为文档理解与信息抽取流程提供更完整的结构化信息。
 
-版面分析模块目前支持的模型 PP-DocLayoutV3，基于 DETR 架构并以 PPHGNetV2-L 为骨干网络，在实例分割任务之上增加了 `order_loss` 分支，可同步学习文档元素的阅读顺序关系。
+版面分析模块目前支持模型 PP-DocLayoutV3，基于 DETR 架构并以 PPHGNetV2-L 为骨干网络，在实例分割任务之上增加了**阅读顺序预测**分支，可端到端学习文档元素的阅读顺序关系。
 
 ## 二、支持模型列表
 
@@ -35,7 +35,7 @@ comments: true
 <td>- / -</td>
 <td>- / -</td>
 <td>-</td>
-<td>基于DETR（PPHGNetV2-L骨干）在包含中英文论文、多栏杂志、报纸、PPT、合同、书本、试卷、研报等场景的自建数据集上训练的版面分析模型，支持25类版面元素的实例分割及阅读顺序预测</td>
+<td>基于DETR在包含中英文论文、多栏杂志、报纸、PPT、合同、书本、试卷、研报等场景的自建数据集上训练的版面分析模型，支持25类版面元素的实例分割及阅读顺序预测</td>
 </tr>
 </tbody>
 </table>
@@ -355,7 +355,7 @@ tar -xf ./dataset/doclayoutv3_examples.tar -C ./dataset/
 
 #### 4.1.2 数据集格式说明
 
-版面分析模块使用 **COCOInstSegDataset** 格式，数据集目录结构如下：
+版面分析模块使用 **COCOInstSegDataset** 格式，并补充了阅读顺序标注，数据集目录结构如下：
 
 ```
 doclayoutv3_examples/
@@ -437,36 +437,50 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
   "done_flag": true,
   "check_pass": true,
   "attributes": {
-    "num_classes": 25,
-    "train_samples": 980,
+    "num_classes": 11,
+    "train_samples": 6351,
     "train_sample_paths": [
-      "check_dataset/demo_img/train_0001.jpg",
-      "check_dataset/demo_img/train_0002.jpg",
-      "check_dataset/demo_img/train_0003.jpg"
+      "check_dataset\/demo_img\/train_4141.jpg",
+      "check_dataset\/demo_img\/train_3699.jpg",
+      "check_dataset\/demo_img\/train_3764.jpg",
+      "check_dataset\/demo_img\/train_2279.jpg",
+      "check_dataset\/demo_img\/train_4647.jpg",
+      "check_dataset\/demo_img\/train_4442.jpg",
+      "check_dataset\/demo_img\/train_2006.jpg",
+      "check_dataset\/demo_img\/train_1463.jpg",
+      "check_dataset\/demo_img\/train_3275.jpg",
+      "check_dataset\/demo_img\/train_4509.jpg"
     ],
-    "val_samples": 200,
+    "val_samples": 945,
     "val_sample_paths": [
-      "check_dataset/demo_img/val_0001.jpg",
-      "check_dataset/demo_img/val_0002.jpg",
-      "check_dataset/demo_img/val_0003.jpg"
+      "check_dataset\/demo_img\/val_0105.jpg",
+      "check_dataset\/demo_img\/val_0031.jpg",
+      "check_dataset\/demo_img\/val_0755.jpg",
+      "check_dataset\/demo_img\/val_0876.jpg",
+      "check_dataset\/demo_img\/val_0374.jpg",
+      "check_dataset\/demo_img\/val_0566.jpg",
+      "check_dataset\/demo_img\/val_0748.jpg",
+      "check_dataset\/demo_img\/val_0167.jpg",
+      "check_dataset\/demo_img\/val_0345.jpg",
+      "check_dataset\/demo_img\/val_0471.jpg"
     ],
     "read_order_validation": {
       "instance_train": {
-        "total_images": 980,
-        "valid_images": 980,
+        "total_images": 500,
+        "valid_images": 500,
         "invalid_images": [],
         "pass_rate": 1.0
       },
       "instance_val": {
-        "total_images": 200,
-        "valid_images": 200,
+        "total_images": 100,
+        "valid_images": 100,
         "invalid_images": [],
         "pass_rate": 1.0
       }
     }
   },
   "analysis": {
-    "histogram": "check_dataset/histogram.png"
+    "histogram": "check_dataset\/histogram.png"
   },
   "dataset_path": "doclayoutv3_examples",
   "show_type": "image",
@@ -475,7 +489,7 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
 </code></pre>
 <p>上述校验结果中，<code>check_pass</code> 为 <code>True</code> 表示数据集格式符合要求，其他部分指标的说明如下：</p>
 <ul>
-<li><code>attributes.num_classes</code>：该数据集类别数为25；</li>
+<li><code>attributes.num_classes</code>：该数据集类别数为11；</li>
 <li><code>attributes.train_samples</code>：该数据集训练集样本数量；</li>
 <li><code>attributes.val_samples</code>：该数据集验证集样本数量；</li>
 <li><code>attributes.train_sample_paths</code>：该数据集训练集样本可视化图片相对路径列表；</li>
@@ -529,7 +543,8 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
 ```bash
 python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
     -o Global.mode=train \
-    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
+    -o Train.num_classes=11
 ```
 
 需要如下几步：
@@ -575,7 +590,7 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
 
 <details><summary>👉 <b>更多说明（点击展开）</b></summary>
 <p>在模型评估时，需要指定模型权重文件路径，每个配置文件中都内置了默认的权重保存路径，如需要改变，只需要通过追加命令行参数的形式进行设置即可，如<code>-o Evaluate.weight_path=./output/best_model/best_model/model.pdparams</code>。</p>
-<p>在完成模型评估后，会产出 <code>evaluate_result.json</code>，其记录了评估的结果，具体来说，记录了评估任务是否正常完成，以及模型的评估指标，包含 mask AP 等。</p></details>
+<p>在完成模型评估后，会产出 <code>evaluate_result.json</code>，其记录了评估的结果，具体来说，记录了评估任务是否正常完成，以及模型的评估指标。</p></details>
 
 ### 4.4 模型推理
 

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
@@ -543,8 +543,7 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
 ```bash
 python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
     -o Global.mode=train \
-    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
-    -o Train.num_classes=11
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
 ```
 
 需要如下几步：

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
@@ -10,6 +10,8 @@ comments: true
 
 版面分析模块目前支持模型 PP-DocLayoutV3，基于 DETR 架构并以 PPHGNetV2-L 为骨干网络，在实例分割任务之上增加了**阅读顺序预测**分支，可端到端学习文档元素的阅读顺序关系。
 
+![版面分析效果](https://raw.githubusercontent.com/cuicheng01/PaddleX_doc_images/refs/heads/main/images/modules/layout_analysis/layout_analysis.png)
+
 ## 二、支持模型列表
 
 > 推理耗时仅包含模型推理耗时，不包含前后处理耗时。
@@ -20,9 +22,7 @@ comments: true
 <thead>
 <tr>
 <th>模型</th><th>模型下载链接</th>
-<th>mAP(0.5)（%）</th>
-<th>GPU推理耗时（ms）<br/>[常规模式 / 高性能模式]</th>
-<th>CPU推理耗时（ms）<br/>[常规模式 / 高性能模式]</th>
+<th>GPU推理耗时（ms）<br/>A100 GPU</th>
 <th>模型存储大小（MB）</th>
 <th>介绍</th>
 </tr>
@@ -31,10 +31,8 @@ comments: true
 <tr>
 <td>PP-DocLayoutV3</td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayoutV3_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams">训练模型</a></td>
-<td>-</td>
-<td>- / -</td>
-<td>- / -</td>
-<td>-</td>
+<td>23.77</td>
+<td>126</td>
 <td>基于DETR在包含中英文论文、多栏杂志、报纸、PPT、合同、书本、试卷、研报等场景的自建数据集上训练的版面分析模型，支持25类版面元素的实例分割及阅读顺序预测</td>
 </tr>
 </tbody>
@@ -46,14 +44,14 @@ comments: true
 
 > ❗ 在快速集成前，请先安装 PaddleX 的 wheel 包，详细请参考 [PaddleX本地安装教程](../../../installation/installation.md)
 
-完成 whl 包的安装后，几行代码即可完成版面分析模块的推理，可以任意切换该模块下的模型，您也可以将版面分析模块中的模型推理集成到您的项目中。运行以下代码前，请您下载[示例图片](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg)到本地。
+完成 whl 包的安装后，几行代码即可完成版面分析模块的推理，可以任意切换该模块下的模型，您也可以将版面分析模块中的模型推理集成到您的项目中。运行以下代码前，请您下载[示例图片](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout_analysis_demo.jpg)到本地。
 
 ```python
 from paddlex import create_model
 
 model_name = "PP-DocLayoutV3"
 model = create_model(model_name=model_name)
-output = model.predict("layout.jpg", batch_size=1)
+output = model.predict("layout_analysis_demo.jpg", batch_size=1)
 
 for res in output:
     res.print()
@@ -80,6 +78,10 @@ for res in output:
   - `polygon_points`：实例分割轮廓点列表，格式为<code>[[x1, y1], [x2, y2], ...]</code>
   - `order`：阅读顺序编号，一个整数，表示该区域在文档中的阅读顺序（从0开始）
 </details>
+
+运行后，`save_to_img()` 保存的可视化结果如下，图中标注了各区域的类别、置信度、实例分割掩码及阅读顺序编号：
+
+![版面分析可视化结果](https://raw.githubusercontent.com/cuicheng01/PaddleX_doc_images/refs/heads/main/images/modules/layout_analysis/layout_analysis_demo_res.jpg)
 
 相关方法、参数等说明如下：
 
@@ -182,20 +184,6 @@ for res in output:
 </ul>
 </td>
 <td>None</td>
-</tr>
-<tr>
-<td><code>use_hpip</code></td>
-<td>是否启用高性能推理插件</td>
-<td><code>bool</code></td>
-<td>无</td>
-<td><code>False</code></td>
-</tr>
-<tr>
-<td><code>hpi_config</code></td>
-<td>高性能推理配置</td>
-<td><code>dict</code> | <code>None</code></td>
-<td>无</td>
-<td><code>None</code></td>
 </tr>
 </table>
 
@@ -621,10 +609,8 @@ python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
 
 1. <b>产线集成</b>
 
-版面分析模块可以集成到PaddleX的[文档场景信息抽取v3产线（PP-ChatOCRv3-doc）](../../../pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md)等产线中，只需要替换模型路径即可完成版面分析模块的模型更新。在产线集成中，你可以使用高性能部署和服务化部署来部署你得到的模型。
+版面分析模块可以集成到PaddleX的[文档解析产线（PaddleOCR-VL）](../../../pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.md)等产线中，只需要替换模型路径即可完成版面分析模块的模型更新。
 
 2. <b>模块集成</b>
 
 您产出的权重可以直接集成到版面分析模块中，可以参考[快速集成](#三快速集成)的 Python 示例代码，只需要将模型替换为你训练的到的模型路径即可。
-
-您也可以利用 PaddleX 高性能推理插件来优化您模型的推理过程，进一步提升效率，详细的流程请参考[PaddleX高性能推理指南](../../../pipeline_deploy/high_performance_inference.md)。

--- a/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
+++ b/docs/module_usage/tutorials/ocr_modules/layout_analysis.md
@@ -1,0 +1,616 @@
+---
+comments: true
+---
+
+# 版面分析模块使用教程
+
+## 一、概述
+
+版面分析任务在版面区域检测的基础上，进一步引入了**实例分割**与**阅读顺序预测**能力。通过对输入的文档图像进行内容解析与区域划分，模型不仅能识别各类版面元素（如文字、图表、图像、公式、段落标题、摘要、参考文献等）并输出其边界框，还能同时输出每个区域的**精确轮廓掩码**和**阅读顺序编号**，为文档理解与信息抽取流程提供更完整的结构化信息。
+
+版面分析模块目前支持的模型 PP-DocLayoutV3，基于 DETR 架构并以 PPHGNetV2-L 为骨干网络，在实例分割任务之上增加了 `order_loss` 分支，可同步学习文档元素的阅读顺序关系。
+
+## 二、支持模型列表
+
+> 推理耗时仅包含模型推理耗时，不包含前后处理耗时。
+
+* <b>版面分析模型，包含25个常见类别：摘要、算法、侧栏文本、图表、目录、行间公式、文档标题、图表标题、页脚、页脚图像、脚注、公式编号、页眉、页眉图像、图像、行内公式、页码、段落标题、参考文献、参考文献内容、印章、表格、文本、竖版文字、图注</b>
+
+<table>
+<thead>
+<tr>
+<th>模型</th><th>模型下载链接</th>
+<th>mAP(0.5)（%）</th>
+<th>GPU推理耗时（ms）<br/>[常规模式 / 高性能模式]</th>
+<th>CPU推理耗时（ms）<br/>[常规模式 / 高性能模式]</th>
+<th>模型存储大小（MB）</th>
+<th>介绍</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>PP-DocLayoutV3</td>
+<td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayoutV3_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams">训练模型</a></td>
+<td>-</td>
+<td>- / -</td>
+<td>- / -</td>
+<td>-</td>
+<td>基于DETR（PPHGNetV2-L骨干）在包含中英文论文、多栏杂志、报纸、PPT、合同、书本、试卷、研报等场景的自建数据集上训练的版面分析模型，支持25类版面元素的实例分割及阅读顺序预测</td>
+</tr>
+</tbody>
+</table>
+
+<b>注：以上精度指标的评估集为自建的版面分析数据集，包含中英文多种文档场景图片。</b>
+
+## 三、快速集成
+
+> ❗ 在快速集成前，请先安装 PaddleX 的 wheel 包，详细请参考 [PaddleX本地安装教程](../../../installation/installation.md)
+
+完成 whl 包的安装后，几行代码即可完成版面分析模块的推理，可以任意切换该模块下的模型，您也可以将版面分析模块中的模型推理集成到您的项目中。运行以下代码前，请您下载[示例图片](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg)到本地。
+
+```python
+from paddlex import create_model
+
+model_name = "PP-DocLayoutV3"
+model = create_model(model_name=model_name)
+output = model.predict("layout.jpg", batch_size=1)
+
+for res in output:
+    res.print()
+    res.save_to_img(save_path="./output/")
+    res.save_to_json(save_path="./output/res.json")
+```
+
+<b>注：</b>PaddleX 支持多个模型托管平台，官方模型默认优先从 HuggingFace 下载。PaddleX 也支持通过环境变量 `PADDLE_PDX_MODEL_SOURCE` 设置优先使用的托管平台，目前支持 `huggingface`、`aistudio`、`bos`、`modelscope`，如优先使用 `bos`：`PADDLE_PDX_MODEL_SOURCE="bos"`；
+
+<details><summary>👉 <b>运行后，得到的结果为：（点击展开）</b></summary>
+
+```bash
+{'res': {'input_path': 'layout.jpg', 'page_index': None, 'boxes': [{'cls_id': 22, 'label': 'text', 'score': 0.98, 'coordinate': [34.1, 349.8, 358.5, 611.0], 'polygon_points': [[34.1, 349.8], [358.5, 349.8], [358.5, 611.0], [34.1, 611.0]], 'order': 3}, ...]}}
+```
+
+参数含义如下：
+- `input_path`：输入的待预测图像的路径
+- `page_index`：如果输入是PDF文件，则表示当前是PDF的第几页，否则为 `None`
+- `boxes`：预测的目标框信息，一个字典列表。每个字典代表一个检出的目标，包含以下信息：
+  - `cls_id`：类别ID，一个整数
+  - `label`：类别标签，一个字符串
+  - `score`：目标框置信度，一个浮点数
+  - `coordinate`：目标框坐标，一个浮点数列表，格式为<code>[xmin, ymin, xmax, ymax]</code>
+  - `polygon_points`：实例分割轮廓点列表，格式为<code>[[x1, y1], [x2, y2], ...]</code>
+  - `order`：阅读顺序编号，一个整数，表示该区域在文档中的阅读顺序（从0开始）
+</details>
+
+相关方法、参数等说明如下：
+
+* `create_model` 实例化版面分析模型（此处以 `PP-DocLayoutV3` 为例），具体说明如下：
+
+<table>
+<thead>
+<tr>
+<th>参数</th>
+<th>参数说明</th>
+<th>参数类型</th>
+<th>可选项</th>
+<th>默认值</th>
+</tr>
+</thead>
+<tr>
+<td><code>model_name</code></td>
+<td>模型名称</td>
+<td><code>str</code></td>
+<td>无</td>
+<td>无</td>
+</tr>
+<tr>
+<td><code>model_dir</code></td>
+<td>模型存储路径</td>
+<td><code>str</code></td>
+<td>无</td>
+<td>无</td>
+</tr>
+<tr>
+<td><code>device</code></td>
+<td>模型推理设备</td>
+<td><code>str</code></td>
+<td>支持指定GPU具体卡号，如"gpu:0"，其他硬件具体卡号，如"npu:0"，CPU如"cpu"。</td>
+<td><code>gpu:0</code></td>
+</tr>
+<tr>
+<td><code>img_size</code></td>
+<td>输入图像大小；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td><code>int/list/None</code></td>
+<td>
+<ul>
+<li><b>int</b>, 如 800，表示将输入图像resize到800x800大小</li>
+<li><b>列表</b>, 如 [800, 800]，表示将输入图像resize到宽为800、高为800大小</li>
+<li><b>None</b>，不指定，将默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>threshold</code></td>
+<td>用于过滤掉低置信度预测结果的阈值；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td><code>float/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>，如 0.5，表示过滤掉所有置信度小于0.5的目标框</li>
+<li><b>字典</b>，字典的key为<b>int</b>类型，代表<code>cls_id</code>，val为<b>float</b>类型阈值，如 <code>{0: 0.45, 2: 0.48}</code></li>
+<li><b>None</b>，不指定，将默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_nms</code></td>
+<td>是否使用NMS后处理，过滤重叠框；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td><code>bool/None</code></td>
+<td>
+<ul>
+<li><b>bool</b>，True/False，表示使用/不使用NMS进行检测框的后处理过滤</li>
+<li><b>None</b>，不指定，将默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_unclip_ratio</code></td>
+<td>检测框的边长缩放倍数；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td><code>float/list/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>，大于0的浮点数，如 1.1，表示将检测框中心不变、宽和高都扩张1.1倍</li>
+<li><b>列表</b>，如 [1.2, 1.5]，表示宽度扩张1.2倍、高度扩张1.5倍</li>
+<li><b>字典</b>，key为<b>int</b>类型的<code>cls_id</code>，value为<b>tuple</b>，如 <code>{0: (1.1, 2.0)}</code></li>
+<li><b>None</b>，不指定，将默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>layout_merge_bboxes_mode</code></td>
+<td>模型输出的检测框的合并处理模式；如果不指定，将默认使用PaddleX官方模型配置</td>
+<td><code>string/dict/None</code></td>
+<td>
+<ul>
+<li><b>large</b>，对互相重叠包含的检测框，只保留外部最大的框</li>
+<li><b>small</b>，对互相重叠包含的检测框，只保留内部被包含的小框</li>
+<li><b>union</b>，不进行框的过滤处理，内外框都保留</li>
+<li><b>dict</b>，key为<b>int</b>类型的<code>cls_id</code>，value为<b>str</b>，如 <code>{0: "large", 2: "small"}</code></li>
+<li><b>None</b>，不指定，将默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+<tr>
+<td><code>use_hpip</code></td>
+<td>是否启用高性能推理插件</td>
+<td><code>bool</code></td>
+<td>无</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>hpi_config</code></td>
+<td>高性能推理配置</td>
+<td><code>dict</code> | <code>None</code></td>
+<td>无</td>
+<td><code>None</code></td>
+</tr>
+</table>
+
+* 其中，`model_name` 必须指定，指定 `model_name` 后，默认使用 PaddleX 内置的模型参数，在此基础上，指定 `model_dir` 时，使用用户自定义的模型。
+
+* 调用版面分析模型的 `predict()` 方法进行推理预测，`predict()` 方法参数有 `input`、`batch_size` 和 `threshold`，具体说明如下：
+
+<table>
+<thead>
+<tr>
+<th>参数</th>
+<th>参数说明</th>
+<th>参数类型</th>
+<th>可选项</th>
+<th>默认值</th>
+</tr>
+</thead>
+<tr>
+<td><code>input</code></td>
+<td>待预测数据，支持多种输入类型</td>
+<td><code>Python Var</code>/<code>str</code>/<code>list</code></td>
+<td>
+<ul>
+  <li><b>Python变量</b>，如<code>numpy.ndarray</code>表示的图像数据</li>
+  <li><b>文件路径</b>，如图像文件的本地路径：<code>/root/data/img.jpg</code></li>
+  <li><b>URL链接</b>，如图像文件的网络URL</li>
+  <li><b>本地目录</b>，该目录下需包含待预测数据文件，如本地路径：<code>/root/data/</code></li>
+  <li><b>列表</b>，列表元素需为上述类型数据，如<code>[numpy.ndarray, numpy.ndarray]</code>，<code>["/root/data/img1.jpg", "/root/data/img2.jpg"]</code></li>
+</ul>
+</td>
+<td>无</td>
+</tr>
+<tr>
+<td><code>batch_size</code></td>
+<td>批大小</td>
+<td><code>int</code></td>
+<td>大于0的任意整数</td>
+<td>1</td>
+</tr>
+<tr>
+<td><code>threshold</code></td>
+<td>用于过滤掉低置信度预测结果的阈值</td>
+<td><code>float/dict/None</code></td>
+<td>
+<ul>
+<li><b>float</b>，如 0.5，表示过滤掉所有置信度小于0.5的目标框</li>
+<li><b>字典</b>，字典的key为<b>int</b>类型，代表<code>cls_id</code>，val为<b>float</b>类型阈值</li>
+<li><b>None</b>，不指定，将默认使用 <code>create_model</code> 指定的 <code>threshold</code> 参数，如果 <code>create_model</code> 也没有指定，则默认使用PaddleX官方模型配置</li>
+</ul>
+</td>
+<td>None</td>
+</tr>
+</table>
+
+* 对预测结果进行处理，每个样本的预测结果均为对应的Result对象，且支持打印、保存为图片、保存为 `json` 文件的操作：
+
+<table>
+<thead>
+<tr>
+<th>方法</th>
+<th>方法说明</th>
+<th>参数</th>
+<th>参数类型</th>
+<th>参数说明</th>
+<th>默认值</th>
+</tr>
+</thead>
+<tr>
+<td rowspan="3"><code>print()</code></td>
+<td rowspan="3">打印结果到终端</td>
+<td><code>format_json</code></td>
+<td><code>bool</code></td>
+<td>是否对输出内容进行使用 <code>JSON</code> 缩进格式化</td>
+<td><code>True</code></td>
+</tr>
+<tr>
+<td><code>indent</code></td>
+<td><code>int</code></td>
+<td>指定缩进级别，以美化输出的 <code>JSON</code> 数据，仅当 <code>format_json</code> 为 <code>True</code> 时有效</td>
+<td>4</td>
+</tr>
+<tr>
+<td><code>ensure_ascii</code></td>
+<td><code>bool</code></td>
+<td>控制是否将非 <code>ASCII</code> 字符转义为 <code>Unicode</code>，仅当 <code>format_json</code> 为 <code>True</code> 时有效</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td rowspan="3"><code>save_to_json()</code></td>
+<td rowspan="3">将结果保存为json格式的文件</td>
+<td><code>save_path</code></td>
+<td><code>str</code></td>
+<td>保存的文件路径，当为目录时，保存文件命名与输入文件类型命名一致</td>
+<td>无</td>
+</tr>
+<tr>
+<td><code>indent</code></td>
+<td><code>int</code></td>
+<td>指定缩进级别，以美化输出的 <code>JSON</code> 数据，仅当 <code>format_json</code> 为 <code>True</code> 时有效</td>
+<td>4</td>
+</tr>
+<tr>
+<td><code>ensure_ascii</code></td>
+<td><code>bool</code></td>
+<td>控制是否将非 <code>ASCII</code> 字符转义为 <code>Unicode</code>，仅当 <code>format_json</code> 为 <code>True</code> 时有效</td>
+<td><code>False</code></td>
+</tr>
+<tr>
+<td><code>save_to_img()</code></td>
+<td>将结果保存为图像格式的文件（可视化图像含实例分割掩码与阅读顺序编号）</td>
+<td><code>save_path</code></td>
+<td><code>str</code></td>
+<td>保存的文件路径，当为目录时，保存文件命名与输入文件类型命名一致</td>
+<td>无</td>
+</tr>
+</table>
+
+* 此外，也支持通过属性获取带结果的可视化图像和预测结果，具体如下：
+
+<table>
+<thead>
+<tr>
+<th>属性</th>
+<th>属性说明</th>
+</tr>
+</thead>
+<tr>
+<td rowspan="1"><code>json</code></td>
+<td rowspan="1">获取预测的<code>json</code>格式的结果</td>
+</tr>
+<tr>
+<td rowspan="1"><code>img</code></td>
+<td rowspan="1">获取格式为<code>dict</code>的可视化图像，图像中标注了各区域的类别、置信度、实例分割掩码及阅读顺序编号</td>
+</tr>
+</table>
+
+关于更多 PaddleX 的单模型推理的 API 的使用方法，可以参考[PaddleX单模型Python脚本使用说明](../../instructions/model_python_API.md)。
+
+
+## 四、二次开发
+
+如果你追求更高精度的现有模型，可以使用PaddleX的二次开发能力，开发更好的版面分析模型。在使用PaddleX开发版面分析模型之前，请务必安装PaddleX的Detection相关的模型训练能力，安装过程可以参考[PaddleX本地安装教程](../../../installation/installation.md)。
+
+### 4.1 数据准备
+
+在进行模型训练前，需要准备相应任务模块的数据集。PaddleX 针对每一个模块提供了数据校验功能，**只有通过数据校验的数据才可以进行模型训练**。此外，PaddleX为每一个模块都提供了Demo数据集，您可以基于官方提供的 Demo 数据完成后续的开发。若您希望用私有数据集进行后续的模型训练，可以参考[PaddleX目标检测任务模块数据标注教程](../../../data_annotations/cv_modules/object_detection.md)。
+
+#### 4.1.1 Demo 数据下载
+
+您可以参考下面的命令将 Demo 数据集下载到指定文件夹：
+
+```bash
+cd /path/to/paddlex
+wget https://paddle-model-ecology.bj.bcebos.com/paddlex/data/doclayoutv3_examples.tar -P ./dataset
+tar -xf ./dataset/doclayoutv3_examples.tar -C ./dataset/
+```
+
+#### 4.1.2 数据集格式说明
+
+版面分析模块使用 **COCOInstSegDataset** 格式，数据集目录结构如下：
+
+```
+doclayoutv3_examples/
+├── images/               # 原始图像目录
+│   ├── train_0001.jpg
+│   ├── val_0001.jpg
+│   └── ...
+├── images_mask/          # 用于训练的图像目录（与 images 内容相同）
+│   └── ...
+└── annotations/
+    ├── instance_train.json   # 训练集标注（COCO实例分割格式 + read_order字段）
+    └── instance_val.json     # 验证集标注（COCO实例分割格式 + read_order字段）
+```
+
+标注文件遵循 COCO 实例分割格式，并在每条标注中增加了 `read_order` 字段，用于记录该区域在文档中的阅读顺序（从0开始的非负整数，同一图像内各标注的 `read_order` 值应构成连续序列）。示例标注如下：
+
+```json
+{
+  "annotations": [
+    {
+      "id": 1,
+      "image_id": 1,
+      "category_id": 22,
+      "bbox": [34.1, 349.8, 324.4, 261.2],
+      "segmentation": [[34.1, 349.8, 358.5, 349.8, 358.5, 611.0, 34.1, 611.0]],
+      "area": 84740.0,
+      "iscrowd": 0,
+      "read_order": 0
+    }
+  ]
+}
+```
+
+模型支持的25个类别及其ID（与 `categories` 中的 `id` 对应）如下：
+
+| 类别名（英文） | 类别含义 |
+|---|---|
+| `abstract` | 摘要 |
+| `algorithm` | 算法 |
+| `aside_text` | 侧栏文本 |
+| `chart` | 图表 |
+| `content` | 目录 |
+| `display_formula` | 行间公式 |
+| `doc_title` | 文档标题 |
+| `figure_title` | 图表标题 |
+| `footer` | 页脚 |
+| `footer_image` | 页脚图像 |
+| `footnote` | 脚注 |
+| `formula_number` | 公式编号 |
+| `header` | 页眉 |
+| `header_image` | 页眉图像 |
+| `image` | 图像 |
+| `inline_formula` | 行内公式 |
+| `number` | 页码 |
+| `paragraph_title` | 段落标题 |
+| `reference` | 参考文献 |
+| `reference_content` | 参考文献内容 |
+| `seal` | 印章 |
+| `table` | 表格 |
+| `text` | 文本 |
+| `vertical_text` | 竖版文字 |
+| `vision_footnote` | 图注 |
+
+#### 4.1.3 数据校验
+
+一行命令即可完成数据校验：
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+```
+
+执行上述命令后，PaddleX 会对数据集进行校验，并统计数据集的基本信息，命令运行成功后会在log中打印出 `Check dataset passed !` 信息。校验结果文件保存在 `./output/check_dataset_result.json`，同时相关产出会保存在当前目录的 `./output/check_dataset` 目录下，产出目录中包括可视化的示例样本图片（标注了实例分割掩码与阅读顺序编号）和样本分布直方图。
+
+<details><summary>👉 <b>校验结果详情（点击展开）</b></summary>
+<p>校验结果文件具体内容为：</p>
+<pre><code class="language-bash">{
+  "done_flag": true,
+  "check_pass": true,
+  "attributes": {
+    "num_classes": 25,
+    "train_samples": 980,
+    "train_sample_paths": [
+      "check_dataset/demo_img/train_0001.jpg",
+      "check_dataset/demo_img/train_0002.jpg",
+      "check_dataset/demo_img/train_0003.jpg"
+    ],
+    "val_samples": 200,
+    "val_sample_paths": [
+      "check_dataset/demo_img/val_0001.jpg",
+      "check_dataset/demo_img/val_0002.jpg",
+      "check_dataset/demo_img/val_0003.jpg"
+    ],
+    "read_order_validation": {
+      "instance_train": {
+        "total_images": 980,
+        "valid_images": 980,
+        "invalid_images": [],
+        "pass_rate": 1.0
+      },
+      "instance_val": {
+        "total_images": 200,
+        "valid_images": 200,
+        "invalid_images": [],
+        "pass_rate": 1.0
+      }
+    }
+  },
+  "analysis": {
+    "histogram": "check_dataset/histogram.png"
+  },
+  "dataset_path": "doclayoutv3_examples",
+  "show_type": "image",
+  "dataset_type": "COCOInstSegDataset"
+}
+</code></pre>
+<p>上述校验结果中，<code>check_pass</code> 为 <code>True</code> 表示数据集格式符合要求，其他部分指标的说明如下：</p>
+<ul>
+<li><code>attributes.num_classes</code>：该数据集类别数为25；</li>
+<li><code>attributes.train_samples</code>：该数据集训练集样本数量；</li>
+<li><code>attributes.val_samples</code>：该数据集验证集样本数量；</li>
+<li><code>attributes.train_sample_paths</code>：该数据集训练集样本可视化图片相对路径列表；</li>
+<li><code>attributes.val_sample_paths</code>：该数据集验证集样本可视化图片相对路径列表；</li>
+<li><code>attributes.read_order_validation</code>：<code>read_order</code> 字段验证统计，包含训练集和验证集各自的总图像数、通过验证的图像数及通过率。</li>
+</ul>
+<p>数据校验还对数据集中所有类别的样本数量分布情况进行了分析，并绘制了分布直方图（histogram.png）。</p>
+
+<b>注意：</b>版面分析数据校验会额外验证每张图像标注中的 <code>read_order</code> 字段：
+<ul>
+<li>完整性：每条标注必须含有 <code>read_order</code> 字段；</li>
+<li>类型合法性：<code>read_order</code> 必须为非负整数；</li>
+<li>连续性：同一图像内各标注的 <code>read_order</code> 应构成从0开始的连续整数序列（如不连续会给出警告）。</li>
+</ul>
+</details>
+
+#### 4.1.4 数据集格式转换/数据集划分（可选）
+
+在您完成数据校验之后，可以通过**修改配置文件**或是**追加超参数**的方式对数据集的训练/验证比例进行重新划分。
+
+<details><summary>👉 <b>数据集划分详情（点击展开）</b></summary>
+<p><b>（1）数据集格式转换</b></p>
+<p>版面分析暂不支持数据格式转换，请直接使用 COCO 实例分割格式（含 <code>read_order</code> 字段）。</p>
+<p><b>（2）数据集划分</b></p>
+<p>数据集划分的参数可以通过修改配置文件中 <code>CheckDataset</code> 下的字段进行设置：</p>
+<pre><code class="language-bash">CheckDataset:
+  split:
+    enable: True
+    train_percent: 90
+    val_percent: 10
+</code></pre>
+<p>随后执行命令：</p>
+<pre><code class="language-bash">python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+</code></pre>
+<p>数据划分执行之后，原有标注文件会被在原路径下重命名为 <code>xxx.bak</code>。</p>
+<p>以上参数同样支持通过追加命令行参数的方式进行设置：</p>
+<pre><code>python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=check_dataset \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples \
+    -o CheckDataset.split.enable=True \
+    -o CheckDataset.split.train_percent=90 \
+    -o CheckDataset.split.val_percent=10
+</code></pre></details>
+
+### 4.2 模型训练
+
+一条命令即可完成模型的训练，以训练 `PP-DocLayoutV3` 为例：
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=train \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+```
+
+需要如下几步：
+
+* 指定模型的 `.yaml` 配置文件路径（此处为 `PP-DocLayoutV3.yaml`）
+* 指定模式为模型训练：`-o Global.mode=train`
+* 指定训练数据集路径：`-o Global.dataset_dir`
+* 其他相关参数均可通过修改 `.yaml` 配置文件中的 `Global` 和 `Train` 下的字段来进行设置，也可以通过在命令行中追加参数来进行调整。如指定前2卡gpu训练：`-o Global.device=gpu:0,1`；设置训练轮次数为10：`-o Train.epochs_iters=10`。更多可修改的参数及其详细解释，可以查阅模型对应任务模块的配置文件说明[PaddleX通用模型配置文件参数说明](../../instructions/config_parameters_common.md)。
+
+<details><summary>👉 <b>更多说明（点击展开）</b></summary>
+<ul>
+<li>模型训练过程中，PaddleX 会自动保存模型权重文件，默认为<code>output</code>，如需指定保存路径，可通过配置文件中 <code>-o Global.output</code> 字段进行设置。</li>
+<li>PaddleX 对您屏蔽了动态图权重和静态图权重的概念。在模型训练的过程中，会同时产出动态图和静态图的权重，在模型推理时，默认选择静态图权重推理。</li>
+<li>
+<p>在完成模型训练后，所有产出保存在指定的输出目录（默认为<code>./output/</code>）下，通常有以下产出：</p>
+</li>
+<li>
+<p><code>train_result.json</code>：训练结果记录文件，记录了训练任务是否正常完成，以及产出的权重指标、相关文件路径等；</p>
+</li>
+<li><code>train.log</code>：训练日志文件，记录了训练过程中的模型指标变化、loss 变化等；</li>
+<li><code>config.yaml</code>：训练配置文件，记录了本次训练的超参数的配置；</li>
+<li><code>.pdparams</code>、<code>.pdema</code>、<code>.pdopt.pdstate</code>、<code>.pdiparams</code>、<code>.json</code>：模型权重相关文件，包括网络参数、优化器、EMA、静态图网络参数、静态图网络结构等；</li>
+<li>【注意】：版面分析模型在训练时使用了 <code>order_loss</code> 分支（权重系数为50），该损失项用于监督阅读顺序预测，训练日志中可以看到 <code>order_loss</code> 的变化情况。</li>
+</ul></details>
+
+### 4.3 模型评估
+
+在完成模型训练后，可以对指定的模型权重文件在验证集上进行评估，验证模型精度。使用 PaddleX 进行模型评估，一条命令即可完成模型的评估：
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=evaluate \
+    -o Global.dataset_dir=./dataset/doclayoutv3_examples
+```
+
+与模型训练类似，需要如下几步：
+
+* 指定模型的 `.yaml` 配置文件路径（此处为 `PP-DocLayoutV3.yaml`）
+* 指定模式为模型评估：`-o Global.mode=evaluate`
+* 指定验证数据集路径：`-o Global.dataset_dir`
+
+其他相关参数均可通过修改 `.yaml` 配置文件中的 `Global` 和 `Evaluate` 下的字段来进行设置，详细请参考[PaddleX通用模型配置文件参数说明](../../instructions/config_parameters_common.md)。
+
+<details><summary>👉 <b>更多说明（点击展开）</b></summary>
+<p>在模型评估时，需要指定模型权重文件路径，每个配置文件中都内置了默认的权重保存路径，如需要改变，只需要通过追加命令行参数的形式进行设置即可，如<code>-o Evaluate.weight_path=./output/best_model/best_model/model.pdparams</code>。</p>
+<p>在完成模型评估后，会产出 <code>evaluate_result.json</code>，其记录了评估的结果，具体来说，记录了评估任务是否正常完成，以及模型的评估指标，包含 mask AP 等。</p></details>
+
+### 4.4 模型推理
+
+在完成模型的训练和评估后，即可使用训练好的模型权重进行推理预测。在PaddleX中实现模型推理预测可以通过两种方式：命令行和wheel包。
+
+#### 4.4.1 模型推理
+
+* 通过命令行的方式进行推理预测，只需如下一条命令。运行以下代码前，请您下载[示例图片](https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg)到本地。
+
+```bash
+python main.py -c paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml \
+    -o Global.mode=predict \
+    -o Predict.model_dir="./output/best_model/inference" \
+    -o Predict.input="layout.jpg"
+```
+
+与模型训练和评估类似，需要如下几步：
+
+* 指定模型的 `.yaml` 配置文件路径（此处为 `PP-DocLayoutV3.yaml`）
+* 指定模式为模型推理预测：`-o Global.mode=predict`
+* 指定模型权重路径：`-o Predict.model_dir="./output/best_model/inference"`
+* 指定输入数据路径：`-o Predict.input="..."`
+
+其他相关参数均可通过修改 `.yaml` 配置文件中的 `Global` 和 `Predict` 下的字段来进行设置，详细请参考[PaddleX通用模型配置文件参数说明](../../instructions/config_parameters_common.md)。
+
+#### 4.4.2 模型集成
+
+模型可以直接集成到PaddleX产线中，也可以直接集成到您自己的项目中。
+
+1. <b>产线集成</b>
+
+版面分析模块可以集成到PaddleX的[文档场景信息抽取v3产线（PP-ChatOCRv3-doc）](../../../pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md)等产线中，只需要替换模型路径即可完成版面分析模块的模型更新。在产线集成中，你可以使用高性能部署和服务化部署来部署你得到的模型。
+
+2. <b>模块集成</b>
+
+您产出的权重可以直接集成到版面分析模块中，可以参考[快速集成](#三快速集成)的 Python 示例代码，只需要将模型替换为你训练的到的模型路径即可。
+
+您也可以利用 PaddleX 高性能推理插件来优化您模型的推理过程，进一步提升效率，详细的流程请参考[PaddleX高性能推理指南](../../../pipeline_deploy/high_performance_inference.md)。

--- a/paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml
+++ b/paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml
@@ -15,7 +15,7 @@ CheckDataset:
     val_percent: null
 
 Train:
-  num_classes: 25
+  num_classes: 11
   epochs_iters: 100
   batch_size: 4
   learning_rate: 0.0001

--- a/paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml
+++ b/paddlex/configs/modules/layout_analysis/PP-DocLayoutV3.yaml
@@ -1,0 +1,40 @@
+Global:
+  model: PP-DocLayoutV3
+  mode: check_dataset # check_dataset/train/evaluate/predict
+  dataset_dir: "./dataset/doclayoutv3_examples"
+  device: gpu:0,1,2,3
+  output: "output"
+
+CheckDataset:
+  convert:
+    enable: False
+    src_dataset_type: null
+  split:
+    enable: False
+    train_percent: null
+    val_percent: null
+
+Train:
+  num_classes: 25
+  epochs_iters: 100
+  batch_size: 4
+  learning_rate: 0.0001
+  pretrain_weight_path: https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams
+  warmup_steps: 100
+  resume_path: null
+  log_interval: 10
+  eval_interval: 1
+
+Evaluate:
+  weight_path: "output/best_model/best_model.pdparams"
+  log_interval: 10
+
+Export:
+  weight_path: https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayoutV3_pretrained.pdparams
+
+Predict:
+  batch_size: 1
+  model_dir: "output/best_model/inference"
+  input: "https://paddle-model-ecology.bj.bcebos.com/paddlex/imgs/demo_image/layout.jpg"
+  kernel_option:
+    run_mode: paddle

--- a/paddlex/modules/__init__.py
+++ b/paddlex/modules/__init__.py
@@ -45,6 +45,12 @@ from .keypoint_detection import (
     KeypointExportor,
     KeypointTrainer,
 )
+from .layout_analysis import (
+    LayoutAnalysisDatasetChecker,
+    LayoutAnalysisEvaluator,
+    LayoutAnalysisExportor,
+    LayoutAnalysisTrainer,
+)
 from .m_3d_bev_detection import (
     BEVFusionDatasetChecker,
     BEVFusionEvaluator,

--- a/paddlex/modules/layout_analysis/__init__.py
+++ b/paddlex/modules/layout_analysis/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .dataset_checker import LayoutAnalysisDatasetChecker
+from .evaluator import LayoutAnalysisEvaluator
+from .exportor import LayoutAnalysisExportor
+from .trainer import LayoutAnalysisTrainer
+
+__all__ = [
+    "LayoutAnalysisDatasetChecker",
+    "LayoutAnalysisTrainer",
+    "LayoutAnalysisEvaluator",
+    "LayoutAnalysisExportor",
+]

--- a/paddlex/modules/layout_analysis/dataset_checker/__init__.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/__init__.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+
+from ...base import BaseDatasetChecker
+from ..model_list import MODELS
+from .dataset_src import check, deep_analyse, split_dataset
+
+
+class LayoutAnalysisDatasetChecker(BaseDatasetChecker):
+    """Dataset Checker for Layout Analysis Model (PP-DocLayoutV3)
+
+    PP-DocLayoutV3 is based on instance segmentation models with additional
+    'read_order' field in annotations for document layout analysis.
+    """
+
+    entities = MODELS
+    sample_num = 10
+
+    def get_dataset_root(self, dataset_dir: str) -> str:
+        """find the dataset root dir
+
+        Args:
+            dataset_dir (str): the directory that contain dataset.
+
+        Returns:
+            str: the root directory of dataset.
+        """
+        anno_dirs = list(Path(dataset_dir).glob("**/images"))
+        assert len(anno_dirs) == 1
+        dataset_dir = anno_dirs[0].parent.as_posix()
+        return dataset_dir
+
+    def convert_dataset(self, src_dataset_dir: str) -> str:
+        """convert the dataset from other type to specified type
+
+        Args:
+            src_dataset_dir (str): the root directory of dataset.
+
+        Returns:
+            str: the root directory of converted dataset.
+
+        Raises:
+            NotImplementedError: Layout Analysis only supports COCO format.
+        """
+        raise NotImplementedError(
+            "Layout Analysis dataset checker does not support dataset conversion. "
+            "Please use COCO format with 'read_order' field in annotations directly."
+        )
+
+    def split_dataset(self, src_dataset_dir: str) -> str:
+        """repartition the train and validation dataset
+
+        Args:
+            src_dataset_dir (str): the root directory of dataset.
+
+        Returns:
+            str: the root directory of splited dataset.
+        """
+        return split_dataset(
+            src_dataset_dir,
+            self.check_dataset_config.split.train_percent,
+            self.check_dataset_config.split.val_percent,
+        )
+
+    def check_dataset(self, dataset_dir: str, sample_num: int = sample_num) -> dict:
+        """check if the dataset meets the specifications and get dataset summary
+
+        Args:
+            dataset_dir (str): the root directory of dataset.
+            sample_num (int): the number to be sampled.
+        Returns:
+            dict: dataset summary including read_order validation results.
+        """
+        return check(dataset_dir, self.output)
+
+    def analyse(self, dataset_dir: str) -> dict:
+        """deep analyse dataset
+
+        Args:
+            dataset_dir (str): the root directory of dataset.
+
+        Returns:
+            dict: the deep analysis results.
+        """
+        return deep_analyse(dataset_dir, self.output)
+
+    def get_show_type(self) -> str:
+        """get the show type of dataset
+
+        Returns:
+            str: show type
+        """
+        return "image"
+
+    def get_dataset_type(self) -> str:
+        """return the dataset type
+
+        Returns:
+            str: dataset type
+        """
+        return "COCOInstSegDataset"

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/__init__.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .analyse_dataset import deep_analyse
+from .check_dataset import check
+from .split_dataset import split_dataset
+
+__all__ = ["check", "split_dataset", "deep_analyse"]

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/analyse_dataset.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/analyse_dataset.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reuse deep_analyse from instance_segmentation module
+from ....instance_segmentation.dataset_checker.dataset_src.analyse_dataset import (
+    deep_analyse,
+)
+
+__all__ = ["deep_analyse"]

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/check_dataset.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/check_dataset.py
@@ -27,19 +27,19 @@ from .utils.visualizer import draw_bbox, draw_mask
 
 
 def validate_read_order(annotations, image_id):
-    """验证单张图片的 read_order 有效性
+    """Validate the read_order field for all annotations of a single image.
 
     Args:
-        annotations: 该图片的所有标注列表
-        image_id: 图片ID
+        annotations: list of all annotations for the image
+        image_id: image ID
 
     Returns:
-        bool: 是否通过验证
+        bool: whether validation passed
 
     Raises:
-        ValueError: 缺失或非法的 read_order
+        ValueError: missing or invalid read_order
     """
-    # 1. 检查完整性和类型
+    # 1. Check completeness and type
     for ann in annotations:
         if "read_order" not in ann:
             raise ValueError(
@@ -52,7 +52,7 @@ def validate_read_order(annotations, image_id):
                 f"Expected non-negative integer."
             )
 
-    # 2. 检查连续性和唯一性
+    # 2. Check continuity and uniqueness
     read_orders = sorted([ann["read_order"] for ann in annotations])
     expected = list(range(len(read_orders)))
 
@@ -78,7 +78,7 @@ def check(dataset_dir, output, sample_num=10):
 
     sample_cnts = dict()
     sample_paths = defaultdict(list)
-    read_order_stats = {}  # 新增: read_order 验证统计
+    read_order_stats = {}  # read_order validation statistics
     tags = ["instance_train", "instance_val"]
 
     for tag in tags:
@@ -101,7 +101,7 @@ def check(dataset_dir, output, sample_num=10):
         coco = COCO(file_list)
         num_class = len(coco.getCatIds())
 
-        # 新增: 验证 read_order
+        # validate read_order
         img_anns = defaultdict(list)
         for ann in datanno:
             img_anns[ann["image_id"]].append(ann)
@@ -130,7 +130,7 @@ def check(dataset_dir, output, sample_num=10):
             f"{tag}: read_order validation pass rate = {read_order_stats[tag]['pass_rate']:.2%}"
         )
 
-        # 可视化
+        # visualization
         vis_save_dir = osp.join(output, "demo_img")
         image_info = jsondata["images"]
         sample_num = min(sample_num, len(image_info))
@@ -146,7 +146,9 @@ def check(dataset_dir, output, sample_num=10):
 
             img = Image.open(img_path)
             img = ImageOps.exif_transpose(img)
-            vis_im = draw_bbox(img, coco, img_id)  # 自动显示 read_order
+            vis_im = draw_bbox(
+                img, coco, img_id
+            )  # draw_bbox renders read_order automatically
             vis_im = draw_mask(vis_im, coco, img_id)
             vis_path = osp.join(vis_save_dir, file_name)
             Path(vis_path).parent.mkdir(parents=True, exist_ok=True)
@@ -160,6 +162,6 @@ def check(dataset_dir, output, sample_num=10):
     attrs["train_sample_paths"] = sample_paths["instance_train"]
     attrs["val_samples"] = sample_cnts["instance_val"]
     attrs["val_sample_paths"] = sample_paths["instance_val"]
-    attrs["read_order_validation"] = read_order_stats  # 新增
+    attrs["read_order_validation"] = read_order_stats
 
     return attrs

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/check_dataset.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/check_dataset.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import os.path as osp
+from collections import defaultdict
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+from .....utils.deps import function_requires_deps
+from .....utils.errors import DatasetFileNotFoundError
+from .....utils.logging import error, info, warning
+from .utils.visualizer import draw_bbox, draw_mask
+
+
+def validate_read_order(annotations, image_id):
+    """验证单张图片的 read_order 有效性
+
+    Args:
+        annotations: 该图片的所有标注列表
+        image_id: 图片ID
+
+    Returns:
+        bool: 是否通过验证
+
+    Raises:
+        ValueError: 缺失或非法的 read_order
+    """
+    # 1. 检查完整性和类型
+    for ann in annotations:
+        if "read_order" not in ann:
+            raise ValueError(
+                f"Annotation {ann['id']} in image {image_id} is missing 'read_order' field. "
+                f"Layout Analysis model requires 'read_order' for all annotations."
+            )
+        if not isinstance(ann["read_order"], int) or ann["read_order"] < 0:
+            raise ValueError(
+                f"Annotation {ann['id']} in image {image_id} has invalid read_order: {ann.get('read_order')}. "
+                f"Expected non-negative integer."
+            )
+
+    # 2. 检查连续性和唯一性
+    read_orders = sorted([ann["read_order"] for ann in annotations])
+    expected = list(range(len(read_orders)))
+
+    if read_orders != expected:
+        warning(
+            f"Image {image_id}: read_order sequence {read_orders} is not continuous. "
+            f"Expected {expected}. This may cause training issues."
+        )
+        return False
+
+    return True
+
+
+@function_requires_deps("pycocotools")
+def check(dataset_dir, output, sample_num=10):
+    """check dataset with read_order validation"""
+    from pycocotools.coco import COCO
+
+    info(f"Checking dataset: {dataset_dir}")
+    dataset_dir = osp.abspath(dataset_dir)
+    if not osp.exists(dataset_dir) or not osp.isdir(dataset_dir):
+        raise DatasetFileNotFoundError(file_path=dataset_dir)
+
+    sample_cnts = dict()
+    sample_paths = defaultdict(list)
+    read_order_stats = {}  # 新增: read_order 验证统计
+    tags = ["instance_train", "instance_val"]
+
+    for tag in tags:
+        file_list = osp.join(dataset_dir, f"annotations/{tag}.json")
+        if not osp.exists(file_list):
+            if tag in ("instance_train", "instance_val"):
+                raise DatasetFileNotFoundError(
+                    file_path=file_list,
+                    solution=f"Ensure that both `instance_train.json` and `instance_val.json` exist in "
+                    f"{dataset_dir}/annotations",
+                )
+            else:
+                continue
+
+        with open(file_list, "r", encoding="utf-8") as f:
+            jsondata = json.load(f)
+
+        datanno = jsondata["annotations"]
+        sample_cnts[tag] = len(datanno)
+        coco = COCO(file_list)
+        num_class = len(coco.getCatIds())
+
+        # 新增: 验证 read_order
+        img_anns = defaultdict(list)
+        for ann in datanno:
+            img_anns[ann["image_id"]].append(ann)
+
+        valid_count = 0
+        invalid_images = []
+        for img_id, anns in img_anns.items():
+            try:
+                is_valid = validate_read_order(anns, img_id)
+                if is_valid:
+                    valid_count += 1
+                else:
+                    invalid_images.append(img_id)
+            except ValueError as e:
+                error(str(e))
+                raise
+
+        read_order_stats[tag] = {
+            "total_images": len(img_anns),
+            "valid_images": valid_count,
+            "invalid_images": invalid_images,
+            "pass_rate": valid_count / len(img_anns) if len(img_anns) > 0 else 0,
+        }
+
+        info(
+            f"{tag}: read_order validation pass rate = {read_order_stats[tag]['pass_rate']:.2%}"
+        )
+
+        # 可视化
+        vis_save_dir = osp.join(output, "demo_img")
+        image_info = jsondata["images"]
+        sample_num = min(sample_num, len(image_info))
+        if sample_num < 10:
+            info("Only {} images in {}.json".format(len(image_info), tag))
+
+        for i in range(sample_num):
+            file_name = image_info[i]["file_name"]
+            img_id = image_info[i]["id"]
+            img_path = osp.join(dataset_dir, "images", file_name)
+            if not osp.exists(img_path):
+                raise DatasetFileNotFoundError(file_path=img_path)
+
+            img = Image.open(img_path)
+            img = ImageOps.exif_transpose(img)
+            vis_im = draw_bbox(img, coco, img_id)  # 自动显示 read_order
+            vis_im = draw_mask(vis_im, coco, img_id)
+            vis_path = osp.join(vis_save_dir, file_name)
+            Path(vis_path).parent.mkdir(parents=True, exist_ok=True)
+            vis_im.save(vis_path)
+            sample_path = osp.join("check_dataset", os.path.relpath(vis_path, output))
+            sample_paths[tag].append(sample_path)
+
+    attrs = {}
+    attrs["num_classes"] = num_class
+    attrs["train_samples"] = sample_cnts["instance_train"]
+    attrs["train_sample_paths"] = sample_paths["instance_train"]
+    attrs["val_samples"] = sample_cnts["instance_val"]
+    attrs["val_sample_paths"] = sample_paths["instance_val"]
+    attrs["read_order_validation"] = read_order_stats  # 新增
+
+    return attrs

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/split_dataset.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/split_dataset.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reuse split_dataset from instance_segmentation module
+from ....instance_segmentation.dataset_checker.dataset_src.split_dataset import (
+    split_dataset,
+)
+
+__all__ = ["split_dataset"]

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/__init__.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .visualizer import draw_bbox, draw_mask, draw_read_order
+
+__all__ = ["draw_bbox", "draw_mask", "draw_read_order"]

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/visualizer.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/visualizer.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import PIL
+from PIL import Image, ImageDraw, ImageFont
+
+from ......utils import logging
+from ......utils.deps import function_requires_deps, is_dep_available
+from ......utils.fonts import PINGFANG_FONT
+
+if is_dep_available("pycocotools"):
+    from pycocotools.coco import COCO
+
+
+def colormap(rgb=False):
+    """
+    Get colormap
+
+    The code of this function is copied from https://github.com/facebookresearch/Detectron/blob/main/detectron/\
+utils/colormap.py
+    """
+    color_list = np.array(
+        [
+            0xFF,
+            0x00,
+            0x00,
+            0xCC,
+            0xFF,
+            0x00,
+            0x00,
+            0xFF,
+            0x66,
+            0x00,
+            0x66,
+            0xFF,
+            0xCC,
+            0x00,
+            0xFF,
+            0xFF,
+            0x4D,
+            0x00,
+            0x80,
+            0xFF,
+            0x00,
+            0x00,
+            0xFF,
+            0xB2,
+            0x00,
+            0x1A,
+            0xFF,
+            0xFF,
+            0x00,
+            0xE5,
+            0xFF,
+            0x99,
+            0x00,
+            0x33,
+            0xFF,
+            0x00,
+            0x00,
+            0xFF,
+            0xFF,
+            0x33,
+            0x00,
+            0xFF,
+            0xFF,
+            0x00,
+            0x99,
+            0xFF,
+            0xE5,
+            0x00,
+            0x00,
+            0xFF,
+            0x1A,
+            0x00,
+            0xB2,
+            0xFF,
+            0x80,
+            0x00,
+            0xFF,
+            0xFF,
+            0x00,
+            0x4D,
+        ]
+    ).astype(np.float32)
+    color_list = color_list.reshape((-1, 3))
+    if not rgb:
+        color_list = color_list[:, ::-1]
+    return color_list.astype("int32")
+
+
+def font_colormap(color_index):
+    """
+    Get font color according to the index of colormap
+    """
+    dark = np.array([0x14, 0x0E, 0x35])
+    light = np.array([0xFF, 0xFF, 0xFF])
+    light_indexs = [0, 3, 4, 8, 9, 13, 14, 18, 19]
+    if color_index in light_indexs:
+        return light.astype("int32")
+    else:
+        return dark.astype("int32")
+
+
+def draw_read_order(draw, bbox, read_order, font, color=(0, 51, 153)):
+    """在 bbox 右上角绘制 read_order 编号
+
+    Args:
+        draw: ImageDraw.Draw 对象
+        bbox: [xmin, ymin, w, h] 格式的边界框
+        read_order: 阅读顺序编号
+        font: ImageFont 对象
+        color: RGB 背景颜色
+    """
+    xmin, ymin, w, h = bbox
+    xmax = xmin + w
+
+    # 计算圆形半径(基于字体大小)
+    circle_radius = max(15, int(font.size * 1.3))
+
+    # 计算显示位置(右上角,留 5px 边距)
+    center_x = xmax - circle_radius - 5
+    center_y = ymin + circle_radius + 5
+
+    # 确保不超出图像左边界
+    if center_x - circle_radius < xmin:
+        center_x = xmin + circle_radius + 5
+
+    # 绘制圆形背景
+    draw.ellipse(
+        [
+            (center_x - circle_radius, center_y - circle_radius),
+            (center_x + circle_radius, center_y + circle_radius),
+        ],
+        fill=color,
+        outline=(255, 255, 255),
+        width=2,
+    )
+
+    # 绘制文字
+    text = str(read_order)
+    if tuple(map(int, PIL.__version__.split("."))) <= (10, 0, 0):
+        tw, th = draw.textsize(text, font=font)
+    else:
+        left, top, right, bottom = draw.textbbox((0, 0), text, font)
+        tw, th = right - left, bottom - top
+
+    text_x = center_x - tw // 2
+    text_y = center_y - th // 2 - 1
+    draw.text((text_x, text_y), text, fill=(255, 255, 255), font=font)
+
+
+@function_requires_deps("pycocotools")
+def draw_bbox(image, coco_info: "COCO", img_id):
+    """
+    Draw bbox on image with read_order annotation
+    """
+    try:
+        image_info = coco_info.loadImgs(img_id)[0]
+        font_size = int(0.024 * int(image_info["width"])) + 2
+    except:
+        font_size = 12
+    font = ImageFont.truetype(PINGFANG_FONT.path, font_size, encoding="utf-8")
+    read_order_font = ImageFont.truetype(
+        PINGFANG_FONT.path, int(font_size * 1.2), encoding="utf-8"
+    )
+
+    image = image.convert("RGB")
+    draw = ImageDraw.Draw(image)
+    image_size = image.size
+    width = int(max(image_size) * 0.005)
+
+    catid2color = {}
+    catid2fontcolor = {}
+    catid_num_dict = {}
+    color_list = colormap(rgb=True)
+    annotations = coco_info.loadAnns(coco_info.getAnnIds(imgIds=img_id))
+
+    for ann in annotations:
+        catid = ann["category_id"]
+        catid_num_dict[catid] = catid_num_dict.get(catid, 0) + 1
+    for i, (catid, _) in enumerate(
+        sorted(catid_num_dict.items(), key=lambda x: x[1], reverse=True)
+    ):
+        if catid not in catid2color:
+            color_index = i % len(color_list)
+            catid2color[catid] = color_list[color_index]
+            catid2fontcolor[catid] = font_colormap(color_index)
+    for ann in annotations:
+        catid, bbox = ann["category_id"], ann["bbox"]
+        color = tuple(catid2color[catid])
+        font_color = tuple(catid2fontcolor[catid])
+        read_order = ann.get("read_order", -1)  # 获取 read_order
+
+        if len(bbox) == 4:
+            # draw bbox
+            xmin, ymin, w, h = bbox
+            xmax = xmin + w
+            ymax = ymin + h
+            draw.line(
+                [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin), (xmin, ymin)],
+                width=width,
+                fill=color,
+            )
+        elif len(bbox) == 8:
+            x1, y1, x2, y2, x3, y3, x4, y4 = bbox
+            draw.line(
+                [(x1, y1), (x2, y2), (x3, y3), (x4, y4), (x1, y1)],
+                width=width,
+                fill=color,
+            )
+            xmin = min(x1, x2, x3, x4)
+            ymin = min(y1, y2, y3, y4)
+        else:
+            logging.info("Error: The shape of bbox must be [M, 4] or [M, 8]!")
+            continue
+
+        # draw label (左上角)
+        label = coco_info.loadCats(catid)[0]["name"]
+        text = "{}".format(label)
+        if tuple(map(int, PIL.__version__.split("."))) <= (10, 0, 0):
+            tw, th = draw.textsize(text, font=font)
+        else:
+            left, top, right, bottom = draw.textbbox((0, 0), text, font)
+            tw, th = right - left, bottom - top
+        if ymin < th:
+            draw.rectangle([(xmin, ymin), (xmin + tw + 4, ymin + th + 1)], fill=color)
+            draw.text((xmin + 2, ymin - 2), text, fill=font_color, font=font)
+        else:
+            draw.rectangle([(xmin, ymin - th), (xmin + tw + 4, ymin + 1)], fill=color)
+            draw.text((xmin + 2, ymin - th - 2), text, fill=font_color, font=font)
+
+        # 新增: 绘制 read_order 编号(右上角)
+        if read_order >= 0:
+            draw_read_order(draw, bbox, read_order, read_order_font)
+
+    return image
+
+
+@function_requires_deps("pycocotools")
+def draw_mask(image, coco_info: "COCO", img_id):
+    """
+    Draw mask on image
+    """
+    mask_color_id = 0
+    w_ratio = 0.4
+    alpha = 0.6
+    color_list = colormap(rgb=True)
+    img_array = np.array(image).astype("float32")
+    h, w = img_array.shape[:2]
+    annotations = coco_info.loadAnns(coco_info.getAnnIds(imgIds=img_id))
+    for ann in annotations:
+        segm = ann["segmentation"]
+        if not segm:
+            continue
+        import pycocotools.mask as mask_util
+
+        rles = mask_util.frPyObjects(segm, h, w)
+        rle = mask_util.merge(rles)
+        mask = mask_util.decode(rle) * 255
+        color_mask = color_list[mask_color_id % len(color_list), 0:3]
+        mask_color_id += 1
+        for c in range(3):
+            color_mask[c] = color_mask[c] * (1 - w_ratio) + w_ratio * 255
+        idx = np.nonzero(mask)
+        img_array[idx[0], idx[1], :] *= 1.0 - alpha
+        img_array[idx[0], idx[1], :] += alpha * color_mask
+    return Image.fromarray(img_array.astype("uint8"))

--- a/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/visualizer.py
+++ b/paddlex/modules/layout_analysis/dataset_checker/dataset_src/utils/visualizer.py
@@ -114,52 +114,26 @@ def font_colormap(color_index):
         return dark.astype("int32")
 
 
-def draw_read_order(draw, bbox, read_order, font, color=(0, 51, 153)):
-    """在 bbox 右上角绘制 read_order 编号
-
-    Args:
-        draw: ImageDraw.Draw 对象
-        bbox: [xmin, ymin, w, h] 格式的边界框
-        read_order: 阅读顺序编号
-        font: ImageFont 对象
-        color: RGB 背景颜色
-    """
+def draw_read_order(draw, bbox, read_order, font, color, font_color):
+    """Draw read_order label at the top-right corner of a bbox."""
     xmin, ymin, w, h = bbox
     xmax = xmin + w
-
-    # 计算圆形半径(基于字体大小)
-    circle_radius = max(15, int(font.size * 1.3))
-
-    # 计算显示位置(右上角,留 5px 边距)
-    center_x = xmax - circle_radius - 5
-    center_y = ymin + circle_radius + 5
-
-    # 确保不超出图像左边界
-    if center_x - circle_radius < xmin:
-        center_x = xmin + circle_radius + 5
-
-    # 绘制圆形背景
-    draw.ellipse(
-        [
-            (center_x - circle_radius, center_y - circle_radius),
-            (center_x + circle_radius, center_y + circle_radius),
-        ],
-        fill=color,
-        outline=(255, 255, 255),
-        width=2,
-    )
-
-    # 绘制文字
     text = str(read_order)
+
+    # measure text size (PIL version compat)
     if tuple(map(int, PIL.__version__.split("."))) <= (10, 0, 0):
         tw, th = draw.textsize(text, font=font)
     else:
         left, top, right, bottom = draw.textbbox((0, 0), text, font)
         tw, th = right - left, bottom - top
 
-    text_x = center_x - tw // 2
-    text_y = center_y - th // 2 - 1
-    draw.text((text_x, text_y), text, fill=(255, 255, 255), font=font)
+    # draw at top-right corner, mirroring the category label at top-left
+    if ymin < th:
+        draw.rectangle([(xmax - tw - 4, ymin), (xmax, ymin + th + 1)], fill=color)
+        draw.text((xmax - tw - 2, ymin - 2), text, fill=font_color, font=font)
+    else:
+        draw.rectangle([(xmax - tw - 4, ymin - th), (xmax, ymin + 1)], fill=color)
+        draw.text((xmax - tw - 2, ymin - th - 2), text, fill=font_color, font=font)
 
 
 @function_requires_deps("pycocotools")
@@ -173,9 +147,6 @@ def draw_bbox(image, coco_info: "COCO", img_id):
     except:
         font_size = 12
     font = ImageFont.truetype(PINGFANG_FONT.path, font_size, encoding="utf-8")
-    read_order_font = ImageFont.truetype(
-        PINGFANG_FONT.path, int(font_size * 1.2), encoding="utf-8"
-    )
 
     image = image.convert("RGB")
     draw = ImageDraw.Draw(image)
@@ -202,7 +173,7 @@ def draw_bbox(image, coco_info: "COCO", img_id):
         catid, bbox = ann["category_id"], ann["bbox"]
         color = tuple(catid2color[catid])
         font_color = tuple(catid2fontcolor[catid])
-        read_order = ann.get("read_order", -1)  # 获取 read_order
+        read_order = ann.get("read_order", -1)  # get read_order
 
         if len(bbox) == 4:
             # draw bbox
@@ -227,7 +198,7 @@ def draw_bbox(image, coco_info: "COCO", img_id):
             logging.info("Error: The shape of bbox must be [M, 4] or [M, 8]!")
             continue
 
-        # draw label (左上角)
+        # draw label (top-left corner)
         label = coco_info.loadCats(catid)[0]["name"]
         text = "{}".format(label)
         if tuple(map(int, PIL.__version__.split("."))) <= (10, 0, 0):
@@ -242,9 +213,9 @@ def draw_bbox(image, coco_info: "COCO", img_id):
             draw.rectangle([(xmin, ymin - th), (xmin + tw + 4, ymin + 1)], fill=color)
             draw.text((xmin + 2, ymin - th - 2), text, fill=font_color, font=font)
 
-        # 新增: 绘制 read_order 编号(右上角)
+        # draw read_order index (top-right corner)
         if read_order >= 0:
-            draw_read_order(draw, bbox, read_order, read_order_font)
+            draw_read_order(draw, bbox, read_order, font, color, font_color)
 
     return image
 

--- a/paddlex/modules/layout_analysis/evaluator.py
+++ b/paddlex/modules/layout_analysis/evaluator.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ..object_detection import DetEvaluator
+from .model_list import MODELS
+
+
+class LayoutAnalysisEvaluator(DetEvaluator):
+    """Layout Analysis Model Evaluator"""
+
+    entities = MODELS
+
+    def update_config(self):
+        """update evaluation config"""
+        if self.eval_config.log_interval:
+            self.pdx_config.update_log_interval(self.eval_config.log_interval)
+        self.pdx_config.update_dataset(
+            self.global_config.dataset_dir, "COCOInstSegDataset"
+        )
+        self.pdx_config.update_weights(self.eval_config.weight_path)

--- a/paddlex/modules/layout_analysis/exportor.py
+++ b/paddlex/modules/layout_analysis/exportor.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..base import BaseExportor
+from .model_list import MODELS
+
+
+class LayoutAnalysisExportor(BaseExportor):
+    """Layout Analysis Model Exportor"""
+
+    entities = MODELS

--- a/paddlex/modules/layout_analysis/model_list.py
+++ b/paddlex/modules/layout_analysis/model_list.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+MODELS = [
+    "PP-DocLayoutV3",
+]

--- a/paddlex/modules/layout_analysis/trainer.py
+++ b/paddlex/modules/layout_analysis/trainer.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ..object_detection import DetTrainer
+from .model_list import MODELS
+
+
+class LayoutAnalysisTrainer(DetTrainer):
+    """Layout Analysis Model Trainer"""
+
+    entities = MODELS
+
+    def _update_dataset(self):
+        """update dataset settings"""
+        metric = self.pdx_config.metric if "metric" in self.pdx_config else "COCO"
+        self.pdx_config.update_dataset(
+            self.global_config.dataset_dir,
+            "COCOInstSegDataset",
+            data_fields=[
+                "image",
+                "gt_bbox",
+                "gt_class",
+                "gt_poly",
+                "is_crowd",
+                "gt_read_order",
+            ],
+            metric=metric,
+        )

--- a/paddlex/repo_apis/PaddleDetection_api/configs/PP-DocLayoutV3.yaml
+++ b/paddlex/repo_apis/PaddleDetection_api/configs/PP-DocLayoutV3.yaml
@@ -1,0 +1,181 @@
+# Runtime
+epoch: 200
+log_iter: 10
+find_unused_parameters: true
+use_gpu: true
+use_xpu: false
+use_mlu: false
+use_npu: false
+use_ema: True
+ema_decay: 0.9999
+ema_decay_type: "exponential"
+ema_filter_no_grad: True
+save_dir: output
+snapshot_epoch: 10
+target_metrics: mask
+print_flops: false
+print_params: false
+eval_size: [800, 800]
+
+# Dataset
+metric: DocLayoutV3Metric
+num_classes: 25
+
+worker_num: 24
+
+TrainDataset:
+  name: COCOInstSegDataset
+  image_dir: images_mask
+  anno_path: annotations/instance_train.json
+  dataset_dir: dataset/doclayoutv3_examples/
+  data_fields: ['image', 'gt_bbox', 'gt_class', 'gt_poly', 'is_crowd', 'gt_read_order']
+
+EvalDataset:
+  name: COCOInstSegDataset
+  image_dir: images_mask
+  anno_path: annotations/instance_val.json
+  dataset_dir: dataset/doclayoutv3_examples/
+
+TestDataset:
+  name: ImageFolder
+  anno_path: annotations/instance_val.json
+  dataset_dir: dataset/doclayoutv3_examples/
+
+TrainReader:
+  sample_transforms:
+    - Decode: {}
+    - Poly2MaskPack: {del_poly: True}
+    - RandomDistort: {prob: 0.8}
+    - UpdateBBoxFromMask: {}
+    - RandomExpand: {prob: 0.5, ratio: 1.5, fill_value: [123.675, 116.28, 103.53]}
+    - RandomCrop: {prob: 0.8, use_box_candidates: true}
+  batch_transforms:
+    - BatchRandomResize: {target_size: [672, 704, 736, 768, 800, 800, 800, 800, 832, 864, 896, 928], random_size: True, random_interp: True, keep_ratio: False}
+    - UnpackMask: {}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - NormalizeBox: {}
+    - BboxXYXY2XYWH: {}
+    - Permute: {}
+  batch_size: 8
+  shuffle: true
+  drop_last: true
+  collate_batch: false
+  use_shared_memory: true
+
+EvalReader:
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [800, 800], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - Permute: {}
+  batch_size: 1 # mask be 1
+  shuffle: false
+  drop_last: false
+
+TestReader:
+  inputs_def:
+    image_shape: [3, 800, 800]
+  sample_transforms:
+    - Decode: {}
+    - Resize: {target_size: [800, 800], keep_ratio: False, interp: 2}
+    - NormalizeImage: {mean: [0., 0., 0.], std: [1., 1., 1.], norm_type: none}
+    - Permute: {}
+  batch_size: 1
+  shuffle: false
+  drop_last: false
+
+# Model
+architecture: DETR
+with_mask: True
+pretrain_weights: https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout_plus-L_pretrained.pdparams
+norm_type: sync_bn
+hidden_dim: 256
+use_focal_loss: True
+num_prototypes: 32
+
+DETR:
+  backbone: PPHGNetV2
+  neck: MaskHybridEncoder
+  transformer: DocLayoutV3Transformer
+  detr_head: DocLayoutV3Head
+  post_process: DocLayoutV3PostProcess
+
+PPHGNetV2:
+  arch: 'L'
+  return_idx: [0, 1, 2, 3]
+  freeze_stem_only: True
+  freeze_at: 0
+  freeze_norm: True
+  lr_mult_list: [0., 0.05, 0.05, 0.05, 0.05]
+
+MaskHybridEncoder:
+  hidden_dim: 256
+  use_encoder_idx: [3]
+  num_encoder_layers: 1
+  encoder_layer:
+    name: TransformerLayer
+    d_model: 256
+    nhead: 8
+    dim_feedforward: 1024
+    dropout: 0.
+    activation: 'gelu'
+  expansion: 1.0
+  mask_feat_channels: [64, 64]
+
+DocLayoutV3Transformer:
+  num_queries: 300
+  position_embed_type: sine
+  feat_strides: [8, 16, 32]
+  num_levels: 3
+  nhead: 8
+  dim_feedforward: 1024
+  dropout: 0.0
+  activation: relu
+  num_denoising: 0
+  label_noise_ratio: 0.5
+  box_noise_scale: 1.0
+  learnt_init_query: False
+  mask_enhanced: True
+
+DocLayoutV3Head:
+  loss:
+    name: DocLayoutV3Loss
+    num_classes: 25
+    use_focal_loss: True
+    loss_coeff: {class: 4, bbox: 5, giou: 2, mask: 5, dice: 5, order: 50}
+    aux_loss: True
+    use_vfl: True
+    vfl_iou_type: 'mask'
+    matcher:
+      name: HungarianMatcher
+      matcher_coeff: {class: 4, bbox: 5, giou: 2, mask: 5, dice: 5}
+
+DocLayoutV3PostProcess:
+  num_top_queries: 300
+  mask_stride: 4
+
+# Optimizer
+LearningRate:
+  base_lr: 0.0002
+  schedulers:
+  - !PiecewiseDecay
+    gamma: 1.0
+    milestones: [100]
+    use_warmup: true
+  - !LinearWarmup
+    start_factor: 0.001
+    steps: 100
+
+OptimizerBuilder:
+  clip_grad_by_norm: 0.1
+  regularizer: false
+  optimizer:
+    type: AdamW
+    weight_decay: 0.0001
+
+# Exporting the model
+export:
+  post_process: True
+  nms: True
+  benchmark: False
+  fuse_conv_bn: False

--- a/paddlex/repo_apis/PaddleDetection_api/configs/PP-DocLayoutV3.yaml
+++ b/paddlex/repo_apis/PaddleDetection_api/configs/PP-DocLayoutV3.yaml
@@ -19,20 +19,22 @@ eval_size: [800, 800]
 
 # Dataset
 metric: DocLayoutV3Metric
+DocLayoutV3Metric:
+  eval_mask: False  # True: compute mask AP during training eval (requires resize_mask: True in DocLayoutV3PostProcess)
 num_classes: 25
 
 worker_num: 24
 
 TrainDataset:
   name: COCOInstSegDataset
-  image_dir: images_mask
+  image_dir: images
   anno_path: annotations/instance_train.json
   dataset_dir: dataset/doclayoutv3_examples/
   data_fields: ['image', 'gt_bbox', 'gt_class', 'gt_poly', 'is_crowd', 'gt_read_order']
 
 EvalDataset:
   name: COCOInstSegDataset
-  image_dir: images_mask
+  image_dir: images
   anno_path: annotations/instance_val.json
   dataset_dir: dataset/doclayoutv3_examples/
 
@@ -140,7 +142,6 @@ DocLayoutV3Transformer:
 DocLayoutV3Head:
   loss:
     name: DocLayoutV3Loss
-    num_classes: 25
     use_focal_loss: True
     loss_coeff: {class: 4, bbox: 5, giou: 2, mask: 5, dice: 5, order: 50}
     aux_loss: True
@@ -153,6 +154,7 @@ DocLayoutV3Head:
 DocLayoutV3PostProcess:
   num_top_queries: 300
   mask_stride: 4
+  resize_mask: False  # True: resize mask to original resolution
 
 # Optimizer
 LearningRate:

--- a/paddlex/repo_apis/PaddleDetection_api/instance_seg/config.py
+++ b/paddlex/repo_apis/PaddleDetection_api/instance_seg/config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Optional
 
 from ....utils.misc import abspath
 from ..object_det.config import DetConfig
@@ -49,13 +49,14 @@ class InstanceSegConfig(DetConfig):
     def update_dataset(
         self,
         dataset_path: str,
-        dataset_type: str = None,
+        dataset_type: Optional[str] = None,
         *,
-        data_fields: List[str] = None,
+        data_fields: Optional[List[str]] = None,
         image_dir: str = "images",
         train_anno_path: str = "annotations/instance_train.json",
         val_anno_path: str = "annotations/instance_val.json",
         test_anno_path: str = "annotations/instance_val.json",
+        metric: Optional[str] = None,
     ):
         """update dataset settings
 
@@ -70,6 +71,7 @@ class InstanceSegConfig(DetConfig):
                 Defaults to "annotations/instance_val.json".
             test_anno_path (str, optional): the test annotations file that relative to `dataset_path`.
                 Defaults to "annotations/instance_val.json".
+            metric (str, optional): the metric type. Defaults to None, which will keep existing metric or use "COCO".
 
         Raises:
             ValueError: the `dataset_type` error.
@@ -87,7 +89,10 @@ class InstanceSegConfig(DetConfig):
                 val_anno_path,
                 test_anno_path,
             )
-            self.set_val("metric", "COCO")
+            if metric is not None:
+                self.set_val("metric", metric)
+            elif "metric" not in self:
+                self.set_val("metric", "COCO")
         else:
             raise ValueError(f"{repr(dataset_type)} is not supported.")
         self.update(ds_cfg)

--- a/paddlex/repo_apis/PaddleDetection_api/instance_seg/register.py
+++ b/paddlex/repo_apis/PaddleDetection_api/instance_seg/register.py
@@ -260,3 +260,18 @@ register_model_info(
         },
     }
 )
+
+register_model_info(
+    {
+        "model_name": "PP-DocLayoutV3",
+        "suite": "InstanceSeg",
+        "config_path": osp.join(PDX_CONFIG_DIR, "PP-DocLayoutV3.yaml"),
+        "supported_apis": ["train", "evaluate", "predict", "export"],
+        "supported_dataset_types": ["COCOInstSegDataset"],
+        "supported_train_opts": {
+            "device": ["cpu", "gpu_nxcx", "xpu", "npu", "mlu"],
+            "dy2st": False,
+            "amp": ["OFF"],
+        },
+    }
+)


### PR DESCRIPTION
Implement complete layout_analyse module for PP-DocLayoutV3 model which extends instance segmentation with read_order field for document layout analysis.

Key features:
- Dataset checker with read_order field validation (completeness, type, continuity)
- Enhanced visualization showing read_order numbers on bounding boxes
- LayoutAnalyseTrainer with gt_read_order data field support
- LayoutAnalyseEvaluator for model evaluation
- LayoutAnalyseExportor for static graph export
- Auto-registration to BaseDatasetChecker for PP-DocLayoutV3 model
- Register PP-DocLayoutV3 model in PaddleDetection API instance_seg suite
- Metric parameter support in InstanceSegConfig for custom metrics

The read_order field enables the model to predict document element reading sequence, which is essential for proper document understanding and information extraction.

Components:
- Inherits from DetTrainer/DetEvaluator to maximize code reuse
- Reuse split_dataset and analyse_dataset from instance_segmentation module
- Compatible with COCOInstSegDataset format
- Supports multi-device training (CPU, GPU, XPU, NPU, MLU)

