### PR TITLE
fix: preserve root logger level when importing paddle (#4892)

### DIFF
--- a/paddlex/utils/import_guard.py
+++ b/paddlex/utils/import_guard.py
@@ -24,12 +24,14 @@ def import_paddle():
 
 
 def import_paddle_module(module_name):
-    """Import a `paddle` module while preserving existing root handlers."""
+    """Import a `paddle` module while preserving the root logger's existing
+    handlers and level."""
     if module_name != "paddle" and not module_name.startswith("paddle."):
         raise ValueError(f"Expected a paddle module name, but got {module_name!r}.")
 
     root_logger = logging.getLogger()
     existing_handler_ids = {id(handler) for handler in root_logger.handlers}
+    existing_level = root_logger.level
     try:
         return importlib.import_module(module_name)
     finally:
@@ -39,3 +41,5 @@ def import_paddle_module(module_name):
             if isinstance(handler, logging.StreamHandler):
                 root_logger.removeHandler(handler)
                 handler.close()
+        if root_logger.level != existing_level:
+            root_logger.setLevel(existing_level)


### PR DESCRIPTION
## Summary
- Fixes [#4892](https://github.com/PaddlePaddle/PaddleX/issues/4892): user logs disappear after `create_pipeline()` when the host app uses uvicorn's `--log-config`.
- Root cause: `import paddle` (triggered inside `create_pipeline`) resets the root logger level (INFO → WARNING). Loggers without an explicit level inherit the root effective level, so INFO messages after `create_pipeline` are silently filtered.
- `paddlex/utils/import_guard.py::import_paddle_module` already snapshots root handlers; this PR also snapshots and restores the root logger level, so paddle's import has no visible side effect on the host application's logging.

## Test plan
- [x] Unit-style repro: `logging.config.fileConfig(...)` → `import_paddle_module("paddle")`. Before patch: `root.level` becomes WARNING. After patch: stays at INFO.
- [x] End-to-end repro from the issue (paddlex 3.3.11 + paddlepaddle 3.2.0 + uvicorn 0.46 + the exact `logging.conf` from [#4892](https://github.com/PaddlePaddle/PaddleX/issues/4892)): all four `main` logger messages around `create_pipeline` now appear in `uvicorn.log`, including the `/health` endpoint log.
- [ ] CI green