### PR TITLE
fix: change PP-OCRv5_server_det HPI backend priority to openvino-first

### DIFF
--- a/paddlex/inference/utils/hpi_model_info_collection.json
+++ b/paddlex/inference/utils/hpi_model_info_collection.json
@@ -1424,8 +1424,8 @@
         "paddle"
       ],
       "PP-OCRv5_server_det": [
-        "paddle_mkldnn",
         "openvino",
+        "paddle_mkldnn",
         "paddle"
       ],
       "PP-OCRv5_mobile_det": [
@@ -2905,8 +2905,8 @@
         "paddle"
       ],
       "PP-OCRv5_server_det": [
-        "paddle_mkldnn",
         "openvino",
+        "paddle_mkldnn",
         "onnxruntime",
         "paddle"
       ],
@@ -4390,8 +4390,8 @@
         "paddle"
       ],
       "PP-OCRv5_server_det": [
-        "paddle_mkldnn",
         "openvino",
+        "paddle_mkldnn",
         "onnxruntime",
         "paddle"
       ],


### PR DESCRIPTION
## Problem
PP-OCRv5_server_det defaults to `paddle_mkldnn` backend when HPI is enabled on cpu_x64, 
which causes `std::exception` crashes in multi-threaded serving environments (gRPC, FastAPI 
with workers, etc.) due to MKL-DNN thread-safety issues.

## Root Cause
The backend priority list in [hpi_model_info_collection.json](cci:7://file:///home/henry/Documents/contrib/PaddleX/paddlex/inference/utils/hpi_model_info_collection.json:0:0-0:0) places `paddle_mkldnn` before 
`openvino` for `PP-OCRv5_server_det` in cpu_x64 sections.

## Evidence
`PP-OCRv5_mobile_det` already correctly prioritizes `openvino` in the `paddle30` section 
and works in the same multi-threaded setup without crashes.

## Fix
Swap `openvino` before `paddle_mkldnn` for `PP-OCRv5_server_det` in all 3 cpu_x64 sections 
(paddle30, paddle31, paddle311). GPU sections are unaffected.

## Reproduction
1. Initialize PaddleOCR with `PP-OCRv5_server_det` + `enable_hpi=True`
2. Serve via multi-threaded gRPC or FastAPI
3. Send concurrent image requests → crashes with `std::exception`
