### PR TITLE
Fix matplotlib 3.10 compatibility: replace removed tostring_rgb()

### DIFF
--- a/paddlex/modules/formula_recognition/dataset_checker/dataset_src/analyse_dataset.py
+++ b/paddlex/modules/formula_recognition/dataset_checker/dataset_src/analyse_dataset.py
@@ -149,9 +149,9 @@ def deep_analyse(dataset_path, output, datatype="FormulaRecDataset"):
     canvas = FigureCanvasAgg(fig)
     canvas.draw()
     width, height = fig.get_size_inches() * fig.get_dpi()
-    pie_array = np.frombuffer(canvas.tostring_rgb(), dtype="uint8").reshape(
-        int(height), int(width), 3
-    )
+    pie_array = np.asarray(canvas.buffer_rgba()).reshape(
+        int(height), int(width), 4
+    )[:, :, :3]
     fig1_path = os.path.join(output, "histogram.png")
     cv2.imwrite(fig1_path, pie_array)
 

--- a/paddlex/modules/text_detection/dataset_checker/dataset_src/analyse_dataset.py
+++ b/paddlex/modules/text_detection/dataset_checker/dataset_src/analyse_dataset.py
@@ -190,9 +190,9 @@ def deep_analyse(dataset_path, output):
     canvas = FigureCanvasAgg(fig)
     canvas.draw()
     width, height = fig.get_size_inches() * fig.get_dpi()
-    bar_array = np.frombuffer(canvas.tostring_rgb(), dtype="uint8").reshape(
-        int(height), int(width), 3
-    )
+    bar_array = np.asarray(canvas.buffer_rgba()).reshape(
+        int(height), int(width), 4
+    )[:, :, :3]
 
     # pie
     fig, ax = plt.subplots()
@@ -202,9 +202,9 @@ def deep_analyse(dataset_path, output):
     canvas = FigureCanvasAgg(fig)
     canvas.draw()
     width, height = fig.get_size_inches() * fig.get_dpi()
-    pie_array = np.frombuffer(canvas.tostring_rgb(), dtype="uint8").reshape(
-        int(height), int(width), 3
-    )
+    pie_array = np.asarray(canvas.buffer_rgba()).reshape(
+        int(height), int(width), 4
+    )[:, :, :3]
 
     os.makedirs(output, exist_ok=True)
     fig_path = os.path.join(output, "histogram.png")

--- a/paddlex/modules/text_recognition/dataset_checker/dataset_src/analyse_dataset.py
+++ b/paddlex/modules/text_recognition/dataset_checker/dataset_src/analyse_dataset.py
@@ -153,9 +153,9 @@ def deep_analyse(dataset_path, output, datatype="MSTextRecDataset"):
     canvas = FigureCanvasAgg(fig)
     canvas.draw()
     width, height = fig.get_size_inches() * fig.get_dpi()
-    pie_array = np.frombuffer(canvas.tostring_rgb(), dtype="uint8").reshape(
-        int(height), int(width), 3
-    )
+    pie_array = np.asarray(canvas.buffer_rgba()).reshape(
+        int(height), int(width), 4
+    )[:, :, :3]
     fig1_path = os.path.join(output, "histogram.png")
     cv2.imwrite(fig1_path, pie_array)
 


### PR DESCRIPTION
## Summary
- `FigureCanvasAgg.tostring_rgb()` was removed in matplotlib 3.10, causing `AttributeError` in dataset checker analysis
- Replaced with `buffer_rgba()` (available since matplotlib 3.1+) in 3 affected files
- Fixes CI failure in `text_recognition_dataset_check`

## Test plan
- [ ] CI passes for `text_recognition_dataset_check`, `text_detection_dataset_check`, `formula_recognition_dataset_check`