### PR TITLE
[fix] Add from __future__ import annotations for Python 3.8 compatibility.

### DIFF
--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import queue
 import re


### PR DESCRIPTION
This enables postponed evaluation of type annotations ([PEP 563](https://peps.python.org/pep-0563/)), allowing modern syntax like `list[str]` ([PEP 585](https://peps.python.org/pep-0585/)) to work on Python 3.8 without requiring extensive code changes.