### PR TITLE
[Fix]: fix missing images in tables when concatenate_pages is enabled

### DIFF
--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -1031,6 +1031,10 @@ class _PaddleOCRVLPipeline(BasePipeline):
 
         concatenate_res = []
         if concatenate_pages:
+            all_imgs_in_doc = []
+            for res in res_list:
+                all_imgs_in_doc.extend(res.get("imgs_in_doc", []))
+            res_list[0]["imgs_in_doc"] = all_imgs_in_doc
             all_page_res = res_list[0]
             all_page_res["parsing_res_list"] = [
                 blk for blks in blocks_by_page for blk in blks


### PR DESCRIPTION
### Description
This PR fixes a bug in the `PaddleOCR-VL` pipeline where images within tables are lost when `concatenate_pages` is set to `True`. 

### Logic
Previously, the pipeline only retained `imgs_in_doc` from the first page when merging results. I have updated the logic to iterate through all page results (`res_list`) and aggregate all `imgs_in_doc` entries into the final output. This ensures that image data across all pages is correctly preserved.

### Changes
- Updated `_PaddleOCRVLPipeline` in `paddlex/inference/pipelines/paddleocr_vl/pipeline.py` to collect and merge image metadata from all processed pages.

### Verification
Verified the fix by processing multi-page documents. All images in tables across different pages are now correctly included in the output dictionary.