### PR TITLE
[fix] Restore Python 3.8 compat and guard future regressions

### DIFF
--- a/.github/workflows/py38_compat.yml
+++ b/.github/workflows/py38_compat.yml
@@ -1,0 +1,28 @@
+name: Python 3.8 Compatibility
+
+on:
+  push:
+    branches: [develop, 'release/*']
+  pull_request:
+    branches: [develop, 'release/*']
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Static annotation check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.8"
+      - name: Scan for PEP 585 / PEP 604 annotations missing `from __future__ import annotations`
+        run: |
+          python .precommit/check_py38_compat.py $(
+            find paddlex -type f -name '*.py' \
+              -not -path 'paddlex/repo_manager/repos/*'
+          )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,9 @@ repos:
         additional_dependencies:
             - stdlib-list==0.10.0
             - setuptools
+    -   id: check-py38-compat
+        name: Check Python 3.8 Compatibility
+        entry: python .precommit/check_py38_compat.py
+        language: python
+        files: ^paddlex/.*\.py$
+        exclude: ^paddlex/repo_manager/repos/

--- a/.precommit/check_py38_compat.py
+++ b/.precommit/check_py38_compat.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static check: flag PEP 585 (``list[...]``/``tuple[...]``/...) and PEP 604
+(``X | Y``) usage in runtime-evaluated annotations when the file lacks
+``from __future__ import annotations``.
+
+Without the ``__future__`` import, these forms are evaluated at function
+definition time and raise ``TypeError`` on Python 3.8 at import — which is
+still a supported target for PaddleX.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+from typing import Iterator, List, Tuple
+
+PEP585_BUILTINS = frozenset(
+    {"list", "tuple", "dict", "set", "frozenset", "type"}
+)
+
+
+def has_future_annotations(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
+def iter_annotations(tree: ast.AST) -> Iterator[ast.AST]:
+    """Yield every AST node that is a runtime-evaluated annotation."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and node.annotation is not None:
+            yield node.annotation
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.returns is not None:
+                yield node.returns
+            args = node.args
+            for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+                if arg.annotation is not None:
+                    yield arg.annotation
+            if args.vararg is not None and args.vararg.annotation is not None:
+                yield args.vararg.annotation
+            if args.kwarg is not None and args.kwarg.annotation is not None:
+                yield args.kwarg.annotation
+
+
+def find_issues(annotation: ast.AST) -> List[Tuple[int, int, str]]:
+    issues: List[Tuple[int, int, str]] = []
+    for node in ast.walk(annotation):
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+            name = node.value.id
+            if name in PEP585_BUILTINS:
+                issues.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        f"PEP 585 builtin generic `{name}[...]`",
+                    )
+                )
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            issues.append(
+                (node.lineno, node.col_offset, "PEP 604 union `X | Y`")
+            )
+    return issues
+
+
+def check(file_path: str) -> bool:
+    src = pathlib.Path(file_path).read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(src, filename=file_path)
+    except SyntaxError as e:
+        print(f"{file_path}:{e.lineno}:{e.offset}: failed to parse: {e.msg}")
+        return False
+
+    if has_future_annotations(tree):
+        return True
+
+    ok = True
+    for annotation in iter_annotations(tree):
+        for line, col, msg in find_issues(annotation):
+            print(
+                f"{file_path}:{line}:{col}: {msg} — "
+                "add `from __future__ import annotations` for Py3.8 support"
+            )
+            ok = False
+    return ok
+
+
+def main() -> int:
+    files = sys.argv[1:]
+    ok = True
+    for f in files:
+        if not check(f):
+            ok = False
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.precommit/check_py38_compat.py
+++ b/.precommit/check_py38_compat.py
@@ -28,9 +28,7 @@ import pathlib
 import sys
 from typing import Iterator, List, Tuple
 
-PEP585_BUILTINS = frozenset(
-    {"list", "tuple", "dict", "set", "frozenset", "type"}
-)
+PEP585_BUILTINS = frozenset({"list", "tuple", "dict", "set", "frozenset", "type"})
 
 
 def has_future_annotations(tree: ast.Module) -> bool:
@@ -73,9 +71,7 @@ def find_issues(annotation: ast.AST) -> List[Tuple[int, int, str]]:
                     )
                 )
         elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-            issues.append(
-                (node.lineno, node.col_offset, "PEP 604 union `X | Y`")
-            )
+            issues.append((node.lineno, node.col_offset, "PEP 604 union `X | Y`"))
     return issues
 
 

--- a/paddlex/inference/models/__init__.py
+++ b/paddlex/inference/models/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from collections.abc import Mapping
 from functools import lru_cache

--- a/paddlex/inference/models/image_classification/modeling/_config.py
+++ b/paddlex/inference/models/image_classification/modeling/_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from ...common.transformers.transformers import PretrainedConfig
 
 

--- a/paddlex/inference/pipelines/base.py
+++ b/paddlex/inference/pipelines/base.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Union
 

--- a/paddlex/inference/serving/basic_serving/_app.py
+++ b/paddlex/inference/serving/basic_serving/_app.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import json

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ BASE_DEP_SPECS = {
     "latex2mathml": "",
     "matplotlib": "",
     "modelscope": [
-        '>= 1.28.0, < 1.30; python_version == "3.8"',
+        # modelscope 1.29.2+ unconditionally imports `zoneinfo`, which is
+        # Python 3.9+ stdlib. Cap at < 1.29.2 to keep Py3.8 working; 1.29.0
+        # and 1.29.1 import cleanly.
+        '>= 1.28.0, < 1.29.2; python_version == "3.8"',
         '>= 1.28.0; python_version >= "3.9"',
     ],
     "numpy": ">= 1.24, < 2.4",


### PR DESCRIPTION
## Summary

- Fix four modules that use PEP 585 generics (`tuple[...]`) or PEP 604 unions (`X | Y`) in runtime-evaluated annotations, which raise `TypeError: 'type' object is not subscriptable` at import on Python 3.8. Each gets `from __future__ import annotations`. Two of them are regressions from #5028 (`paddlex/inference/models/__init__.py`, `paddlex/inference/pipelines/base.py`); two are pre-existing violations surfaced by the new static check (`paddlex/inference/serving/basic_serving/_app.py`, `paddlex/inference/models/image_classification/modeling/_config.py`).
- Tighten the Python 3.8 cap on `modelscope` from `< 1.30` to `< 1.29.2`. modelscope 1.29.2 unconditionally `import zoneinfo` in `modelscope/hub/utils/utils.py`, a Python 3.9+ stdlib module, so any `import modelscope` on Py3.8 fails with `ModuleNotFoundError`. Verified that 1.28.2 / 1.29.0 / 1.29.1 import cleanly; 1.29.2 and 1.30.0 both fail the same way.
- Add an AST-based pre-commit hook + GitHub Actions workflow that flag the same annotation pattern. The guard scans every `paddlex/**/*.py` (excluding `paddlex/repo_manager/repos/`, which is populated by `paddlex install`) and fails if any runtime annotation uses PEP 585 / PEP 604 without `from __future__ import annotations`. Pre-commit can be bypassed locally, so the CI job is the binding gate.

## Context

Same class of annotation regression previously fixed in #5047. PR #5028 re-introduced it, and two unrelated spots (added in earlier commits) had the same bug silently. Adding the static check prevents a third round.

## Test plan

- [x] `uv python install 3.8` then compile/exec stripped skeletons of all four fixed annotation files — all pass.
- [x] Negative control: strip the new future import from `models/__init__.py` and re-run — confirmed `TypeError: 'type' object is not subscriptable` on 3.8.
- [x] `python .precommit/check_py38_compat.py` over the entire `paddlex/` tree (excluding `repo_manager/repos/`) — exit 0.
- [x] Sanity: hand-crafted `def f() -> tuple[int, int]: ...` without `__future__` is flagged; adding the import makes it pass.
- [x] Fresh Py3.8 venv: `pip install modelscope==1.28.2 / 1.29.0 / 1.29.1 / 1.29.2 / 1.30.0` each, then `python -c "import modelscope"` — confirms 1.29.2 and 1.30.0 fail, all earlier versions import cleanly.
- [x] `pre-commit run` on all touched files — all relevant hooks pass.
- [ ] CI `Python 3.8 Compatibility` job passes on this PR.