### PR TITLE
[ROCm] Remove BF16 workarounds for PaddleOCR-VL on HIP

### DIFF
--- a/paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py
+++ b/paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py
@@ -65,9 +65,6 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel):
     _tied_weights_keys = ["lm_head.weight"]
     config_class = PaddleOCRVLConfig
     _no_split_modules = ["Ernie4_5DecoderLayer", "SiglipEncoderLayer"]
-    # Keep visual encoder in fp32 for ROCm stability (MIOpen bf16 conv has bugs)
-    # This also improves precision for vision processing
-    _keep_in_fp32_modules = ["visual", "mlp_AR"]
     base_model_prefix = ""
 
     def __init__(self, config):

--- a/paddlex/inference/models/runners/paddle_static/runner.py
+++ b/paddlex/inference/models/runners/paddle_static/runner.py
@@ -403,9 +403,6 @@ class PaddleStaticRunner(InferenceRunner):
                 config.set_optimization_level(3)
                 if self._model_name == "PP-DocLayoutV3":
                     config.delete_pass("matmul_add_act_fuse_pass")
-                if paddle.is_compiled_with_rocm():
-                    config.delete_pass("conv2d_add_act_fuse_pass")
-                    config.delete_pass("conv2d_add_fuse_pass")
             elif self._config["device_type"] == "npu":
                 config.enable_custom_device("npu", self._config.get("device_id", 0))
                 if hasattr(config, "enable_new_ir"):
@@ -459,9 +456,6 @@ class PaddleStaticRunner(InferenceRunner):
                 config.disable_mkldnn()
                 if hasattr(config, "enable_new_executor"):
                     config.enable_new_executor()
-                if paddle.is_compiled_with_rocm():
-                    config.delete_pass("conv2d_add_act_fuse_pass")
-                    config.delete_pass("conv2d_add_fuse_pass")
             elif self._config["device_type"] == "iluvatar_gpu":
                 config.enable_custom_device(
                     "iluvatar_gpu", int(self._config.get("device_id", 0))
@@ -493,18 +487,12 @@ class PaddleStaticRunner(InferenceRunner):
                 if hasattr(config, "enable_new_executor"):
                     config.enable_new_executor()
                 config.set_optimization_level(3)
-                if paddle.is_compiled_with_rocm():
-                    config.delete_pass("conv2d_add_act_fuse_pass")
-                    config.delete_pass("conv2d_add_fuse_pass")
         config.enable_memory_optim()
         for del_p in self._config.get("delete_pass", []):
             config.delete_pass(del_p)
 
         if not DEBUG:
             config.disable_glog_info()
-        if paddle.is_compiled_with_rocm():
-            config.delete_pass("conv2d_add_act_fuse_pass")
-            config.delete_pass("conv2d_add_fuse_pass")
 
         predictor = paddle_inference.create_predictor(config)
 


### PR DESCRIPTION
## Summary

PaddlePaddle/Paddle#78711 在框架层适配了 HIP BF16 剩余的算子缺口（`layer_norm` / `softmax` 注册 BF16 内核，`conv2d_add[_act]_fuse_pass` 在 HIP wheel 上不再注册）。配合已合入的 PaddlePaddle/Paddle#78587（BF16 conv 内核），PaddleOCR-VL 端到端 BF16 推理在 AMD GPU 上已经可以跑通。本 PR 同步移除 PaddleX 中针对 ROCm 的两类 BF16 workaround。

修复 #5095。**依赖 PaddlePaddle/Paddle#78711 与 PaddlePaddle/Paddle#78587 都合入并发版后才能合并**——否则旧 wheel 上 BF16 视觉子图仍会崩溃。

## Changes

- `paddlex/inference/models/doc_vlm/modeling/paddleocr_vl/_paddleocr_vl.py`：删除 `_keep_in_fp32_modules = ["visual", "mlp_AR"]`，让 SigLIP 视觉塔 + `mlp_AR` projector 跟随模型 dtype，无需强制 FP32。
- `paddlex/inference/models/runners/paddle_static/runner.py`：删除 4 处 `if paddle.is_compiled_with_rocm(): config.delete_pass("conv2d_add_act_fuse_pass"); config.delete_pass("conv2d_add_fuse_pass")` 块（行 406-408、462-464、496-498、505-507）。

CUDA 推理行为完全不变。

## 与现有 PR 的关系

- `_keep_in_fp32_modules = None` 部分与 #5077（fchange，Hackathon）改动重叠。本 PR 同时把 `runner.py` 中 4 处 `delete_pass` workaround 一并清理（#5077 未覆盖），所以两个 PR 任一先合后只需 trivial rebase 即可。建议合本 PR 时若 #5077 已先合，git 自动跳过 `_keep_in_fp32_modules` 的删除，余下 `runner.py` 部分继续生效。
- 与 #5076（fchange）和 #5081（Lau-JW）issue 描述的问题为同一组 workaround，详细差异说明见 #5095。

## Test plan

- AMD MI300X (gfx942) / ROCm 7.2 / Paddle develop（含 PaddlePaddle/Paddle#78587 + PaddlePaddle/Paddle#78711）：
  - `paddlex.create_pipeline("PaddleOCR-VL")` BF16 推理 `test_ocr.png` 端到端跑通。
  - 输出文本与 FP32-fallback 路径语义一致（416 vs 417 字节，仅多一处段落分隔）。
  - `rocprofv3 --kernel-trace --stats`：FP32 GEMM 调用从 18 756 → 1 316，GPU kernel 时间 4 415.7 ms → 3 915.5 ms（1.13×）。
  - 详细 benchmark 见 PaddlePaddle/Paddle#78711 PR 描述里附的 BF16 benchmark。
- CUDA：未独立验证（无硬件），但 `_keep_in_fp32_modules` 注释明确写其目的为 "ROCm stability (MIOpen bf16 conv has bugs)"，移除后视觉塔仍按模型加载 dtype 运行；`delete_pass` 块包在 `is_compiled_with_rocm()` 下，对 CUDA 路径无影响。