### PR TITLE
[Fix] Add aarch64 (ARM64) support to HPI backend selection

### DIFF
--- a/.github/workflows/ultra-infer-aarch64.yml
+++ b/.github/workflows/ultra-infer-aarch64.yml
@@ -1,0 +1,58 @@
+name: ultra-infer aarch64 wheel
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: ["develop"]
+    paths:
+      - "deploy/ultra-infer/**"
+      - "paddlex/inference/utils/hpi.py"
+      - ".github/workflows/ultra-infer-aarch64.yml"
+  pull_request:
+    branches: ["develop"]
+    paths:
+      - "deploy/ultra-infer/**"
+      - "paddlex/inference/utils/hpi.py"
+      - ".github/workflows/ultra-infer-aarch64.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ultra-infer aarch64 wheel
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/ultra-infer/Dockerfile.aarch64
+          platforms: linux/arm64
+          push: false
+          outputs: type=local,dest=./dist
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ultra-infer-aarch64
+          path: dist/*.whl
+          retention-days: 30

--- a/deploy/ultra-infer/Dockerfile.aarch64
+++ b/deploy/ultra-infer/Dockerfile.aarch64
@@ -1,0 +1,39 @@
+# Build ultra-infer wheel for Linux aarch64 (ARM64).
+#
+# Usage (via workflow or manually with QEMU):
+#   docker buildx build --platform linux/arm64 \
+#       --output type=local,dest=./dist \
+#       -f deploy/ultra-infer/Dockerfile.aarch64 .
+
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        patchelf \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir wheel numpy setuptools
+
+COPY deploy/ultra-infer /build/ultra-infer
+WORKDIR /build/ultra-infer/python
+
+ENV WITH_GPU=OFF
+ENV ENABLE_ORT_BACKEND=ON
+ENV ENABLE_OPENVINO_BACKEND=OFF
+ENV ENABLE_TRT_BACKEND=OFF
+ENV ENABLE_PADDLE_BACKEND=OFF
+ENV ENABLE_VISION=OFF
+ENV ENABLE_TEXT=OFF
+ENV ENABLE_BENCHMARK=OFF
+ENV CC=gcc
+ENV CXX=g++
+
+RUN python setup.py build && python setup.py bdist_wheel
+
+# Final stage: only the wheel, for --output extraction
+FROM scratch
+COPY --from=builder /build/ultra-infer/python/dist/*.whl /

--- a/paddlex/inference/utils/hpi.py
+++ b/paddlex/inference/utils/hpi.py
@@ -183,6 +183,24 @@ def suggest_inference_backend_and_config(
         arch = uname.machine.lower()
         if arch == "x86_64":
             key = "cpu_x64"
+        elif arch in ("aarch64", "arm64"):
+            # aarch64/arm64: no model-specific prior knowledge yet.
+            # Prefer ONNX Runtime via ultra-infer (ENABLE_ORT_BACKEND=ON).
+            # See: https://github.com/PaddlePaddle/PaddleOCR/issues/17590
+            aarch64_backends = [
+                b for b in ("onnxruntime", "paddle") if b in available_backends
+            ]
+            if not aarch64_backends:
+                return None, "No suitable inference backend for aarch64."
+            if hpi_config.backend is not None:
+                if hpi_config.backend in aarch64_backends:
+                    return hpi_config.backend, {}
+                return (
+                    None,
+                    f"Inference backend {repr(hpi_config.backend)}"
+                    " is not available on aarch64.",
+                )
+            return aarch64_backends[0], {}
         else:
             return None, f"{repr(arch)} is not a supported architecture."
     elif hpi_config.device_type == "gpu":


### PR DESCRIPTION
## Summary

- Add `aarch64`/`arm64` architecture support to `suggest_inference_backend_and_config()` in `paddlex/inference/utils/hpi.py`
- On aarch64, prefer ONNX Runtime as the inference backend (with automatic paddle2onnx model conversion)
- Fall back to Paddle native inference if ORT is unavailable

## Motivation

Pre-built PaddlePaddle aarch64 wheels have ABI issues causing SIGSEGV during both model loading and inference ([PaddleOCR#17590](https://github.com/PaddlePaddle/PaddleOCR/issues/17590), [PaddleOCR#16685](https://github.com/PaddlePaddle/PaddleOCR/issues/16685)). The HPI path with ONNX Runtime completely bypasses the broken native kernels.

The ultra-infer CMake build system already supports aarch64 — it downloads correct prebuilt binaries for ORT, paddle2onnx, OpenCV, and patchelf. The only missing piece was the backend selection function rejecting non-x86_64 architectures.

## What this changes

`paddlex/inference/utils/hpi.py` — `suggest_inference_backend_and_config()`:
- Previously: rejects all architectures except `x86_64`
- Now: adds `aarch64`/`arm64` handling that short-circuits to `onnxruntime` backend (OpenVINO and MKL-DNN are unavailable on ARM)

## How to build ultra-infer for aarch64

```bash
cd deploy/ultra-infer/python
WITH_GPU=OFF ENABLE_ORT_BACKEND=ON ENABLE_OPENVINO_BACKEND=OFF \
  python setup.py build && python setup.py bdist_wheel
pip install dist/ultra_infer*.whl
```

## Test plan

- [x] Built ultra-infer from source for aarch64 in Docker (`python:3.12-slim-bookworm`, native ARM64 on Apple Silicon)
- [x] Tested with PaddleOCR 3.4.0 + PaddleX 3.4.2 + PaddlePaddle 3.2.2
- [x] All 5 OCR models (PP-LCNet_x1_0_doc_ori, UVDoc, PP-LCNet_x1_0_textline_ori, PP-OCRv5_server_det, PP-OCRv5_server_rec) load and run inference successfully
- [x] Text detection works correctly (`'HelloOCR'` detected from test image)
- [x] No SIGSEGV at either crash site

Companion PR for PaddleOCR: (will be linked after creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)