### PR TITLE
fix: use cv2.imencode to support writing files with non-ASCII paths

### DIFF
--- a/paddlex/inference/utils/io/writers.py
+++ b/paddlex/inference/utils/io/writers.py
@@ -349,7 +349,13 @@ class OpenCVImageWriterBackend(_ImageWriterBackend):
             arr = obj
         else:
             raise TypeError("Unsupported object type")
-        return cv2.imwrite(out_path, arr)
+        ext = Path(out_path).suffix
+        success, buf = cv2.imencode(ext, arr)
+        if not success:
+            return False
+        with open(out_path, "wb") as f:
+            f.write(buf.tobytes())
+        return True
 
 
 class PILImageWriterBackend(_ImageWriterBackend):


### PR DESCRIPTION
## Summary
- `OpenCVImageWriterBackend._write_obj` used `cv2.imwrite`, which fails on Windows when the output path contains non-ASCII (e.g. Chinese) characters, producing corrupt files or silent failures whenever users call `result.save_to_img(...)` with a Chinese save path / input basename.
- Mirror the reader-side fix (38d4053e, "fix: use cv2.imdecode to support reading files with Chinese characters in filename") by encoding via `cv2.imencode` and writing the bytes through Python's built-in `open()`, which handles Unicode paths correctly on all platforms.
- Preserves existing fallthrough semantics: returns `False` on encode failure without creating a partial file.

## Related issues
Fixes https://github.com/PaddlePaddle/PaddleOCR/issues/15734
Fixes https://github.com/PaddlePaddle/PaddleOCR/issues/16324

## Test plan
- [x] Roundtrip: write a random `np.ndarray` via `ImageWriter(backend="opencv")` to an ASCII path, a pure-Chinese filename path, and a Chinese-dir + Chinese-file path; reload via `ImageReader(backend="opencv")` and assert `np.array_equal(loaded, original)` for PNG.
- [x] Same roundtrip for JPEG under a Chinese directory (shape preserved, lossy content).
- [x] Negative: path without an extension returns `False` and does NOT create a zero-byte file.
- [x] Local pre-commit: `black`, `flake8`, `isort`, `Check License Headers`, `Check Python 3.8 Compatibility` all pass. (The `check-imports` hook fails under Python 3.13 due to an unrelated `stdlib_list` data-file issue; unaffected by this change.)