### PR TITLE
(Fixes PaddlePaddle/PaddleOCR#18064) fix: guard against KMeans n_clusters=0 crash in table recognition pipeline 

### DIFF
--- a/paddlex/inference/pipelines/table_recognition/pipeline_v2.py
+++ b/paddlex/inference/pipelines/table_recognition/pipeline_v2.py
@@ -460,6 +460,9 @@ class _TableRecognitionPipelineV2(BasePipeline):
             """
             # Number of input rectangles
             num_rects = len(rectangles)
+            # Guard: N must be >= 1 for KMeans
+            if N <= 0 or num_rects == 0:
+                return []
             # If N is greater than or equal to the number of rectangles, return the original rectangles
             if N >= num_rects:
                 return rectangles
@@ -545,12 +548,13 @@ class _TableRecognitionPipelineV2(BasePipeline):
             else:
                 # Need to combine ocr_miss_boxes into N rectangles
                 N = html_pred_boxes_nums - len(cells_det_results)
-                # Combine ocr_miss_boxes into N rectangles
-                ocr_supp_boxes = combine_rectangles(ocr_miss_boxes, N)
-                # Combine cells_det_results and ocr_supp_boxes
-                final_results = np.concatenate(
-                    (cells_det_results, ocr_supp_boxes), axis=0
-                ).tolist()
+                if N <= 0:
+                    final_results = cells_det_results.tolist()
+                else:
+                    ocr_supp_boxes = combine_rectangles(ocr_miss_boxes, N)
+                    final_results = np.concatenate(
+                        (cells_det_results, ocr_supp_boxes), axis=0
+                    ).tolist()
         if len(final_results) <= 0.6 * html_pred_boxes_nums:
             final_results = combine_rectangles(ocr_det_results, html_pred_boxes_nums)
         return final_results


### PR DESCRIPTION


(Fixes PaddlePaddle/PaddleOCR#18064)


## Problem
When using PPStructureV3 with engine="transformers" and 
wireless_table_structure_recognition_model_name="SLANeXt_wireless", 
the pipeline crashes with:

sklearn.utils._param_validation.InvalidParameterError: 
The 'n_clusters' parameter of KMeans must be an int in the 
range [1, inf). Got 0 instead.

Related issue: #5140

## Root Cause
SLANeXt does not support resampling in the transformers engine
(logged as a warning), which causes zero cell detections.
This zero value propagates to KMeans as n_clusters=0 → crash.

Two code paths trigger this:
1. N = html_pred_boxes_nums - len(cells_det_results) can be <= 0
2. combine_rectangles() passes N directly to KMeans without validation

## Fix
1. Added early return guard in combine_rectangles() when N <= 0 or 
   rectangles list is empty
2. Added N <= 0 guard before calling combine_rectangles() in 
   cells_det_results_reprocessing()

## Testing
Tested locally with paddleocr==3.5.0, transformers==5.9.0 on Windows.
Pipeline now completes successfully instead of crashing.

Before fix:
  [transformers] Resampling is not supported in SLANeXt
  ❌ InvalidParameterError: n_clusters=0

After fix:
  [transformers] Resampling is not supported in SLANeXt
  ✅ Prediction done