### PR TITLE
fix(ts): support pandas 2.x StringDtype and restore Python 3.8 compatibility

### DIFF
--- a/deploy/ultra-infer/python/ultra_infer/py_only/ts/processors.py
+++ b/deploy/ultra-infer/python/ultra_infer/py_only/ts/processors.py
@@ -172,10 +172,10 @@ def _load_from_one_dataframe(
     else:
         time_col_vals = data.index
 
-    if np.issubdtype(time_col_vals.dtype, np.integer) and isinstance(freq, str):
+    if pd.api.types.is_integer_dtype(time_col_vals.dtype) and isinstance(freq, str):
         time_col_vals = time_col_vals.astype(str)
 
-    if np.issubdtype(time_col_vals.dtype, np.integer):
+    if pd.api.types.is_integer_dtype(time_col_vals.dtype):
         if freq:
             if not isinstance(freq, int) or freq < 1:
                 raise ValueError(
@@ -187,10 +187,11 @@ def _load_from_one_dataframe(
         if (stop_idx - start_idx) / freq != len(data):
             raise ValueError("The number of rows doesn't match with the RangeIndex!")
         time_index = pd.RangeIndex(start=start_idx, stop=stop_idx, step=freq)
-    elif np.issubdtype(time_col_vals.dtype, np.object_) or np.issubdtype(
-        time_col_vals.dtype, np.datetime64
+    elif (
+        pd.api.types.is_string_dtype(time_col_vals.dtype)
+        or pd.api.types.is_datetime64_any_dtype(time_col_vals.dtype)
     ):
-        time_col_vals = pd.to_datetime(time_col_vals, infer_datetime_format=True)
+        time_col_vals = pd.to_datetime(time_col_vals)
         time_index = pd.DatetimeIndex(time_col_vals)
         if freq:
             if not isinstance(freq, str):
@@ -336,7 +337,7 @@ def _to_time_features(
     else:
         tf_kcov = kcov.index.to_frame()
     time_col = tf_kcov.columns[0]
-    if np.issubdtype(tf_kcov[time_col].dtype, np.integer):
+    if pd.api.types.is_integer_dtype(tf_kcov[time_col].dtype):
         raise ValueError(
             "The time_col can't be the type of numpy.integer, and it must be the type of numpy.datetime64"
         )

--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
@@ -15,7 +15,7 @@
 import math
 from collections.abc import Iterable, Mapping, Sequence
 from functools import partial
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 import numpy as np
 
@@ -1002,14 +1002,14 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
                 cu_seqlens=cu_seqlens,
             )
 
-        def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
             stacked_params_mapping = [
                 ("qkv_proj", "q_proj", "q"),
                 ("qkv_proj", "k_proj", "k"),
                 ("qkv_proj", "v_proj", "v"),
             ]
             params_dict = dict(self.named_parameters(remove_duplicate=False))
-            loaded_params: set[str] = set()
+            loaded_params: Set[str] = set()
             for name, loaded_weight in weights:
                 if "rotary_emb.inv_freq" in name:
                     continue
@@ -1197,7 +1197,7 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
 
             return inputs_embeds
 
-        def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
 
             loader = AutoWeightsLoader(self)
             autoloaded_weights = loader.load_weights(weights)

--- a/paddlex/inference/models/common/transformers/transformers/conversion_utils.py
+++ b/paddlex/inference/models/common/transformers/transformers/conversion_utils.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar
 
 import numpy as np
 import paddle
@@ -42,7 +40,7 @@ class StateDictNameMapping:
     action: Optional[str] = None  # the value can be: transpose, merge_last_two_dim
     index: Optional[int] = None
 
-    slots: list[str] = None
+    slots: List[str] = None
 
     def __post_init__(self):
         self.target_name = self.target_name or self.source_name
@@ -54,7 +52,7 @@ class StateDictNameMapping:
         """check that whether merge last two dim"""
         return self.action == "merge_last_two_dim"
 
-    def run(self, state_dict: dict[str, ndarray], name: str) -> ndarray:
+    def run(self, state_dict: Dict[str, ndarray], name: str) -> ndarray:
         """run some custom operation on ndarray, eg: transpose, merge_last_two_dim
 
         Args:

--- a/paddlex/inference/models/common/ts/funcs.py
+++ b/paddlex/inference/models/common/ts/funcs.py
@@ -231,11 +231,11 @@ def load_from_one_dataframe(
         time_col_vals = data.index
 
     # Handle integer-based time column values when frequency is a string
-    if np.issubdtype(time_col_vals.dtype, np.integer) and isinstance(freq, str):
+    if pd.api.types.is_integer_dtype(time_col_vals.dtype) and isinstance(freq, str):
         time_col_vals = time_col_vals.astype(str)
 
     # Process integer-based time column values
-    if np.issubdtype(time_col_vals.dtype, np.integer):
+    if pd.api.types.is_integer_dtype(time_col_vals.dtype):
         if freq:
             if not isinstance(freq, int) or freq < 1:
                 raise ValueError(
@@ -248,11 +248,12 @@ def load_from_one_dataframe(
             raise ValueError("The number of rows doesn't match with the RangeIndex!")
         time_index = pd.RangeIndex(start=start_idx, stop=stop_idx, step=freq)
 
-    # Process datetime-like time column values
-    elif np.issubdtype(time_col_vals.dtype, np.object_) or np.issubdtype(
-        time_col_vals.dtype, np.datetime64
+    # Process datetime-like time column values (including StringDtype in pandas 2.x)
+    elif (
+        pd.api.types.is_string_dtype(time_col_vals.dtype)
+        or pd.api.types.is_datetime64_any_dtype(time_col_vals.dtype)
     ):
-        time_col_vals = pd.to_datetime(time_col_vals, infer_datetime_format=True)
+        time_col_vals = pd.to_datetime(time_col_vals)
         time_index = pd.DatetimeIndex(time_col_vals)
         if freq:
             if not isinstance(freq, str):
@@ -490,7 +491,7 @@ def time_feature(
         tf_kcov = kcov.index.to_frame()
     time_col = tf_kcov.columns[0]
     # Check if time column is of datetime type
-    if np.issubdtype(tf_kcov[time_col].dtype, np.integer):
+    if pd.api.types.is_integer_dtype(tf_kcov[time_col].dtype):
         raise ValueError(
             "The time_col can't be the type of numpy.integer, and it must be the type of numpy.datetime64"
         )

--- a/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
 import copy
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -878,7 +876,7 @@ class _LayoutParsingPipelineV2(BasePipeline):
         use_chart_recognition: Union[bool, None],
         use_region_detection: Union[bool, None],
         format_block_content: Union[bool, None],
-        markdown_ignore_labels: Optional[list[str]] = None,
+        markdown_ignore_labels: Optional[List[str]] = None,
     ) -> dict:
         """
         Get the model settings based on the provided parameters or default values.
@@ -937,7 +935,7 @@ class _LayoutParsingPipelineV2(BasePipeline):
 
     def predict(
         self,
-        input: Union[str, list[str], np.ndarray, list[np.ndarray]],
+        input: Union[str, List[str], np.ndarray, List[np.ndarray]],
         use_doc_orientation_classify: Union[bool, None] = None,
         use_doc_unwarping: Union[bool, None] = None,
         use_textline_orientation: Optional[bool] = None,
@@ -969,7 +967,7 @@ class _LayoutParsingPipelineV2(BasePipeline):
         use_ocr_results_with_table_cells: bool = True,
         use_e2e_wired_table_rec_model: bool = False,
         use_e2e_wireless_table_rec_model: bool = True,
-        markdown_ignore_labels: Optional[list[str]] = None,
+        markdown_ignore_labels: Optional[List[str]] = None,
         **kwargs,
     ) -> LayoutParsingResultV2:
         """

--- a/paddlex/inference/pipelines/layout_parsing/result_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/result_v2.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import copy
 import re
 from copy import deepcopy
 from functools import partial
-from typing import List
+from typing import Dict, List
 
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
@@ -192,7 +190,7 @@ class LayoutParsingResultV2(
         WordMixin.__init__(self)
         LatexMixin.__init__(self)
 
-    def _to_img(self) -> dict[str, np.ndarray]:
+    def _to_img(self) -> Dict[str, np.ndarray]:
         from .utils import get_show_color
 
         res_img_dict = {}
@@ -256,7 +254,7 @@ class LayoutParsingResultV2(
 
         return res_img_dict
 
-    def _to_str(self, *args, **kwargs) -> dict[str, str]:
+    def _to_str(self, *args, **kwargs) -> Dict[str, str]:
         """Converts the instance's attributes to a dictionary and then to a string.
 
         Args:
@@ -311,7 +309,7 @@ class LayoutParsingResultV2(
 
         return JsonMixin._to_str(data, *args, **kwargs)
 
-    def _to_json(self, *args, **kwargs) -> dict[str, str]:
+    def _to_json(self, *args, **kwargs) -> Dict[str, str]:
         """
         Converts the object's data to a JSON dictionary.
 
@@ -460,7 +458,7 @@ class LayoutParsingResultV2(
                 data["formula_res_list"].append(formula_res.json["res"])
         return JsonMixin._to_json(data, *args, **kwargs)
 
-    def _to_html(self) -> dict[str, str]:
+    def _to_html(self) -> Dict[str, str]:
         """Converts the prediction to its corresponding HTML representation.
 
         Returns:
@@ -476,7 +474,7 @@ class LayoutParsingResultV2(
                 res_html_dict[key] = table_res.html["pred"]
         return res_html_dict
 
-    def _to_xlsx(self) -> dict[str, str]:
+    def _to_xlsx(self) -> Dict[str, str]:
         """Converts the prediction HTML to an XLSX file path.
 
         Returns:

--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import queue
 import re
 import threading
 import time
 from itertools import chain
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -178,7 +176,7 @@ class _PaddleOCRVLPipeline(BasePipeline):
         use_ocr_for_image_block: Union[bool, None],
         format_block_content: Union[bool, None],
         merge_layout_blocks: Union[bool, None],
-        markdown_ignore_labels: Optional[list[str]] = None,
+        markdown_ignore_labels: Optional[List[str]] = None,
     ) -> dict:
         """
         Get the model settings based on the provided parameters or default values.
@@ -512,7 +510,7 @@ class _PaddleOCRVLPipeline(BasePipeline):
 
     def predict(
         self,
-        input: Union[str, list[str], np.ndarray, list[np.ndarray]],
+        input: Union[str, List[str], np.ndarray, List[np.ndarray]],
         use_doc_orientation_classify: Union[bool, None] = False,
         use_doc_unwarping: Union[bool, None] = False,
         use_layout_detection: Union[bool, None] = None,
@@ -534,7 +532,7 @@ class _PaddleOCRVLPipeline(BasePipeline):
         max_pixels: Optional[int] = None,
         max_new_tokens: Optional[int] = None,
         merge_layout_blocks: Optional[bool] = None,
-        markdown_ignore_labels: Optional[list[str]] = None,
+        markdown_ignore_labels: Optional[List[str]] = None,
         vlm_extra_args: Optional[dict] = None,
         **kwargs,
     ) -> PaddleOCRVLResult:

--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import queue
 import re
 import threading

--- a/paddlex/inference/pipelines/paddleocr_vl/result.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/result.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import random
 from functools import partial
+from typing import Dict
 
 import numpy as np
 from PIL import Image, ImageDraw
@@ -271,7 +270,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin):
             label for label in SKIP_ORDER_LABELS.copy() + markdown_ignore_labels
         ]
 
-    def _to_img(self) -> dict[str, np.ndarray]:
+    def _to_img(self) -> Dict[str, np.ndarray]:
         """
         Convert the parsing result to a dictionary of images.
 
@@ -350,7 +349,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin):
 
         return res_img_dict
 
-    def _to_html(self) -> dict[str, str]:
+    def _to_html(self) -> Dict[str, str]:
         """
         Converts the prediction to its corresponding HTML representation.
 
@@ -366,7 +365,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin):
                 res_html_dict[key] = table_res.html["pred"]
         return res_html_dict
 
-    def _to_xlsx(self) -> dict[str, str]:
+    def _to_xlsx(self) -> Dict[str, str]:
         """
         Converts the prediction HTML to an XLSX file path.
 
@@ -382,7 +381,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin):
                 res_xlsx_dict[key] = table_res.xlsx["pred"]
         return res_xlsx_dict
 
-    def _to_str(self, *args, **kwargs) -> dict[str, str]:
+    def _to_str(self, *args, **kwargs) -> Dict[str, str]:
         """
         Converts the instance's attributes to a dictionary and then to a string.
 
@@ -423,7 +422,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin):
         data["parsing_res_list"] = parsing_res_list
         return JsonMixin._to_str(data, *args, **kwargs)
 
-    def _to_json(self, *args, **kwargs) -> dict[str, str]:
+    def _to_json(self, *args, **kwargs) -> Dict[str, str]:
         """
         Converts the object's data to a JSON dictionary.
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ BASE_DEP_SPECS = {
     "langchain-text-splitters": ">= 0.2, < 1.0",
     "lxml": "",
     "matplotlib": "",
-    "modelscope": ">=1.28.0",
+    "modelscope": "==1.29.0",
     "numpy": ">= 1.24",
     "openai": ">= 1.63",
     "OpenCC": "",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ BASE_DEP_SPECS = {
     "langchain-text-splitters": ">= 0.2, < 1.0",
     "lxml": "",
     "matplotlib": "",
-    "modelscope": "==1.29.0",
+    "modelscope": [
+        '== 1.29.0; python_version == "3.8"',
+        '>= 1.28.0; python_version >= "3.9"',
+    ],
     "numpy": ">= 1.24",
     "openai": ">= 1.63",
     "OpenCC": "",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ BASE_DEP_SPECS = {
     "lxml": "",
     "matplotlib": "",
     "modelscope": [
-        '== 1.29.0; python_version == "3.8"',
+        '>= 1.28.0, < 1.30; python_version == "3.8"',
         '>= 1.28.0; python_version >= "3.9"',
     ],
     "numpy": ">= 1.24",


### PR DESCRIPTION
## Summary
- Fix the TS dtype compatibility issue on pandas 2.x, where string time columns may be inferred as `StringDtype` and cause `np.issubdtype()` to fail during inference
- Replace TS dtype checks with `pd.api.types.is_integer_dtype()` / `is_string_dtype()` / `is_datetime64_any_dtype()` so both legacy `object` string columns and pandas 2.x `StringDtype` are handled correctly
- Pin `modelscope` to `1.29.0` to avoid the Python 3.8 `zoneinfo` import issue
- Replace runtime builtin generic annotations such as `list[...]` / `dict[...]` / `set[...]` with `List[...]` / `Dict[...]` / `Set[...]` in affected files to keep Python 3.8 compatibility without relying on postponed annotation evaluation

## Test plan
- [x] Actual TS runtime flow verified on Python 3.8 + pandas 1.3.5
- [x] Actual TS runtime flow verified on Python 3.8 + pandas 1.5.3
- [x] Actual TS runtime flow verified on Python 3.9 + pandas 1.5.3
- [x] Actual TS runtime flow verified on Python 3.10 + pandas 1.3.5
- [x] Actual TS runtime flow verified on Python 3.11 + pandas 1.5.3
- [x] Actual TS runtime flow verified on Python 3.12 + pandas 2.2.3 with `StringDtype`
- [x] `import paddlex` verified on Python 3.8 after the `modelscope` pin and annotation compatibility cleanup