### PR TITLE
fix: handle return_word_box=True for Arabic text recognition

### DIFF
--- a/paddlex/inference/models/text_recognition/predictor.py
+++ b/paddlex/inference/models/text_recognition/predictor.py
@@ -136,7 +136,10 @@ class TextRecPredictor(BasePredictor):
             "arabic_PP-OCRv3_mobile_rec",
             "arabic_PP-OCRv5_mobile_rec",
         ):
-            texts = [get_display(s) for s in texts]
+            texts = [
+                (get_display(s[0]), s[1]) if isinstance(s, tuple) else get_display(s)
+                for s in texts
+            ]
         return {
             "input_path": batch_data.input_paths,
             "page_index": batch_data.page_indexes,


### PR DESCRIPTION
## Summary

Fix TypeError when using Arabic OCR models with return_word_box=True.

Related issue: https://github.com/PaddlePaddle/PaddleOCR/issues/16952

## Root Cause

When `return_word_box=True`, `CTCLabelDecode` returns `texts` as a list of tuples `(text_string, word_info_list)` instead of plain strings (see `processors.py` line 294). The Arabic bidi reshaping code at `predictor.py` line 139 passes these tuples directly to `get_display()`, which expects a unicode string.

## Fix

Check whether each element in `texts` is a tuple. If so, apply `get_display()` only to the text string while preserving the word box info. Plain string mode is unaffected.

## Reproduction

```python
from paddleocr import PaddleOCR

ocr = PaddleOCR(lang='ar')
result = ocr.predict('arabic_text.png', return_word_box=True)  # crashes without fix