### PR TITLE
Fix LaTeX export crash on reference blocks

### DIFF
--- a/paddlex/inference/common/result/mixin.py
+++ b/paddlex/inference/common/result/mixin.py
@@ -424,7 +424,7 @@ class LatexMixin:
                     content = escape_latex(re.sub(r"^\[\d+\]\s*", "", line))
                     key = f"ref{abs(hash(line)) % 100000}"
                     bibitems.append(f"\\bibitem{{{key}}} {content}")
-                return "\n".join(bibitems) + "\n", "\n".join(bibitems) + "\n"
+                return "\n".join(bibitems) + "\n"
             return f"% [Unknown block: {label}] {escape_latex(content)}\n\n"
 
         def blocks_to_latex(blocks, abs_image_paths) -> str:


### PR DESCRIPTION
block_to_latex() for reference type blocks returned a tuple instead of a string due to a stray comma on mixin.py:427, causing TypeError: sequence item 35: expected str instance, tuple found when blocks_to_latex() joins with "\n".join().

Remove the duplicate return value:
```python
# before (returns tuple)
return "\n".join(bibitems) + "\n", "\n".join(bibitems) + "\n"

# after (returns str)
return "\n".join(bibitems) + "\n"
```


Fixes PaddlePaddle/PaddleOCR#17754

