### PR TITLE
fix: gate langchain_text_splitters import behind its own dep check

### DIFF
--- a/paddlex/inference/pipelines/components/retriever/base.py
+++ b/paddlex/inference/pipelines/components/retriever/base.py
@@ -23,6 +23,7 @@ from .....utils.subclass_register import AutoRegisterABCMetaClass
 
 if is_dep_available("langchain"):
     from langchain_core.documents import Document
+if is_dep_available("langchain-text-splitters"):
     from langchain_text_splitters import RecursiveCharacterTextSplitter
 if is_dep_available("langchain-community"):
     from langchain_community import vectorstores


### PR DESCRIPTION
## Problem

`paddlex/inference/pipelines/components/retriever/base.py` declares its
dependencies as:

```python
if is_dep_available("langchain"):
    from langchain_core.documents import Document
    from langchain_text_splitters import RecursiveCharacterTextSplitter
if is_dep_available("langchain-community"):
    from langchain_community import vectorstores
    from langchain_community.vectorstores import FAISS
```

`is_dep_available("langchain")` only verifies that the `langchain`
distribution itself is installed. In `langchain` 1.x, however, the
`langchain-text-splitters` package is no longer pulled in transitively
(only `langchain-core`, `langgraph`, and `pydantic` are required).

When a user has `langchain` installed (often as a transitive dep of
some other tool) without `langchain-text-splitters`, the
unconditional `from langchain_text_splitters import …` raises
`ModuleNotFoundError` at **import** time — before the
`@class_requires_deps(...)` decorator on `BaseRetriever` has a chance
to surface its friendly `DependencyError`. This makes
`import paddlex` (and therefore `import paddleocr`) fail outright,
even for users who don't touch the retriever at all.

## Fix

Move the `langchain_text_splitters` import behind its own
`is_dep_available("langchain-text-splitters")` guard, mirroring the
pattern already used for `langchain-community` immediately below.
The `class_requires_deps` decorator on `BaseRetriever` continues to
list `langchain-text-splitters`, so attempts to actually use the
class without the package installed still fail with a clear,
actionable `DependencyError`.

Diff is one line:

```diff
 if is_dep_available("langchain"):
     from langchain_core.documents import Document
+if is_dep_available("langchain-text-splitters"):
     from langchain_text_splitters import RecursiveCharacterTextSplitter
 if is_dep_available("langchain-community"):
     from langchain_community import vectorstores
     from langchain_community.vectorstores import FAISS
```

## Verification

Tested against `paddleocr` 3.6.0.dev (which depends on
`paddlex>=3.5.0,<3.6.0`):

| Environment | Before | After |
|---|---|---|
| no langchain installed | `import paddleocr` ✅ | `import paddleocr` ✅ |
| `langchain==1.2.15`, no `langchain-text-splitters`, no `langchain-community` | ❌ `ModuleNotFoundError: No module named 'langchain_text_splitters'` | ✅ `import paddleocr` succeeds; instantiating `BaseRetriever` raises `DependencyError: 'BaseRetriever' is not ready for use … langchain-text-splitters, langchain-community` |
| `langchain` + `langchain-text-splitters` + `langchain-community` all installed | n/a | ✅ all retriever symbols importable and `BaseRetriever` instantiable |

## Related

Fixes https://github.com/PaddlePaddle/PaddleOCR/issues/17186
Follow-up to PaddleX #4944, #4981, #4997, which addressed the original
`langchain.docstore` removal but left this second-order regression in
place.