### PR TITLE
perf(ort): use cuDNN heuristic algo search for dynamic shape inference

### DIFF
--- a/deploy/ultra-infer/ultra_infer/runtime/backends/ort/ort_backend.cc
+++ b/deploy/ultra-infer/ultra_infer/runtime/backends/ort/ort_backend.cc
@@ -112,6 +112,7 @@ bool OrtBackend::BuildOption(const OrtBackendOption &option) {
     } else {
       OrtCUDAProviderOptions cuda_options;
       cuda_options.device_id = option.device_id;
+      cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchHeuristic;
       if (option.external_stream_) {
         cuda_options.has_user_compute_stream = 1;
         cuda_options.user_compute_stream = option.external_stream_;


### PR DESCRIPTION
## Summary

- Switch cuDNN conv algorithm search from `EXHAUSTIVE` (default) to `HEURISTIC` in ORT CUDA provider
- Eliminates latency spikes when input shapes change dynamically (e.g., OCR rec with varying batch size and width)

## Benchmark

Tested on **RTX 2080 Ti**, 6-layer conv model with 16 different dynamic shapes simulating OCR recognition workload (`[batch, 3, 48, width]`, batch∈[1,8], width∈[90,480]):

### Dynamic shape (each shape seen for the first time)

| Strategy | Total (16 shapes) | Avg per shape | Max |
|---|---|---|---|
| EXHAUSTIVE (default) | 10141 ms | 634 ms | 1348 ms |
| **HEURISTIC** | **31 ms** | **1.9 ms** | **5.1 ms** |

**326x faster** on shape changes.

### Steady-state (same shape repeated 100 times, after warmup)

| Shape | EXHAUSTIVE avg | HEURISTIC avg | Diff |
|---|---|---|---|
| `[1, 3, 48, 160]` | 0.593 ms | 0.497 ms | +16% faster |
| `[4, 3, 48, 320]` | 2.246 ms | 1.828 ms | +19% faster |
| `[8, 3, 48, 480]` | 5.060 ms | 4.911 ms | +3% faster |

No regression in steady-state throughput. HEURISTIC is slightly faster with lower p99 variance.

## Root Cause

`EXHAUSTIVE` mode benchmarks all cuDNN conv algorithms for every new input shape, costing 300-1300ms per shape. In OCR scenarios, batch size and image width vary per inference call, triggering this repeatedly.