### PR TITLE
Add Python 3.12 training support for dependency resolution

### DIFF
--- a/paddlex/repo_manager/repo.py
+++ b/paddlex/repo_manager/repo.py
@@ -16,6 +16,7 @@ import importlib
 import os
 import os.path as osp
 import shutil
+import sys
 import tempfile
 
 from packaging.requirements import Requirement
@@ -394,13 +395,22 @@ class RepositoryGroupInstaller(object):
                 line_s = "albumentations @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/albumentations-1.4.10%2Bpdx-py3-none-any.whl"
                 line_s += "\nalbucore @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/albucore-0.0.13%2Bpdx-py3-none-any.whl"
             elif req.name.replace("_", "-") == "nuscenes-devkit":
-                # HACK
-                line_s = "nuscenes-devkit @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/nuscenes_devkit-1.1.11%2Bpdx-py3-none-any.whl"
+                # HACK: Use patched wheel with opencv-contrib-python.
+                # 1.2.0+pdx requires Python >=3.9; 1.1.11+pdx for older Python.
+                if sys.version_info >= (3, 9):
+                    line_s = "nuscenes-devkit @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/nuscenes_devkit-1.2.0%2Bpdx-py3-none-any.whl"
+                else:
+                    line_s = "nuscenes-devkit @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/nuscenes_devkit-1.1.11%2Bpdx-py3-none-any.whl"
             elif req.name == "imgaug":
                 # HACK
                 line_s = "imgaug @ https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/patched_packages/imgaug-0.4.0%2Bpdx-py2.py3-none-any.whl"
             elif "tool_helpers" in req.name:
                 # For compatibility with higher versions of Python (python>=3.12)
+                continue
+            elif req.name in ("multiprocess", "dill"):
+                # For compatibility with higher versions of Python (python>=3.12)
+                # These are transitive dependencies of `datasets` and will be
+                # installed without the restrictive version pins.
                 continue
             lines.append(line_s)
 


### PR DESCRIPTION
## Summary
- Skip `multiprocess` and `dill` version pins from PaddleNLP during dependency collection (transitive deps of `datasets` will provide compatible versions)
- Upgrade nuscenes-devkit patched wheel from 1.1.11+pdx to 1.2.0+pdx for Python >=3.9 (fixes `Shapely<2.0` and `matplotlib<3.6` constraints that fail to build on Python 3.12)
- Keeps 1.1.11+pdx fallback for Python <3.9

## Test plan
- [x] End-to-end `pip install --dry-run` test passed for all 8 training repos on Python 3.12
- [x] Verified `nuscenes-devkit-1.2.0+pdx` BOS URL is accessible
- [x] Verified `multiprocess` and `dill` are correctly installed as transitive deps of `datasets`