### PR TITLE
[ROCm] Remove BF16 workaround now that Paddle framework supports HIP BF16

### DIFF
--- a/paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py
+++ b/paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py
@@ -65,9 +65,7 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel):
     _tied_weights_keys = ["lm_head.weight"]
     config_class = PaddleOCRVLConfig
     _no_split_modules = ["Ernie4_5DecoderLayer", "SiglipEncoderLayer"]
-    # Keep visual encoder in fp32 for ROCm stability (MIOpen bf16 conv has bugs)
-    # This also improves precision for vision processing
-    _keep_in_fp32_modules = ["visual", "mlp_AR"]
+    _keep_in_fp32_modules = None
     base_model_prefix = ""
 
     def __init__(self, config):

--- a/paddlex/inference/utils/misc.py
+++ b/paddlex/inference/utils/misc.py
@@ -31,7 +31,15 @@ def is_bfloat16_available(device):
     device_type, _ = parse_device(device)
     return (
         "npu" in get_device_type() or paddle.amp.is_bfloat16_supported()
-    ) and device_type in ("gpu", "npu", "xpu", "mlu", "metax_gpu", "iluvatar_gpu")
+    ) and device_type in (
+        "gpu",
+        "dcu",
+        "npu",
+        "xpu",
+        "mlu",
+        "metax_gpu",
+        "iluvatar_gpu",
+    )
 
 
 def is_float16_available(device):


### PR DESCRIPTION
## Description

Remove BF16 workarounds for ROCm now that Paddle framework supports HIP BF16 precision type.

## Changes

1. **paddlex/inference/utils/misc.py**: Add "dcu" device to `is_bfloat16_available()` function

2. **paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py**: Set `_keep_in_fp32_modules = None` instead of `["visual", "mlp_AR"]`

## Motivation

Previously PaddleX had workarounds because Paddle framework did not support HIP BF16:
- `is_bfloat16_available()` returned False for ROCm
- Visual encoder forced to FP32 via `_keep_in_fp32_modules`

Now that Paddle framework supports HIP BF16 (PR: https://github.com/PaddlePaddle/Paddle/pull/78665), these workarounds can be removed.

## Related Issues

Fixes #5081

## Checklist
- [x] Code is formatted per PaddleX coding conventions
- [x] Unit tests pass
- [x] Documentation updated if needed