### PR TITLE
fix(genai): prevent PaddleOCR-VL vLLM token mismatch for tiny crops

### DIFF
--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_image_utils.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_image_utils.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Shared image preprocessing helpers for PaddleOCR-VL GenAI backends."""
+
+import math
+from collections.abc import Mapping
+
+from PIL import Image
+
+
+def smart_resize(
+    height: int,
+    width: int,
+    factor: int = 28,
+    min_pixels: int = 28 * 28 * 130,
+    max_pixels: int = 28 * 28 * 1280,
+):
+    """Resize dimensions to the nearest valid grid under the pixel budget."""
+    if height < factor:
+        width = round((width * factor) / height)
+        height = factor
+
+    if width < factor:
+        height = round((height * factor) / width)
+        width = factor
+
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}"
+        )
+
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = math.floor(height / beta / factor) * factor
+        w_bar = math.floor(width / beta / factor) * factor
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+    return h_bar, w_bar
+
+
+def resize_image(image, min_pixels, max_pixels, factor) -> Image.Image:
+    width, height = image.size
+    resized_height, resized_width = smart_resize(
+        height,
+        width,
+        factor=factor,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    return image.resize((resized_width, resized_height))
+
+
+def _resize_image_payload(payload, *, min_pixels, max_pixels, factor):
+    if isinstance(payload, Image.Image):
+        return resize_image(payload, min_pixels, max_pixels, factor)
+    if isinstance(payload, list):
+        return [
+            _resize_image_payload(
+                item,
+                min_pixels=min_pixels,
+                max_pixels=max_pixels,
+                factor=factor,
+            )
+            for item in payload
+        ]
+    if isinstance(payload, tuple):
+        return tuple(
+            _resize_image_payload(
+                item,
+                min_pixels=min_pixels,
+                max_pixels=max_pixels,
+                factor=factor,
+            )
+            for item in payload
+        )
+    return payload
+
+
+def prepare_hf_processor_mm_data(mm_data: Mapping[str, object], image_processor):
+    prepared = dict(mm_data)
+    if "image" not in prepared:
+        return prepared
+
+    factor = image_processor.patch_size * image_processor.merge_size
+    prepared["image"] = _resize_image_payload(
+        prepared["image"],
+        min_pixels=image_processor.min_pixels,
+        max_pixels=image_processor.max_pixels,
+        factor=factor,
+    )
+    return prepared

--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_image_utils.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_image_utils.py
@@ -95,14 +95,13 @@ def _resize_image_payload(payload, *, min_pixels, max_pixels, factor):
 
 def prepare_hf_processor_mm_data(mm_data: Mapping[str, object], image_processor):
     prepared = dict(mm_data)
-    if "image" not in prepared:
-        return prepared
-
     factor = image_processor.patch_size * image_processor.merge_size
-    prepared["image"] = _resize_image_payload(
-        prepared["image"],
-        min_pixels=image_processor.min_pixels,
-        max_pixels=image_processor.max_pixels,
-        factor=factor,
-    )
+    for image_key in ("image", "images"):
+        if image_key in prepared:
+            prepared[image_key] = _resize_image_payload(
+                prepared[image_key],
+                min_pixels=image_processor.min_pixels,
+                max_pixels=image_processor.max_pixels,
+                factor=factor,
+            )
     return prepared

--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_sglang/processor.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_sglang/processor.py
@@ -19,7 +19,6 @@ from ......utils.deps import is_dep_available
 
 if all(map(is_dep_available, ("sglang", "torch"))):
     import asyncio
-    import math
 
     import torch
     from PIL import Image
@@ -27,58 +26,7 @@ if all(map(is_dep_available, ("sglang", "torch"))):
         BaseMultimodalProcessor,
         MultimodalSpecialTokens,
     )
-
-    def smart_resize(
-        height: int,
-        width: int,
-        factor: int = 28,
-        min_pixels: int = 28 * 28 * 130,
-        max_pixels: int = 28 * 28 * 1280,
-    ):
-        """Rescales the image so that the following conditions are met:
-
-        1. Both dimensions (height and width) are divisible by 'factor'.
-
-        2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
-
-        3. The aspect ratio of the image is maintained as closely as possible.
-
-        """
-        if height < factor:
-            width = round((width * factor) / height)
-            height = factor
-
-        if width < factor:
-            height = round((height * factor) / width)
-            width = factor
-
-        if max(height, width) / min(height, width) > 200:
-            raise ValueError(
-                f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}"
-            )
-        h_bar = round(height / factor) * factor
-        w_bar = round(width / factor) * factor
-        if h_bar * w_bar > max_pixels:
-            beta = math.sqrt((height * width) / max_pixels)
-            h_bar = math.floor(height / beta / factor) * factor
-            w_bar = math.floor(width / beta / factor) * factor
-        elif h_bar * w_bar < min_pixels:
-            beta = math.sqrt(min_pixels / (height * width))
-            h_bar = math.ceil(height * beta / factor) * factor
-            w_bar = math.ceil(width * beta / factor) * factor
-        return h_bar, w_bar
-
-    def resize_image(image, min_pixels, max_pixels, factor) -> Image.Image:
-        width, height = image.size
-        resized_height, resized_width = smart_resize(
-            height,
-            width,
-            factor=factor,
-            min_pixels=min_pixels,
-            max_pixels=max_pixels,
-        )
-        image = image.resize((resized_width, resized_height))
-        return image
+    from .._image_utils import resize_image
 
     async def resize_image_async(image, min_pixels, max_pixels, factor):
         return resize_image(image, min_pixels, max_pixels, factor)

--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from collections.abc import Iterable, Mapping, Sequence
 from functools import partial
 from typing import List, Optional, Set, Tuple, Union
@@ -20,6 +19,7 @@ from typing import List, Optional, Set, Tuple, Union
 import numpy as np
 
 from .....utils.deps import is_dep_available
+from ._image_utils import prepare_hf_processor_mm_data, smart_resize
 
 if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
     import torch
@@ -84,47 +84,6 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
     )
     from vllm.multimodal.profiling import BaseDummyInputsBuilder
     from vllm.sequence import IntermediateTensors
-
-    def smart_resize(
-        height: int,
-        width: int,
-        factor: int = 28,
-        min_pixels: int = 28 * 28 * 130,
-        max_pixels: int = 28 * 28 * 1280,
-    ):
-        """Rescales the image so that the following conditions are met:
-
-        1. Both dimensions (height and width) are divisible by 'factor'.
-
-        2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
-
-        3. The aspect ratio of the image is maintained as closely as possible.
-
-        """
-
-        if height < factor:
-            width = round((width * factor) / height)
-            height = factor
-
-        if width < factor:
-            height = round((height * factor) / width)
-            width = factor
-
-        if max(height, width) / min(height, width) > 200:
-            raise ValueError(
-                f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}"
-            )
-        h_bar = round(height / factor) * factor
-        w_bar = round(width / factor) * factor
-        if h_bar * w_bar > max_pixels:
-            beta = math.sqrt((height * width) / max_pixels)
-            h_bar = math.floor(height / beta / factor) * factor
-            w_bar = math.floor(width / beta / factor) * factor
-        elif h_bar * w_bar < min_pixels:
-            beta = math.sqrt(min_pixels / (height * width))
-            h_bar = math.ceil(height * beta / factor) * factor
-            w_bar = math.ceil(width * beta / factor) * factor
-        return h_bar, w_bar
 
     class PaddleOCRVLProcessingInfo(BaseProcessingInfo):
 
@@ -225,9 +184,13 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
             tok_kwargs: Mapping[str, object],
         ) -> BatchFeature:
             if mm_data:
+                hf_processor = self.info.get_hf_processor(**mm_kwargs)
+                prepared_mm_data = prepare_hf_processor_mm_data(
+                    mm_data, hf_processor.image_processor
+                )
                 processed_outputs = self.info.ctx.call_hf_processor(
-                    self.info.get_hf_processor(**mm_kwargs),
-                    dict(text=prompt, **mm_data),
+                    hf_processor,
+                    dict(text=prompt, **prepared_mm_data),
                     dict(**mm_kwargs, **tok_kwargs),
                 )
                 processed_outputs["pixel_values"] = processed_outputs[

--- a/tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py
+++ b/tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py
@@ -1,0 +1,96 @@
+#
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for PaddleOCR-VL image preprocessing helpers."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from PIL import Image
+
+
+def _load_image_utils_module():
+    current = Path(__file__).resolve()
+    repo_root = next(parent for parent in current.parents if (parent / "pyproject.toml").exists())
+    module_path = (
+        repo_root
+        / "paddlex"
+        / "inference"
+        / "genai"
+        / "models"
+        / "paddleocr_vl_09b"
+        / "_image_utils.py"
+    )
+    spec = spec_from_file_location("paddleocr_vl_image_utils", module_path)
+    module = module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyImageProcessor:
+    min_pixels = 28 * 28 * 130
+    max_pixels = 28 * 28 * 1280
+    patch_size = 14
+    merge_size = 2
+
+
+def test_smart_resize_upscales_32_square_to_min_pixel_grid():
+    image_utils = _load_image_utils_module()
+
+    assert image_utils.smart_resize(
+        height=32,
+        width=32,
+        factor=28,
+        min_pixels=DummyImageProcessor.min_pixels,
+        max_pixels=DummyImageProcessor.max_pixels,
+    ) == (336, 336)
+
+
+def test_prepare_hf_processor_mm_data_resizes_tiny_pil_images():
+    image_utils = _load_image_utils_module()
+    mm_data = {"image": [Image.new("RGB", (32, 32), "white")], "meta": "keep"}
+
+    prepared = image_utils.prepare_hf_processor_mm_data(
+        mm_data, DummyImageProcessor()
+    )
+
+    assert prepared["meta"] == "keep"
+    assert prepared["image"][0].size == (336, 336)
+
+
+def test_prepare_hf_processor_mm_data_does_not_mutate_original_payload():
+    image_utils = _load_image_utils_module()
+    original_image = Image.new("RGB", (32, 32), "white")
+    mm_data = {"image": [original_image]}
+
+    prepared = image_utils.prepare_hf_processor_mm_data(
+        mm_data, DummyImageProcessor()
+    )
+
+    assert mm_data["image"][0].size == (32, 32)
+    assert prepared["image"][0].size == (336, 336)
+    assert prepared["image"][0] is not original_image
+
+
+def test_prepare_hf_processor_mm_data_keeps_non_pil_payloads():
+    image_utils = _load_image_utils_module()
+    mm_data = {"image": ["already-encoded"], "meta": "keep"}
+
+    prepared = image_utils.prepare_hf_processor_mm_data(
+        mm_data, DummyImageProcessor()
+    )
+
+    assert prepared == mm_data

--- a/tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py
+++ b/tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py
@@ -71,6 +71,18 @@ def test_prepare_hf_processor_mm_data_resizes_tiny_pil_images():
     assert prepared["image"][0].size == (336, 336)
 
 
+def test_prepare_hf_processor_mm_data_resizes_vllm_images_payload():
+    image_utils = _load_image_utils_module()
+    mm_data = {"images": [Image.new("RGB", (32, 32), "white")], "meta": "keep"}
+
+    prepared = image_utils.prepare_hf_processor_mm_data(
+        mm_data, DummyImageProcessor()
+    )
+
+    assert prepared["meta"] == "keep"
+    assert prepared["images"][0].size == (336, 336)
+
+
 def test_prepare_hf_processor_mm_data_does_not_mutate_original_payload():
     image_utils = _load_image_utils_module()
     original_image = Image.new("RGB", (32, 32), "white")


### PR DESCRIPTION
## Summary

- Pre-resize PaddleOCR-VL PIL image payloads on the vLLM path before calling the HF processor.
- Share the PaddleOCR-VL image resizing helper across vLLM and sglang integration code.
- Add regression tests for tiny crop token counting, PIL payload resizing, passthrough behavior, and payload non-mutation.

## Background

PaddleOCR-VL can produce very small formula crops during pipeline post-processing. For the image in `PaddlePaddle/PaddleOCR#17378`, the formula crop path can reduce the original `32x32` image into a tiny RGB crop equivalent to:

```text
PIL size: (width=11, height=3)
NumPy shape after PIL conversion: (3, 11, 3)
```

In the vLLM integration, image placeholder replacement is computed from the original multimodal item size. For a PIL image, vLLM reads the size from `image.size`, so this crop is interpreted as:

```text
height = 3
width = 11
smart_resize(3, 11) -> (196, 672)
placeholder image tokens = 168
```

The HF PaddleOCR-VL processor converts the same PIL image into a NumPy array before resizing. The converted shape is:

```text
(3, 11, 3)
```

Because both the first and last dimensions are channel-like, the processor's channel-dimension inference treats the first dimension as the channel dimension. The processor therefore computes the visual grid from:

```text
height = 11
width = 3
smart_resize(11, 3) -> (644, 196)
image_grid_thw = [1, 46, 14]
visual tokens = 161
```

This creates a mismatch between the number of image placeholder tokens inserted into the prompt and the number of visual features produced by the processor:

```text
placeholder image tokens: 168
visual feature tokens:    161
```

That mismatch can surface as vLLM image embedding / image token alignment failures for tiny PaddleOCR-VL crops.

## Fix

This PR normalizes PIL image payloads before they are passed to the HF processor on the vLLM path.

For the tiny crop above, the PIL payload is resized first with the same PaddleOCR-VL resize contract used by vLLM token counting:

```text
before: PIL size = (11, 3)
after:  PIL size = (672, 196)
```

After this resize, the HF processor sees an unambiguous channels-last array:

```text
NumPy shape after PIL conversion: (196, 672, 3)
image_grid_thw = [1, 14, 48]
visual tokens = 168
```

The prompt placeholder count and processor-produced visual feature count are then aligned:

```text
placeholder image tokens: 168
visual feature tokens:    168
```

The helper keeps non-PIL payloads unchanged, preserving the existing behavior for already-encoded or non-image payloads.

## Tests

- `./.venv/bin/python -m pytest tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py tests/unit/inference/genai/models/paddleocr_vl_09b/test_vllm_image_shape_diagnostics.py -q`
- `./.venv/bin/python -m py_compile paddlex/inference/genai/models/paddleocr_vl_09b/_image_utils.py paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py paddlex/inference/genai/models/paddleocr_vl_09b/_sglang/processor.py tests/unit/inference/genai/models/paddleocr_vl_09b/test_image_preprocessing.py tests/unit/inference/genai/models/paddleocr_vl_09b/test_vllm_image_shape_diagnostics.py`

## Related

- Addresses `PaddlePaddle/PaddleOCR#17378`
- Supersedes `#5086`
