### PR TITLE
fix: include hpi_model_info_collection.json in wheel after path move

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -347,7 +347,7 @@ def packages_and_package_data():
     pkg_data.append("inference/pipelines/ppchatocrv3/ch_prompt.yaml")
     pkg_data.append("hpip_links.html")
     pkg_data.append("hpip_links_cu12.html")
-    pkg_data.append("inference/utils/hpi_model_info_collection.json")
+    pkg_data.append("inference/models/runners/hpi/hpi_model_info_collection.json")
     genai_chat_templates = [
         Path(p).relative_to("paddlex").as_posix()
         for p in glob.glob("paddlex/inference/genai/chat_templates/*.jinja")


### PR DESCRIPTION
## Summary
- `paddlex/inference/utils/hpi_model_info_collection.json` was moved to
  `paddlex/inference/models/runners/hpi/hpi_model_info_collection.json`
  in #5028, and the loader in `backend.py` was updated to read it from the
  new location via `importlib.resources.open_text(__package__, ...)`.
- However `setup.py` still appended the old path to `package_data`, so the
  240KB JSON was not bundled into the wheel. Pip-installed `paddlex==3.5.1`
  therefore raises `FileNotFoundError` whenever HPI tries to look up the
  model info collection.
- This PR updates `setup.py` to point at the new path so the file is
  packaged again.

## Test plan
- [ ] `python -m build` and inspect the produced wheel — confirm
  `paddlex/inference/models/runners/hpi/hpi_model_info_collection.json`
  is present.
- [ ] `pip install` the wheel into a clean env and run an HPI pipeline
  (e.g. `PP-DocumentLayoutV3`) — confirm the file loads and HPI no longer
  warns about the missing collection.

Fixes #5116