### PR TITLE
docs: make GitHub source links version aware

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -25,6 +25,10 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mike mkdocs-material jieba mkdocs-git-revision-date-localized-plugin mkdocs-git-committers-plugin-2 mkdocs-git-authors-plugin mkdocs-static-i18n mkdocs-minify-plugin 
+      - name: Check docs GitHub source links
+        run: python tools/check_docs_github_links.py --repo-slug PaddlePaddle/PaddleX --forbidden-ref develop --forbidden-ref main --forbidden-ref master
+      - name: Resolve docs GitHub source refs
+        run: python tools/resolve_doc_github_refs.py --placeholder '{{PADDLEX_GITHUB_REF}}' --source-ref "${GITHUB_REF_NAME}"
       - name: Deploy docs (version from branch release/X → mike X)
         run: |
           git fetch origin gh-pages --depth=1
@@ -35,3 +39,5 @@ jobs:
           fi
           mike deploy --push --update-aliases "$VERSION" latest
           mike set-default --push latest
+        env:
+          DOCS_EDIT_URI: edit/${{ github.ref_name }}/docs/

--- a/docs/pipeline_deploy/serving.en.md
+++ b/docs/pipeline_deploy/serving.en.md
@@ -270,7 +270,7 @@ Find the high-stability serving SDK corresponding to the pipeline in the table b
 </table>
 </details>
 
-For manual packaging, please refer to [the `hps` project documentation](https://github.com/PaddlePaddle/PaddleX/blob/develop/deploy/hps/README_en.md#2-pipeline-material-packaging).
+For manual packaging, please refer to [the `hps` project documentation](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/deploy/hps/README_en.md#2-pipeline-material-packaging).
 
 ### 2.2 Adjust Configurations
 
@@ -331,7 +331,7 @@ First, pull the Docker image as needed:
     docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:paddlex3.6-cpu
     ```
 
-If you need to build the image on your own, please refer to [the `hps` project documentation](https://github.com/PaddlePaddle/PaddleX/blob/develop/deploy/hps/README_en.md#1-image-building)
+If you need to build the image on your own, please refer to [the `hps` project documentation](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/deploy/hps/README_en.md#1-image-building)
 
 With the image prepared, navigate to the `server` directory and execute the following command to run the server:
 

--- a/docs/pipeline_deploy/serving.md
+++ b/docs/pipeline_deploy/serving.md
@@ -270,7 +270,7 @@ paddlex --serve --pipeline image_classification --use_hpip
 </table>
 </details>
 
-如需手动打包可参考 [`hps` 项目文档](https://github.com/PaddlePaddle/PaddleX/blob/develop/deploy/hps/README.md#2-产线物料打包)。
+如需手动打包可参考 [`hps` 项目文档](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/deploy/hps/README.md#2-产线物料打包)。
 
 ### 2.2 调整配置
 
@@ -331,7 +331,7 @@ paddlex --serve --pipeline image_classification --use_hpip
     docker pull ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlex/hps:paddlex3.6-cpu
     ```
 
-如需自定义构建镜像可参考 [`hps` 项目文档](https://github.com/PaddlePaddle/PaddleX/blob/develop/deploy/hps/README.md#1-镜像构建)。
+如需自定义构建镜像可参考 [`hps` 项目文档](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/deploy/hps/README.md#1-镜像构建)。
 
 准备好镜像后，切换到 `server` 目录，执行如下命令运行服务器：
 

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
@@ -1438,11 +1438,11 @@ for item in markdown_images:
 
 **Note:**
 
-- The default text recognition model used by PP-StructureV3 is the **Chinese-English recognition model**. Limited recognition capability for purely English text. For fully English scenarios, you can modify the `model_name` under the `TextRecognition` configuration item in the [PP-StructureV3 configuration file](https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-rc/paddlex/configs/pipelines/PP-StructureV3.yaml) to `en_PP-OCRv4_mobile_rec` or other English recognition models for better recognition results. For other language scenarios, you can also refer to the model list mentioned earlier and choose the corresponding language recognition model for replacement.
+- The default text recognition model used by PP-StructureV3 is the **Chinese-English recognition model**. Limited recognition capability for purely English text. For fully English scenarios, you can modify the `model_name` under the `TextRecognition` configuration item in the [PP-StructureV3 configuration file](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/pipelines/PP-StructureV3.yaml) to `en_PP-OCRv4_mobile_rec` or other English recognition models for better recognition results. For other language scenarios, you can also refer to the model list mentioned earlier and choose the corresponding language recognition model for replacement.
 
 - In the example code, the parameters `use_doc_orientation_classify`, `use_doc_unwarping`, and `use_textline_orientation` are all set to False by default. These parameters respectively control the document orientation classification, document unwarping, and text line orientation classification functions. If you need to use these features, you can manually set them to True.
 
-- PP-StructureV3 provides flexible parameter configuration, allowing you to adjust parameters for layout detection, text detection, text recognition, etc., based on the characteristics of the document for better results. For more detailed configurations, please refer to the [PP-StructureV3 configuration file](https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-rc/paddlex/configs/pipelines/PP-StructureV3.yaml).
+- PP-StructureV3 provides flexible parameter configuration, allowing you to adjust parameters for layout detection, text detection, text recognition, etc., based on the characteristics of the document for better results. For more detailed configurations, please refer to the [PP-StructureV3 configuration file](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/pipelines/PP-StructureV3.yaml).
 
 In the above Python script, the following steps are executed:
 

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.md
@@ -1405,11 +1405,11 @@ for item in markdown_images:
 
 **注：**
 
-- PP-StructureV3 产线使用的默认文本识别模型为 **中英文识别模型**，对于纯英文的识别能力有限，对于全英文场景，您可以将 [PP-StructureV3 配置文件](https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-rc/paddlex/configs/pipelines/PP-StructureV3.yaml)中 `TextRecognition` 配置项下的 `model_name` 修改为 `en_PP-OCRv4_mobile_rec` 等英文识别模型以取得更好的识别效果。对应其他语言场景，也可以参考前文的模型列表，选择对应的语言识别模型进行替换。
+- PP-StructureV3 产线使用的默认文本识别模型为 **中英文识别模型**，对于纯英文的识别能力有限，对于全英文场景，您可以将 [PP-StructureV3 配置文件](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/pipelines/PP-StructureV3.yaml)中 `TextRecognition` 配置项下的 `model_name` 修改为 `en_PP-OCRv4_mobile_rec` 等英文识别模型以取得更好的识别效果。对应其他语言场景，也可以参考前文的模型列表，选择对应的语言识别模型进行替换。
 
 - 在示例代码中，`use_doc_orientation_classify`、`use_doc_unwarping`、`use_textline_orientation` 参数默认均设置为 `False`，分别表示关闭文档方向分类、文档扭曲矫正、文本行方向分类功能，如果需要使用这些功能，可以手动设置为 `True`。
 
-- PP-StructureV3 产线提供了灵活的参数配置，可以在使用过程中针对文档的特点灵活的调整版面检测、文本检测、文本识别等模块的参数，以获得更好的效果，更多详细配置可以参考[PP-StructureV3 配置文件](https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-rc/paddlex/configs/pipelines/PP-StructureV3.yaml)。
+- PP-StructureV3 产线提供了灵活的参数配置，可以在使用过程中针对文档的特点灵活的调整版面检测、文本检测、文本识别等模块的参数，以获得更好的效果，更多详细配置可以参考[PP-StructureV3 配置文件](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/pipelines/PP-StructureV3.yaml)。
 
 在上述 Python 脚本中，执行了如下几个步骤：
 <details><summary>（1）实例化 <code>create_pipeline</code> 实例化产线对象，具体参数说明如下：</summary>

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.en.md
@@ -775,7 +775,7 @@ docker run \
     paddlex_genai_server --model_name PaddleOCR-VL-1.6-0.9B --host 0.0.0.0 --port 8118 --backend vllm
 ```
 
-For Blackwell GPUs, replace the image above with the SM120-specific image:
+For Blackwell GPUs, replace the image above with the dedicated image:
 
 ```bash
 docker run \

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.en.md
@@ -762,9 +762,9 @@ The VLM inference service only handles the VLM recognition stage of the complete
 
 #### 3.1.1 Using Docker Images
 
-PaddleX provides a vLLM Docker image to quickly start a VLM inference service. For common NVIDIA GPUs, use `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest`. For NVIDIA 50 series GPUs (SM120 / Compute Capability 12.x), use `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest-sm120`.
+PaddleX provides a vLLM Docker image to quickly start a VLM inference service. For NVIDIA GPUs other than the Blackwell architecture, use `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest`. For Blackwell GPUs, use `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest-sm120`.
 
-Using a common NVIDIA GPU and `PaddleOCR-VL-1.6-0.9B` as an example:
+Using an NVIDIA GPU other than the Blackwell architecture and `PaddleOCR-VL-1.6-0.9B` as an example:
 
 ```bash
 docker run \
@@ -775,7 +775,7 @@ docker run \
     paddlex_genai_server --model_name PaddleOCR-VL-1.6-0.9B --host 0.0.0.0 --port 8118 --backend vllm
 ```
 
-For NVIDIA 50 series GPUs, replace the image above with the SM120-specific image:
+For Blackwell GPUs, replace the image above with the SM120-specific image:
 
 ```bash
 docker run \

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PaddleOCR-VL.md
@@ -744,9 +744,9 @@ for res in output:
 
 #### 3.1.1 使用 Docker 镜像
 
-PaddleX 提供了 vLLM Docker 镜像，用于快速启动 VLM 推理服务。普通 NVIDIA GPU 可使用 `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest`，NVIDIA 50 系显卡（SM120 / Compute Capability 12.x）请使用 `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest-sm120`。
+PaddleX 提供了 vLLM Docker 镜像，用于快速启动 VLM 推理服务。除 Blackwell 架构外的 NVIDIA GPU 可使用 `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest`，Blackwell 架构 GPU 请使用 `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddlex-genai-vllm-server:latest-sm120`。
 
-以普通 NVIDIA GPU 和 `PaddleOCR-VL-1.6-0.9B` 为例，可使用以下命令启动服务：
+以除 Blackwell 架构外的 NVIDIA GPU 和 `PaddleOCR-VL-1.6-0.9B` 为例，可使用以下命令启动服务：
 
 ```bash
 docker run \
@@ -757,7 +757,7 @@ docker run \
     paddlex_genai_server --model_name PaddleOCR-VL-1.6-0.9B --host 0.0.0.0 --port 8118 --backend vllm
 ```
 
-若使用 NVIDIA 50 系显卡，可将上述镜像替换为 SM120 专用版本：
+若使用 Blackwell 架构 GPU，可将上述镜像替换为专用版本：
 
 ```bash
 docker run \

--- a/docs/support_list/models_list.en.md
+++ b/docs/support_list/models_list.en.md
@@ -25,7 +25,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>12.03 / 2.49</td>
 <td>60.86 / 42.69</td>
 <td>331</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/CLIP_vit_base_patch16_224.yaml">CLIP_vit_base_patch16_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/CLIP_vit_base_patch16_224.yaml">CLIP_vit_base_patch16_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_base_patch16_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_base_patch16_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>CLIP_vit_large_patch14_224</td>
@@ -33,7 +33,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>49.15 / 9.75</td>
 <td>223.16 / 206.49</td>
 <td>1040</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/CLIP_vit_large_patch14_224.yaml">CLIP_vit_large_patch14_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/CLIP_vit_large_patch14_224.yaml">CLIP_vit_large_patch14_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_large_patch14_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_large_patch14_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_base_224</td>
@@ -41,7 +41,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.37 / 5.65</td>
 <td>143.98 / 52.31</td>
 <td>313.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_base_224.yaml">ConvNeXt_base_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_base_224.yaml">ConvNeXt_base_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_base_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_base_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_base_384</td>
@@ -49,7 +49,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>29.48 / 11.17</td>
 <td>293.76 / 134.27</td>
 <td>313.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_base_384.yaml">ConvNeXt_base_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_base_384.yaml">ConvNeXt_base_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_base_384_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_base_384_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_large_224</td>
@@ -57,7 +57,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>22.99 / 12.73</td>
 <td>220.79 / 113.24</td>
 <td>700.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_large_224.yaml">ConvNeXt_large_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_large_224.yaml">ConvNeXt_large_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_large_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_large_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_large_384</td>
@@ -65,7 +65,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>58.90 / 24.63</td>
 <td>509.48 / 260.27</td>
 <td>700.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_large_384.yaml">ConvNeXt_large_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_large_384.yaml">ConvNeXt_large_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_large_384_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_large_384_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_small</td>
@@ -73,7 +73,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.72 / 4.35</td>
 <td>95.92 / 33.34</td>
 <td>178.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_small.yaml">ConvNeXt_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_small.yaml">ConvNeXt_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_small_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_small_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ConvNeXt_tiny</td>
@@ -81,7 +81,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.00 / 2.47</td>
 <td>63.59 / 18.23</td>
 <td>101.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_tiny.yaml">ConvNeXt_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_tiny.yaml">ConvNeXt_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_tiny_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_tiny_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-L</td>
@@ -89,7 +89,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.96 / 2.68</td>
 <td>51.93 / 35.33</td>
 <td>357.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-L.yaml">FasterNet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-L.yaml">FasterNet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-L_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-M</td>
@@ -97,7 +97,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.17 / 2.16</td>
 <td>38.49 / 21.17</td>
 <td>204.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-M.yaml">FasterNet-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-M.yaml">FasterNet-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-M_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-S</td>
@@ -105,7 +105,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.70 / 1.24</td>
 <td>19.51 / 11.22</td>
 <td>119.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-S.yaml">FasterNet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-S.yaml">FasterNet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-S_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-T0</td>
@@ -113,7 +113,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.73 / 0.82</td>
 <td>6.40 / 1.96</td>
 <td>15.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T0.yaml">FasterNet-T0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T0.yaml">FasterNet-T0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T0_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-T1</td>
@@ -121,7 +121,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.80 / 0.80</td>
 <td>8.14 / 3.13</td>
 <td>29.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T1.yaml">FasterNet-T1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T1.yaml">FasterNet-T1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T1_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T1_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterNet-T2</td>
@@ -129,7 +129,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.10 / 0.88</td>
 <td>12.71 / 5.35</td>
 <td>57.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T2.yaml">FasterNet-T2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T2.yaml">FasterNet-T2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T2_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T2_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV1_x0_5</td>
@@ -137,7 +137,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>1.98 / 0.51</td>
 <td>2.50 / 1.04</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_5.yaml">MobileNetV1_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_5.yaml">MobileNetV1_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -146,7 +146,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>1.99 / 0.45</td>
 <td>1.82 / 0.73</td>
 <td>1.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_25.yaml">MobileNetV1_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_25.yaml">MobileNetV1_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_25_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_25_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -155,7 +155,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.33 / 0.41</td>
 <td>3.33 / 1.34</td>
 <td>9.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_75.yaml">MobileNetV1_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_75.yaml">MobileNetV1_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_75_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_75_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -164,7 +164,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.31 / 0.45</td>
 <td>3.91 / 1.89</td>
 <td>15.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x1_0.yaml">MobileNetV1_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x1_0.yaml">MobileNetV1_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x1_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x1_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -173,7 +173,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.58 / 0.62</td>
 <td>3.86 / 1.23</td>
 <td>7.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x0_5.yaml">MobileNetV2_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x0_5.yaml">MobileNetV2_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x0_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x0_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.05 / 0.66</td>
 <td>3.30 / 0.98</td>
 <td>5.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x0_25.yaml">MobileNetV2_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x0_25.yaml">MobileNetV2_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x0_25_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x0_25_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -191,7 +191,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.85 / 0.63</td>
 <td>5.50 / 1.87</td>
 <td>12.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x1_0.yaml">MobileNetV2_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x1_0.yaml">MobileNetV2_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x1_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x1_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -200,7 +200,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.93 / 0.73</td>
 <td>8.84 / 3.12</td>
 <td>25.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x1_5.yaml">MobileNetV2_x1_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x1_5.yaml">MobileNetV2_x1_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x1_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x1_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -209,7 +209,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.89 / 0.79</td>
 <td>10.36 / 4.50</td>
 <td>41.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x2_0.yaml">MobileNetV2_x2_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x2_0.yaml">MobileNetV2_x2_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x2_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x2_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -218,7 +218,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.60 / 0.77</td>
 <td>5.32 / 1.58</td>
 <td>9.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_5.yaml">MobileNetV3_large_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_5.yaml">MobileNetV3_large_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -227,7 +227,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.44 / 0.75</td>
 <td>5.20 / 1.50</td>
 <td>7.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_35.yaml">MobileNetV3_large_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_35.yaml">MobileNetV3_large_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_35_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_35_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x0_75</td>
@@ -235,7 +235,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.30 / 0.85</td>
 <td>6.02 / 1.93</td>
 <td>14.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_75.yaml">MobileNetV3_large_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_75.yaml">MobileNetV3_large_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_75_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_75_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x1_0</td>
@@ -243,7 +243,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.38 / 0.81</td>
 <td>7.16 / 2.19</td>
 <td>19.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_0.yaml">MobileNetV3_large_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_0.yaml">MobileNetV3_large_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x1_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x1_0_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x1_25</td>
@@ -251,7 +251,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.54 / 0.84</td>
 <td>7.06 / 2.84</td>
 <td>26.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_25.yaml">MobileNetV3_large_x1_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_25.yaml">MobileNetV3_large_x1_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x1_25_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x1_25_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x0_5</td>
@@ -259,7 +259,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.87 / 0.77</td>
 <td>4.90 / 1.32</td>
 <td>6.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_5.yaml">MobileNetV3_small_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_5.yaml">MobileNetV3_small_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_5_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x0_35</td>
@@ -267,7 +267,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.68 / 0.77</td>
 <td>3.94 / 1.27</td>
 <td>6.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_35.yaml">MobileNetV3_small_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_35.yaml">MobileNetV3_small_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_35_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_35_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -276,7 +276,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.92 / 0.77</td>
 <td>4.68 / 1.39</td>
 <td>8.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_75.yaml">MobileNetV3_small_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_75.yaml">MobileNetV3_small_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_75_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_75_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -285,7 +285,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.23 / 0.78</td>
 <td>5.24 / 1.48</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_0.yaml">MobileNetV3_small_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_0.yaml">MobileNetV3_small_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x1_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x1_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -294,7 +294,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.59 / 0.79</td>
 <td>5.36 / 1.63</td>
 <td>13.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_25.yaml">MobileNetV3_small_x1_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_25.yaml">MobileNetV3_small_x1_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x1_25_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x1_25_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -303,7 +303,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.04 / 2.28</td>
 <td>34.34 / 22.01</td>
 <td>125.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_large.yaml">MobileNetV4_conv_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_large.yaml">MobileNetV4_conv_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_large_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_large_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -312,7 +312,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.70 / 1.05</td>
 <td>13.78 / 5.64</td>
 <td>37.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_medium.yaml">MobileNetV4_conv_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_medium.yaml">MobileNetV4_conv_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_medium_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_medium_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -321,7 +321,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.81 / 0.55</td>
 <td>5.24 / 1.50</td>
 <td>14.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_small.yaml">MobileNetV4_conv_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_small.yaml">MobileNetV4_conv_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_small_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_small_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -330,7 +330,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.43 / 4.28</td>
 <td>61.16 / 31.06</td>
 <td>145.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_large.yaml">MobileNetV4_hybrid_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_large.yaml">MobileNetV4_hybrid_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_hybrid_large_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_hybrid_large_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -339,7 +339,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.82 / 1.30</td>
 <td>22.01 / 6.06</td>
 <td>42.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_medium.yaml">MobileNetV4_hybrid_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_medium.yaml">MobileNetV4_hybrid_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_hybrid_medium_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_hybrid_medium_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -348,7 +348,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.43 / 3.81</td>
 <td>71.24 / 51.48</td>
 <td>249.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_base.yaml">PP-HGNet_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_base.yaml">PP-HGNet_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_base_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_base_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -357,7 +357,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.87 / 1.68</td>
 <td>25.58 / 18.50</td>
 <td>86.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_small.yaml">PP-HGNet_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_small.yaml">PP-HGNet_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_small_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_small_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -366,7 +366,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.84 / 1.38</td>
 <td>17.03 / 10.58</td>
 <td>52.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_tiny.yaml">PP-HGNet_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_tiny.yaml">PP-HGNet_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_tiny_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_tiny_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -375,7 +375,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.41 / 0.87</td>
 <td>10.58 / 1.87</td>
 <td>21.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B0.yaml">PP-HGNetV2-B0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B0.yaml">PP-HGNetV2-B0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -384,7 +384,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.52 / 0.73</td>
 <td>11.98 / 2.28</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B1.yaml">PP-HGNetV2-B1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B1.yaml">PP-HGNetV2-B1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B1_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B1_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -393,7 +393,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.67 / 0.96</td>
 <td>14.22 / 4.04</td>
 <td>39.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B2.yaml">PP-HGNetV2-B2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B2.yaml">PP-HGNetV2-B2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B2_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B2_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -402,7 +402,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.47 / 1.94</td>
 <td>17.73 / 5.63</td>
 <td>57.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B3.yaml">PP-HGNetV2-B3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B3.yaml">PP-HGNetV2-B3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B3_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B3_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -411,7 +411,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.05 / 1.16</td>
 <td>16.23 / 7.55</td>
 <td>70.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B4.yaml">PP-HGNetV2-B4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B4.yaml">PP-HGNetV2-B4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B4_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B4_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -420,7 +420,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.38 / 1.95</td>
 <td>31.53 / 18.02</td>
 <td>140.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B5.yaml">PP-HGNetV2-B5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B5.yaml">PP-HGNetV2-B5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -429,7 +429,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.86 / 3.28</td>
 <td>67.25 / 56.70</td>
 <td>268.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B6.yaml">PP-HGNetV2-B6.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B6.yaml">PP-HGNetV2-B6.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B6_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B6_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -438,7 +438,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.41 / 0.60</td>
 <td>2.54 / 0.90</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_5.yaml">PP-LCNet_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_5.yaml">PP-LCNet_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -447,7 +447,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.16 / 0.60</td>
 <td>2.73 / 0.77</td>
 <td>5.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_25.yaml">PP-LCNet_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_25.yaml">PP-LCNet_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_25_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_25_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -456,7 +456,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.18 / 0.60</td>
 <td>2.32 / 0.89</td>
 <td>5.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_35.yaml">PP-LCNet_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_35.yaml">PP-LCNet_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_35_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_35_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -465,7 +465,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.61 / 0.58</td>
 <td>3.00 / 1.09</td>
 <td>8.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_75.yaml">PP-LCNet_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_75.yaml">PP-LCNet_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_75_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_75_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -474,7 +474,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.59 / 0.68</td>
 <td>3.18 / 1.19</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x1_0.yaml">PP-LCNet_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x1_0.yaml">PP-LCNet_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -483,7 +483,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.60 / 0.68</td>
 <td>3.98 / 1.66</td>
 <td>16.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x1_5.yaml">PP-LCNet_x1_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x1_5.yaml">PP-LCNet_x1_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -492,7 +492,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.53 / 0.68</td>
 <td>5.21 / 2.24</td>
 <td>23.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x2_0.yaml">PP-LCNet_x2_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x2_0.yaml">PP-LCNet_x2_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x2_0_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x2_0_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -501,7 +501,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.76 / 0.67</td>
 <td>6.78 / 3.20</td>
 <td>32.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x2_5.yaml">PP-LCNet_x2_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x2_5.yaml">PP-LCNet_x2_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x2_5_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x2_5_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -510,7 +510,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.04 / 0.62</td>
 <td>6.80 / 2.67</td>
 <td>23.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_base.yaml">PP-LCNetV2_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_base.yaml">PP-LCNetV2_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_base_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_base_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -519,7 +519,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.91 / 0.85</td>
 <td>10.30 / 5.38</td>
 <td>37.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_large.yaml">PP-LCNetV2_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_large.yaml">PP-LCNetV2_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_large_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_large_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -528,7 +528,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.07 / 0.60</td>
 <td>4.28 / 1.58</td>
 <td>14.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_small.yaml">PP-LCNetV2_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_small.yaml">PP-LCNetV2_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_small_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_small_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -537,7 +537,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.87 / 0.77</td>
 <td>7.91 / 4.64</td>
 <td>41.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet18_vd.yaml">ResNet18_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet18_vd.yaml">ResNet18_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet18_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet18_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -546,7 +546,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.63 / 0.74</td>
 <td>6.30 / 4.16</td>
 <td>41.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet18.yaml">ResNet18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet18.yaml">ResNet18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet18_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet18_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -555,7 +555,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.47 / 1.09</td>
 <td>14.30 / 8.33</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet34_vd.yaml">ResNet34_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet34_vd.yaml">ResNet34_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet34_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet34_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -564,7 +564,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.20 / 1.07</td>
 <td>12.53 / 7.83</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet34.yaml">ResNet34.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet34.yaml">ResNet34.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet34_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet34_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -573,7 +573,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.66 / 1.23</td>
 <td>16.34 / 10.00</td>
 <td>90.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet50_vd.yaml">ResNet50_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet50_vd.yaml">ResNet50_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -582,7 +582,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.25 / 1.17</td>
 <td>15.93 / 9.72</td>
 <td>90.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet50.yaml">ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet50.yaml">ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -591,7 +591,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.93 / 2.07</td>
 <td>32.47 / 23.62</td>
 <td>158.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet101_vd.yaml">ResNet101_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet101_vd.yaml">ResNet101_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet101_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet101_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -600,7 +600,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.73 / 2.06</td>
 <td>29.69 / 17.72</td>
 <td>158.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet101.yaml">ResNet101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet101.yaml">ResNet101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet101_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet101_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -609,7 +609,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>20.70 / 2.82</td>
 <td>43.90 / 27.91</td>
 <td>214.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet152_vd.yaml">ResNet152_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet152_vd.yaml">ResNet152_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet152_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet152_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -618,7 +618,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>17.86 / 2.79</td>
 <td>46.19 / 26.00</td>
 <td>214.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet152.yaml">ResNet152.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet152.yaml">ResNet152.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet152_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet152_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -627,7 +627,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>22.55 / 3.54</td>
 <td>58.54 / 35.70</td>
 <td>266.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet200_vd.yaml">ResNet200_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet200_vd.yaml">ResNet200_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet200_vd_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet200_vd_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -636,7 +636,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.24 / 0.96</td>
 <td>8.78 / 2.44</td>
 <td>11.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S1.yaml">StarNet-S1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S1.yaml">StarNet-S1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S1_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S1_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -645,7 +645,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.78 / 0.85</td>
 <td>7.24 / 2.48</td>
 <td>14.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S2.yaml">StarNet-S2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S2.yaml">StarNet-S2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S2_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S2_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -654,7 +654,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.77 / 1.07</td>
 <td>9.69 / 3.35</td>
 <td>22.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S3.yaml">StarNet-S3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S3.yaml">StarNet-S3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S3_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S3_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -663,7 +663,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.01 / 1.48</td>
 <td>14.79 / 4.58</td>
 <td>28.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S4.yaml">StarNet-S4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S4.yaml">StarNet-S4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S4_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S4_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -672,7 +672,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.04 / 10.77</td>
 <td>133.79 / 118.45</td>
 <td>340</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window7_224.yaml">SwinTransformer_base_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window7_224.yaml">SwinTransformer_base_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_base_patch4_window7_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_base_patch4_window7_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SwinTransformer_base_patch4_window12_384</td>
@@ -680,7 +680,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>33.99 / 28.42</td>
 <td>400.19 / 317.36</td>
 <td>311.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window12_384.yaml">SwinTransformer_base_patch4_window12_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window12_384.yaml">SwinTransformer_base_patch4_window12_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_base_patch4_window12_384_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_base_patch4_window12_384_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SwinTransformer_large_patch4_window7_224</td>
@@ -688,7 +688,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>23.69 / 6.18</td>
 <td>198.60 / 177.18</td>
 <td>694.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window7_224.yaml">SwinTransformer_large_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window7_224.yaml">SwinTransformer_large_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_large_patch4_window7_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_large_patch4_window7_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SwinTransformer_large_patch4_window12_384</td>
@@ -696,7 +696,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>68.07 / 14.84</td>
 <td>609.07 / 525.72</td>
 <td>696.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window12_384.yaml">SwinTransformer_large_patch4_window12_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window12_384.yaml">SwinTransformer_large_patch4_window12_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_large_patch4_window12_384_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_large_patch4_window12_384_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SwinTransformer_small_patch4_window7_224</td>
@@ -704,7 +704,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>12.17 / 3.51</td>
 <td>111.03 / 92.51</td>
 <td>175.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_small_patch4_window7_224.yaml">SwinTransformer_small_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_small_patch4_window7_224.yaml">SwinTransformer_small_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_small_patch4_window7_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_small_patch4_window7_224_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SwinTransformer_tiny_patch4_window7_224</td>
@@ -712,7 +712,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.11 / 2.01</td>
 <td>62.72 / 47.35</td>
 <td>100.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_tiny_patch4_window7_224.yaml">SwinTransformer_tiny_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_tiny_patch4_window7_224.yaml">SwinTransformer_tiny_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_tiny_patch4_window7_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_tiny_patch4_window7_224_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -737,7 +737,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>48.87 / 8.10</td>
 <td>275.33 / 188.48</td>
 <td>325.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/CLIP_vit_base_patch16_448_ML.yaml">CLIP_vit_base_patch16_448_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/CLIP_vit_base_patch16_448_ML.yaml">CLIP_vit_base_patch16_448_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_base_patch16_448_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_base_patch16_448_ML_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B0_ML</td>
@@ -745,7 +745,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>7.15 / 1.77</td>
 <td>21.35 / 8.19</td>
 <td>39.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B0_ML.yaml">PP-HGNetV2-B0_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B0_ML.yaml">PP-HGNetV2-B0_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B0_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B0_ML_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B4_ML</td>
@@ -753,7 +753,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>8.11 / 2.82</td>
 <td>44.76 / 29.38</td>
 <td>88.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B4_ML.yaml">PP-HGNetV2-B4_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B4_ML.yaml">PP-HGNetV2-B4_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B4_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B4_ML_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B6_ML</td>
@@ -761,7 +761,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>34.54 / 8.22</td>
 <td>189.17 / 189.17</td>
 <td>286.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B6_ML.yaml">PP-HGNetV2-B6_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B6_ML.yaml">PP-HGNetV2-B6_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B6_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B6_ML_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-LCNet_x1_0_ML</td>
@@ -769,7 +769,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.28 / 1.62</td>
 <td>13.16 / 5.61</td>
 <td>29.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-LCNet_x1_0_ML.yaml">PP-LCNet_x1_0_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-LCNet_x1_0_ML.yaml">PP-LCNet_x1_0_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_ML_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ResNet50_ML</td>
@@ -777,7 +777,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.54 / 2.97</td>
 <td>55.39 / 35.52</td>
 <td>108.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/ResNet50_ML.yaml">ResNet50_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/ResNet50_ML.yaml">ResNet50_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_ML_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_ML_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -803,7 +803,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.52 / 0.66</td>
 <td>2.60 / 1.07</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/pedestrian_attribute_recognition/PP-LCNet_x1_0_pedestrian_attribute.yaml">PP-LCNet_x1_0_pedestrian_attribute.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/pedestrian_attribute_recognition/PP-LCNet_x1_0_pedestrian_attribute.yaml">PP-LCNet_x1_0_pedestrian_attribute.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_pedestrian_attribute_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_pedestrian_attribute_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -829,7 +829,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>2.53 / 0.67</td>
 <td>2.73 / 1.10</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_attribute_recognition/PP-LCNet_x1_0_vehicle_attribute.yaml">PP-LCNet_x1_0_vehicle_attribute.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_attribute_recognition/PP-LCNet_x1_0_vehicle_attribute.yaml">PP-LCNet_x1_0_vehicle_attribute.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_vehicle_attribute_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_vehicle_attribute_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -854,7 +854,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.91 / 1.06</td>
 <td>6.82 / 2.89</td>
 <td>16.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec.yaml">PP-ShiTuV2_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec.yaml">PP-ShiTuV2_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-ShiTuV2_rec_CLIP_vit_base</td>
@@ -862,7 +862,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>12.57 / 11.62</td>
 <td>67.09 / 67.09</td>
 <td>306.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_base.yaml">PP-ShiTuV2_rec_CLIP_vit_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_base.yaml">PP-ShiTuV2_rec_CLIP_vit_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_CLIP_vit_base_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_CLIP_vit_base_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-ShiTuV2_rec_CLIP_vit_large</td>
@@ -870,7 +870,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>49.85 / 49.85</td>
 <td>229.14 / 229.14</td>
 <td>1050</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_large.yaml">PP-ShiTuV2_rec_CLIP_vit_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_large.yaml">PP-ShiTuV2_rec_CLIP_vit_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_CLIP_vit_large_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_CLIP_vit_large_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -898,7 +898,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.31 / 0.73</td>
 <td>5.93 / 1.30</td>
 <td>4.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_recognition/MobileFaceNet.yaml">MobileFaceNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_recognition/MobileFaceNet.yaml">MobileFaceNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileFaceNet_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileFaceNet_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>ResNet50_face</td>
@@ -907,7 +907,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.12 / 3.11</td>
 <td>15.85 / 9.44</td>
 <td>87.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_recognition/ResNet50_face.yaml">ResNet50_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_recognition/ResNet50_face.yaml">ResNet50_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_face_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_face_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -932,7 +932,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.81 / 4.53</td>
 <td>43.03 / 25.31</td>
 <td>27.54</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/mainbody_detection/PP-ShiTuV2_det.yaml">PP-ShiTuV2_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/mainbody_detection/PP-ShiTuV2_det.yaml">PP-ShiTuV2_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_det_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -957,7 +957,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>120.28 / 120.28</td>
 <td>- / 6514.61</td>
 <td>245.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-FPN.yaml">Cascade-FasterRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-FPN.yaml">Cascade-FasterRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-FasterRCNN-ResNet50-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-FasterRCNN-ResNet50-FPN_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN</td>
@@ -965,7 +965,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>124.10 / 124.10</td>
 <td>- / 6709.52</td>
 <td>246.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>CenterNet-DLA-34</td>
@@ -973,7 +973,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>67.19 / 67.19</td>
 <td>6622.61 / 6622.61</td>
 <td>75.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/CenterNet-DLA-34.yaml">CenterNet-DLA-34.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/CenterNet-DLA-34.yaml">CenterNet-DLA-34.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CenterNet-DLA-34_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CenterNet-DLA-34_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>CenterNet-ResNet50</td>
@@ -981,7 +981,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>216.06 / 216.06</td>
 <td>2545.79 / 2545.79</td>
 <td>319.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/CenterNet-ResNet50.yaml">CenterNet-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/CenterNet-ResNet50.yaml">CenterNet-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CenterNet-ResNet50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CenterNet-ResNet50_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>DETR-R50</td>
@@ -989,7 +989,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>58.80 / 26.90</td>
 <td>370.96 / 208.77</td>
 <td>159.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/DETR-R50.yaml">DETR-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/DETR-R50.yaml">DETR-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DETR-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DETR-R50_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet34-FPN</td>
@@ -997,7 +997,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>76.90 / 76.90</td>
 <td>- / 4136.79</td>
 <td>137.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet34-FPN.yaml">FasterRCNN-ResNet34-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet34-FPN.yaml">FasterRCNN-ResNet34-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet34-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet34-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1006,7 +1006,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>95.48 / 95.48</td>
 <td>- / 3693.90</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-FPN.yaml">FasterRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-FPN.yaml">FasterRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1015,7 +1015,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>98.03 / 98.03</td>
 <td>- / 4278.36</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-FPN.yaml">FasterRCNN-ResNet50-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-FPN.yaml">FasterRCNN-ResNet50-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-vd-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-vd-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1024,7 +1024,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>99.23 / 99.23</td>
 <td>- / 4415.68</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1033,7 +1033,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>129.10 / 129.10</td>
 <td>- / 3868.44</td>
 <td>120.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50.yaml">FasterRCNN-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50.yaml">FasterRCNN-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1042,7 +1042,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>131.48 / 131.48</td>
 <td>- / 4380.00</td>
 <td>216.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101-FPN.yaml">FasterRCNN-ResNet101-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101-FPN.yaml">FasterRCNN-ResNet101-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet101-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet101-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1051,7 +1051,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>216.71 / 216.71</td>
 <td>- / 5376.45</td>
 <td>188.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101.yaml">FasterRCNN-ResNet101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101.yaml">FasterRCNN-ResNet101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet101_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet101_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1060,7 +1060,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>234.38 / 234.38</td>
 <td>- / 6154.61</td>
 <td>360.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNeXt101-vd-FPN.yaml">FasterRCNN-ResNeXt101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNeXt101-vd-FPN.yaml">FasterRCNN-ResNeXt101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNeXt101-vd-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNeXt101-vd-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1069,7 +1069,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>65.92 / 65.92</td>
 <td>- / 2468.98</td>
 <td>159.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-Swin-Tiny-FPN.yaml">FasterRCNN-Swin-Tiny-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-Swin-Tiny-FPN.yaml">FasterRCNN-Swin-Tiny-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-Swin-Tiny-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-Swin-Tiny-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1078,7 +1078,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>101.02 / 34.42</td>
 <td>752.15 / 752.15</td>
 <td>124.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml">FCOS-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml">FCOS-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FCOS-ResNet50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FCOS-ResNet50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1087,7 +1087,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>14.31 / 11.06</td>
 <td>45.95 / 25.06</td>
 <td>20.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-L.yaml">PicoDet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-L.yaml">PicoDet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1096,7 +1096,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.48 / 5.00</td>
 <td>22.88 / 9.03</td>
 <td>16.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-M.yaml">PicoDet-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-M.yaml">PicoDet-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1105,7 +1105,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.15 / 3.26</td>
 <td>16.06 / 4.04</td>
 <td>4.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-S.yaml">PicoDet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-S.yaml">PicoDet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1114,7 +1114,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.54 / 3.52</td>
 <td>17.96 / 5.38</td>
 <td>5.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-XS.yaml">PicoDet-XS.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-XS.yaml">PicoDet-XS.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-XS_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-XS_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1123,7 +1123,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>32.06 / 28.00</td>
 <td>185.32 / 116.21</td>
 <td>185.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-L.yaml">PP-YOLOE_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-L.yaml">PP-YOLOE_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1132,7 +1132,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>18.37 / 15.04</td>
 <td>108.77 / 63.48</td>
 <td>83.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-M.yaml">PP-YOLOE_plus-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-M.yaml">PP-YOLOE_plus-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1141,7 +1141,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.43 / 7.52</td>
 <td>60.16 / 26.94</td>
 <td>28.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-S.yaml">PP-YOLOE_plus-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-S.yaml">PP-YOLOE_plus-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1150,7 +1150,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>56.28 / 50.60</td>
 <td>292.08 / 212.24</td>
 <td>349.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-X.yaml">PP-YOLOE_plus-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-X.yaml">PP-YOLOE_plus-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-X_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-X_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1159,7 +1159,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>114.57 / 101.56</td>
 <td>938.20 / 938.20</td>
 <td>435.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-H.yaml">RT-DETR-H.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-H.yaml">RT-DETR-H.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1168,7 +1168,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>34.76 / 27.60</td>
 <td>495.39 / 247.68</td>
 <td>113.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-L.yaml">RT-DETR-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-L.yaml">RT-DETR-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1177,7 +1177,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>19.11 / 14.82</td>
 <td>263.13 / 143.05</td>
 <td>70.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-R18.yaml">RT-DETR-R18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-R18.yaml">RT-DETR-R18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-R18_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-R18_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1186,7 +1186,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>41.11 / 10.12</td>
 <td>536.20 / 482.86</td>
 <td>149.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-R50.yaml">RT-DETR-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-R50.yaml">RT-DETR-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-R50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1195,7 +1195,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>61.91 / 51.41</td>
 <td>639.79 / 639.79</td>
 <td>232.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-X.yaml">RT-DETR-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-X.yaml">RT-DETR-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-X_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-X_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1204,7 +1204,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>39.62 / 35.54</td>
 <td>166.57 / 136.34</td>
 <td>219.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-DarkNet53.yaml">YOLOv3-DarkNet53.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-DarkNet53.yaml">YOLOv3-DarkNet53.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-DarkNet53_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-DarkNet53_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1213,7 +1213,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>16.54 / 6.21</td>
 <td>64.37 / 45.55</td>
 <td>83.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-MobileNetV3.yaml">YOLOv3-MobileNetV3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-MobileNetV3.yaml">YOLOv3-MobileNetV3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-MobileNetV3_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-MobileNetV3_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1222,7 +1222,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>31.64 / 26.72</td>
 <td>226.75 / 226.75</td>
 <td>163.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-ResNet50_vd_DCN.yaml">YOLOv3-ResNet50_vd_DCN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-ResNet50_vd_DCN.yaml">YOLOv3-ResNet50_vd_DCN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-ResNet50_vd_DCN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-ResNet50_vd_DCN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1231,7 +1231,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>49.68 / 45.03</td>
 <td>232.52 / 156.24</td>
 <td>192.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-L.yaml">YOLOX-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-L.yaml">YOLOX-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1240,7 +1240,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>43.46 / 29.52</td>
 <td>147.64 / 80.06</td>
 <td>90.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-M.yaml">YOLOX-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-M.yaml">YOLOX-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1249,7 +1249,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>42.94 / 17.79</td>
 <td>64.15 / 7.19</td>
 <td>3.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-N.yaml">YOLOX-N.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-N.yaml">YOLOX-N.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-N_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-N_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1258,7 +1258,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>46.53 / 29.34</td>
 <td>98.37 / 35.02</td>
 <td>32.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-S.yaml">YOLOX-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-S.yaml">YOLOX-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1267,7 +1267,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>31.81 / 18.91</td>
 <td>55.34 / 11.63</td>
 <td>18.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-T.yaml">YOLOX-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-T.yaml">YOLOX-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-T_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-T_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>YOLOX-X</td>
@@ -1275,7 +1275,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>84.06 / 77.28</td>
 <td>390.38 / 272.88</td>
 <td>351.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-X.yaml">YOLOX-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-X.yaml">YOLOX-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-X_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-X_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Co-Deformable-DETR-R50</td>
@@ -1283,7 +1283,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>259.62 / 259.62</td>
 <td>32413.76 / 32413.76</td>
 <td>184</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-Deformable-DETR-R50.yaml">Co-Deformable-DETR-R50.yaml.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-Deformable-DETR-R50.yaml">Co-Deformable-DETR-R50.yaml.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-Deformable-DETR-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-Deformable-DETR-R50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1292,7 +1292,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>120.17 / 120.17</td>
 <td>- / 15620.29</td>
 <td>187</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-Deformable-DETR-Swin-T.yaml">Co-Deformable-Swin-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-Deformable-DETR-Swin-T.yaml">Co-Deformable-Swin-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-Deformable-DETR-Swin-T_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-Deformable-DETR-Swin-T_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1301,7 +1301,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>1123.23 / 1123.23</td>
 <td>- / -</td>
 <td>186</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-DINO-R50.yaml">Co-DINO-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-DINO-R50.yaml">Co-DINO-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-DINO-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-DINO-R50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1310,7 +1310,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>- / -</td>
 <td>- / -</td>
 <td>840</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-DINO-Swin-L.yaml">Co-DINO-Swin-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-DINO-Swin-L.yaml">Co-DINO-Swin-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-DINO-Swin-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-DINO-Swin-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -1336,7 +1336,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>116.07 / 20.10</td>
 <td>176.44 / 40.21</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml">PP-YOLOE_plus_SOD-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml">PP-YOLOE_plus_SOD-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-S_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 
@@ -1346,7 +1346,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>100.02 / 48.33</td>
 <td>271.29 / 151.20</td>
 <td>325.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml">PP-YOLOE_plus_SOD-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml">PP-YOLOE_plus_SOD-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1355,7 +1355,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>515.69 / 460.17</td>
 <td>2816.08 / 1736.00</td>
 <td>340.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-largesize-L.yaml">PP-YOLOE_plus_SOD-largesize-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-largesize-L.yaml">PP-YOLOE_plus_SOD-largesize-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-largesize-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-largesize-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -1382,7 +1382,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>- / -</td>
 <td>- / -</td>
 <td>658.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_detection/GroundingDINO-T.yaml">GroundingDINO-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_detection/GroundingDINO-T.yaml">GroundingDINO-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/GroundingDINO-T_infer.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -1392,7 +1392,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>- / -</td>
 <td>292.14 / 292.14</td>
 <td>421.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_detection/YOLO-Worldv2-L.yaml">YOLO-Worldv2-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_detection/YOLO-Worldv2-L.yaml">YOLO-Worldv2-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLO-Worldv2-L_infer.tar">Inference Model</a></td>
 </tr>
 </table>
@@ -1414,7 +1414,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>- / -</td>
 <td>- / -</td>
 <td>2433.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_box.yaml">SAM-H_box.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_box.yaml">SAM-H_box.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SAM-H_box_infer.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -1422,7 +1422,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>- / -</td>
 <td>- / -</td>
 <td>2433.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_point.yaml">SAM-H_point.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_point.yaml">SAM-H_point.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SAM-H_point_infer.tar">Inference Model</a></td>
 </tr>
 </table>
@@ -1445,7 +1445,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>67.50 / 61.15</td>
 <td>414.79 / 414.79</td>
 <td>211.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/rotated_object_detection/PP-YOLOE-R-L.yaml">PP-YOLOE-R-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/rotated_object_detection/PP-YOLOE-R-L.yaml">PP-YOLOE-R-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-R-L_infer.tar">Inference Model</a>/<a href="https://paddledet.bj.bcebos.com/models/ppyoloe_r_crn_l_3x_dota.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -1470,7 +1470,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>30.59 / 26.64</td>
 <td>180.05 / 112.70</td>
 <td>196.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/human_detection/PP-YOLOE-L_human.yaml">PP-YOLOE-L_human.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/human_detection/PP-YOLOE-L_human.yaml">PP-YOLOE-L_human.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-L_human_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-L_human_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-YOLOE-S_human</td>
@@ -1478,7 +1478,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.26 / 6.66</td>
 <td>54.01 / 23.48</td>
 <td>28.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/human_detection/PP-YOLOE-S_human.yaml">PP-YOLOE-S_human.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/human_detection/PP-YOLOE-S_human.yaml">PP-YOLOE-S_human.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-S_human_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-S_human_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -1503,7 +1503,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>30.30 / 26.27</td>
 <td>169.28 / 111.88</td>
 <td>196.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_detection/PP-YOLOE-L_vehicle.yaml">PP-YOLOE-L_vehicle.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_detection/PP-YOLOE-L_vehicle.yaml">PP-YOLOE-L_vehicle.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-L_vehicle_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-L_vehicle_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-YOLOE-S_vehicle</td>
@@ -1511,7 +1511,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.54 / 6.69</td>
 <td>52.73 / 23.58</td>
 <td>28.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_detection/PP-YOLOE-S_vehicle.yaml">PP-YOLOE-S_vehicle.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_detection/PP-YOLOE-S_vehicle.yaml">PP-YOLOE-S_vehicle.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-S_vehicle_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-S_vehicle_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -1536,7 +1536,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>50.90 / 45.74</td>
 <td>71.92 / 71.92</td>
 <td>0.447</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/BlazeFace.yaml">BlazeFace.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/BlazeFace.yaml">BlazeFace.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BlazeFace_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BlazeFace_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>BlazeFace-FPN-SSH</td>
@@ -1544,7 +1544,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>58.99 / 51.75</td>
 <td>87.39 / 87.39</td>
 <td>0.606</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/BlazeFace-FPN-SSH.yaml">BlazeFace-FPN-SSH.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/BlazeFace-FPN-SSH.yaml">BlazeFace-FPN-SSH.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BlazeFace-FPN-SSH_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BlazeFace-FPN-SSH_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PicoDet_LCNet_x2_5_face</td>
@@ -1552,7 +1552,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>33.91 / 26.53</td>
 <td>153.56 / 79.21</td>
 <td>28.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/PicoDet_LCNet_x2_5_face.yaml">PicoDet_LCNet_x2_5_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/PicoDet_LCNet_x2_5_face.yaml">PicoDet_LCNet_x2_5_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_LCNet_x2_5_face_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_LCNet_x2_5_face_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-S_face</td>
@@ -1560,7 +1560,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>21.28 / 11.09</td>
 <td>137.26 / 72.09</td>
 <td>26.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/PP-YOLOE_plus-S_face.yaml">PP-YOLOE_plus-S_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/PP-YOLOE_plus-S_face.yaml">PP-YOLOE_plus-S_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-S_face_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-S_face_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -1586,7 +1586,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.94 / 1.63</td>
 <td>34.88 / 34.88</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_anomaly_detection/STFPM.yaml">STFPM.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_anomaly_detection/STFPM.yaml">STFPM.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/STFPM_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/STFPM_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -1613,7 +1613,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>24.22 / 4.34</td>
 <td>- / 6.19</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/keypoint_detection/PP-TinyPose_128x96.yaml">PP-TinyPose_128x96.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/keypoint_detection/PP-TinyPose_128x96.yaml">PP-TinyPose_128x96.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TinyPose_128x96_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TinyPose_128x96_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1623,7 +1623,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>21.73 / 3.59</td>
 <td>- / 10.18</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/keypoint_detection/PP-TinyPose_256x192.yaml">PP-TinyPose_256x192.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/keypoint_detection/PP-TinyPose_256x192.yaml">PP-TinyPose_256x192.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TinyPose_256x192_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TinyPose_256x192_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -1644,7 +1644,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>BEVFusion</td>
 <td>53.9</td>
 <td>60.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/3d_bev_detection/BEVFusion.yaml">BEVFusion.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/3d_bev_detection/BEVFusion.yaml">BEVFusion.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BEVFusion_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BEVFusion_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -1669,7 +1669,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>481.33 / 446.18</td>
 <td>2952.95 / 1907.07</td>
 <td>94.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R50.yaml">Deeplabv3_Plus-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R50.yaml">Deeplabv3_Plus-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3_Plus-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3_Plus-R50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1678,7 +1678,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>766.70 / 194.42</td>
 <td>4441.56 / 2984.19</td>
 <td>162.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R101.yaml">Deeplabv3_Plus-R101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R101.yaml">Deeplabv3_Plus-R101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3_Plus-R101_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3_Plus-R101_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1687,7 +1687,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>681.65 / 602.10</td>
 <td>3786.41 / 3093.10</td>
 <td>138.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R50.yaml">Deeplabv3-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R50.yaml">Deeplabv3-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3-R50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3-R50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1696,7 +1696,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>974.62 / 896.99</td>
 <td>5222.60 / 4230.79</td>
 <td>205.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R101.yaml">Deeplabv3-R101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R101.yaml">Deeplabv3-R101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3-R101_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3-R101_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1705,7 +1705,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>271.02 / 221.38</td>
 <td>1791.52 / 1061.62</td>
 <td>43.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W18.yaml">OCRNet_HRNet-W18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W18.yaml">OCRNet_HRNet-W18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/OCRNet_HRNet-W18_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/OCRNet_HRNet-W18_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1714,7 +1714,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>582.92 / 536.28</td>
 <td>3513.72 / 2543.10</td>
 <td>270</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W48.yaml">OCRNet_HRNet-W48.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W48.yaml">OCRNet_HRNet-W48.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/OCRNet_HRNet-W48_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/OCRNet_HRNet-W48_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1723,7 +1723,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>28.12 / 23.84</td>
 <td>398.31 / 398.31</td>
 <td>28.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-T.yaml">PP-LiteSeg-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-T.yaml">PP-LiteSeg-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LiteSeg-T_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LiteSeg-T_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1732,7 +1732,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>35.69 / 35.69</td>
 <td>485.10 / 485.10</td>
 <td>47.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-B.yaml">PP-LiteSeg-B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-B.yaml">PP-LiteSeg-B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LiteSeg-B_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LiteSeg-B_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1741,7 +1741,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>11.1946</td>
 <td>268.929</td>
 <td>13.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B0.yaml">SegFormer-B0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B0.yaml">SegFormer-B0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B0 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B0 (slice)_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1750,7 +1750,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>17.9998</td>
 <td>403.393</td>
 <td>48.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B1.yaml">SegFormer-B1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B1.yaml">SegFormer-B1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B1 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B1 (slice)_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1759,7 +1759,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>48.0371</td>
 <td>1248.52</td>
 <td>96.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B2.yaml">SegFormer-B2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B2.yaml">SegFormer-B2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B2 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B2 (slice)_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1768,7 +1768,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>64.341</td>
 <td>1666.35</td>
 <td>167.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B3.yaml">SegFormer-B3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B3.yaml">SegFormer-B3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B3 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B3 (slice)_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1777,7 +1777,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>82.4336</td>
 <td>1995.42</td>
 <td>226.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B4.yaml">SegFormer-B4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B4.yaml">SegFormer-B4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B4 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B4 (slice)_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1786,7 +1786,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>97.3717</td>
 <td>2420.19</td>
 <td>229.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B5.yaml">SegFormer-B5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B5.yaml">SegFormer-B5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B5 (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B5 (slice)_pretrained.pdparams">Training Model</a></td></tr>
 
 </tbody>
@@ -1810,7 +1810,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>24.4073</td>
 <td>397.574</td>
 <td>30.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_base.yaml">SeaFormer_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_base.yaml">SeaFormer_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_base(slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_base(slice)_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SeaFormer_large (slice)</td>
@@ -1818,7 +1818,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>27.8123</td>
 <td>550.464</td>
 <td>49.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_large.yaml">SeaFormer_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_large.yaml">SeaFormer_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_large (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_large (slice)_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SeaFormer_small (slice)</td>
@@ -1826,7 +1826,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>19.2295</td>
 <td>358.343</td>
 <td>14.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_small.yaml">SeaFormer_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_small.yaml">SeaFormer_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_small (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_small (slice)_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>SeaFormer_tiny (slice)</td>
@@ -1834,7 +1834,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>13.9496</td>
 <td>330.132</td>
 <td>6.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_tiny.yaml">SeaFormer_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_tiny.yaml">SeaFormer_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_tiny (slice)_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_tiny (slice)_pretrained.pdparams">Training Model</a></td></tr>
 
 
@@ -1844,7 +1844,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>65.21 / 65.21</td>
 <td>- / 629.85</td>
 <td>242.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/MaskFormer_small.yaml">MaskFormer_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/MaskFormer_small.yaml">MaskFormer_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskFormer_small_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskFormer_small_pretrained.pdparams">Training Model</a></td></tr>
 
 <tr>
@@ -1853,7 +1853,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>47.95 / 47.95</td>
 <td>- / 492.67</td>
 <td>160.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/MaskFormer_tiny.yaml">MaskFormer_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/MaskFormer_tiny.yaml">MaskFormer_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskFormer_tiny_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskFormer_tiny_pretrained.pdparams">Training Model</a></td></tr>
 
 </tbody>
@@ -1879,7 +1879,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>180.83 / 180.83</td>
 <td>1711.24 / 1711.24</td>
 <td>449.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-H.yaml">Mask-RT-DETR-H.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-H.yaml">Mask-RT-DETR-H.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-H_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-H_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-L</td>
@@ -1887,7 +1887,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>113.20 / 113.20</td>
 <td>1179.56 / 1179.56</td>
 <td>113.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-L.yaml">Mask-RT-DETR-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-L.yaml">Mask-RT-DETR-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-L_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-M</td>
@@ -1895,7 +1895,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>87.08 / 87.08</td>
 <td>- / 2090.73</td>
 <td>66.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-M.yaml">Mask-RT-DETR-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-M.yaml">Mask-RT-DETR-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1904,7 +1904,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>120.86 / 120.86</td>
 <td>- / 2163.07</td>
 <td>51.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-S.yaml">Mask-RT-DETR-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-S.yaml">Mask-RT-DETR-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1913,7 +1913,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>141.43 / 141.43</td>
 <td>1379.14 / 1379.14</td>
 <td>237.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-X.yaml">Mask-RT-DETR-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-X.yaml">Mask-RT-DETR-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-X_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-X_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1922,7 +1922,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>136.79 / 136.79</td>
 <td>- / 5935.41</td>
 <td>254.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-FPN.yaml">Cascade-MaskRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-FPN.yaml">Cascade-MaskRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-MaskRCNN-ResNet50-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-MaskRCNN-ResNet50-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1931,7 +1931,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>137.40 / 137.40</td>
 <td>- / 6816.68</td>
 <td>254.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1940,7 +1940,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>112.79 / 112.79</td>
 <td>- / 4912.37</td>
 <td>157.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-FPN.yaml">MaskRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-FPN.yaml">MaskRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1949,7 +1949,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>112.88 / 112.88</td>
 <td>- / 5204.97</td>
 <td>157.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-vd-FPN.yaml">MaskRCNN-ResNet50-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-vd-FPN.yaml">MaskRCNN-ResNet50-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50-vd-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50-vd-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1958,7 +1958,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>181.60 / 181.60</td>
 <td>- / 5523.45</td>
 <td>127.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50.yaml">MaskRCNN-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50.yaml">MaskRCNN-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1967,7 +1967,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>138.84 / 138.84</td>
 <td>- / 5107.74</td>
 <td>225.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-FPN.yaml">MaskRCNN-ResNet101-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-FPN.yaml">MaskRCNN-ResNet101-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet101-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet101-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1976,7 +1976,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>141.73 / 141.73</td>
 <td>- / 5592.76</td>
 <td>225.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-vd-FPN.yaml">MaskRCNN-ResNet101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-vd-FPN.yaml">MaskRCNN-ResNet101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet101-vd-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet101-vd-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1985,7 +1985,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>220.83 / 220.83</td>
 <td>- / 5932.59</td>
 <td>370.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNeXt101-vd-FPN.yaml">MaskRCNN-ResNeXt101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNeXt101-vd-FPN.yaml">MaskRCNN-ResNeXt101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNeXt101-vd-FPN_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNeXt101-vd-FPN_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -1994,7 +1994,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>243.41 / 222.30</td>
 <td>2507.70 / 1282.35</td>
 <td>31.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/PP-YOLOE_seg-S.yaml">PP-YOLOE_seg-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/PP-YOLOE_seg-S.yaml">PP-YOLOE_seg-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_seg-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_seg-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2003,7 +2003,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>131.99 / 131.99</td>
 <td>- / 2369.98</td>
 <td>179.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-beta2/paddlex/configs/modules/instance_segmentation/SOLOv2.yaml">SOLOv2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/SOLOv2.yaml">SOLOv2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SOLOv2_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SOLOv2_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2032,7 +2032,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>89.55 / 70.19</td>
 <td>383.15 / 383.15</td>
 <td>84.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv5_server_det.yaml">PP-OCRv5_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv5_server_det.yaml">PP-OCRv5_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_server_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv5_server_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2041,7 +2041,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.67 / 6.36</td>
 <td>57.77 / 28.15</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv5_mobile_det.yaml">PP-OCRv5_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv5_mobile_det.yaml">PP-OCRv5_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_mobile_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv5_mobile_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 
@@ -2051,7 +2051,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>127.82 / 98.87</td>
 <td>585.95 / 489.77</td>
 <td>109</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv4_server_det.yaml">PP-OCRv4_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv4_server_det.yaml">PP-OCRv4_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2060,7 +2060,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.87 / 4.17</td>
 <td>56.60 / 20.79</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv4_mobile_det.yaml">PP-OCRv4_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv4_mobile_det.yaml">PP-OCRv4_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2069,7 +2069,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.90 / 3.60</td>
 <td>41.93 / 20.76</td>
 <td>2.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv3_mobile_det.yaml">PP-OCRv3_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv3_mobile_det.yaml">PP-OCRv3_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv3_mobile_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv3_mobile_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2078,7 +2078,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>119.50 / 75.00</td>
 <td>379.35 / 318.35</td>
 <td>102.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv3_server_det.yaml">PP-OCRv3_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv3_server_det.yaml">PP-OCRv3_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv3_server_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv3_server_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2104,7 +2104,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>9.70 / 3.56</td>
 <td>50.38 / 19.64</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/seal_text_detection/PP-OCRv4_mobile_seal_det.yaml">PP-OCRv4_mobile_seal_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/seal_text_detection/PP-OCRv4_mobile_seal_det.yaml">PP-OCRv4_mobile_seal_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_seal_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_seal_det_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PP-OCRv4_server_seal_det</td>
@@ -2112,7 +2112,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>124.64 / 91.57</td>
 <td>545.68 / 439.86</td>
 <td>109</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/seal_text_detection/PP-OCRv4_server_seal_det.yaml">PP-OCRv4_server_seal_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/seal_text_detection/PP-OCRv4_server_seal_det.yaml">PP-OCRv4_server_seal_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_seal_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_seal_det_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -2138,7 +2138,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>8.46 / 2.36</td>
 <td>31.21 / 31.21</td>
 <td>81</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv5_server_rec.yaml">PP-OCRv5_server_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv5_server_rec.yaml">PP-OCRv5_server_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_server_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2147,7 +2147,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>16</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv5_mobile_rec.yaml">PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv5_mobile_rec.yaml">PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 
@@ -2157,7 +2157,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>8.69 / 2.78</td>
 <td>37.93 / 37.93</td>
 <td>182</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec_doc.yaml">PP-OCRv4_server_rec_doc.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec_doc.yaml">PP-OCRv4_server_rec_doc.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_rec_doc_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2166,7 +2166,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.26 / 1.12</td>
 <td>17.48 / 3.61</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_mobile_rec.yaml">PP-OCRv4_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_mobile_rec.yaml">PP-OCRv4_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_rec_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2175,7 +2175,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>8.75 / 2.49</td>
 <td>36.93 / 36.93</td>
 <td>173</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec.yaml">PP-OCRv4_server_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec.yaml">PP-OCRv4_server_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_rec_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2184,7 +2184,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.89 / 1.16</td>
 <td>8.72 / 3.56</td>
 <td>10.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv3_mobile_rec.yaml">PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv3_mobile_rec.yaml">PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 </table>
@@ -2205,7 +2205,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>10.38 / 8.31</td>
 <td>66.52 / 30.83</td>
 <td>80.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ch_SVTRv2_rec.yaml">ch_SVTRv2_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ch_SVTRv2_rec.yaml">ch_SVTRv2_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ch_SVTRv2_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ch_SVTRv2_rec_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2226,7 +2226,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>6.29 / 1.57</td>
 <td>20.64 / 5.40</td>
 <td>48.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ch_RepSVTR_rec.yaml">ch_RepSVTR_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ch_RepSVTR_rec.yaml">ch_RepSVTR_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ch_RepSVTR_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ch_RepSVTR_rec_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2248,7 +2248,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>4.81 / 1.23</td>
 <td>17.20 / 4.18</td>
 <td>7.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/en_PP-OCRv4_mobile_rec.yaml">en_PP-OCRv4_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/en_PP-OCRv4_mobile_rec.yaml">en_PP-OCRv4_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/en_PP-OCRv4_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2257,7 +2257,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>3.56 / 0.78</td>
 <td>8.44 / 5.78</td>
 <td>17.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/en_PP-OCRv3_mobile_rec.yaml">en_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/en_PP-OCRv3_mobile_rec.yaml">en_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/en_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 </table>
@@ -2281,7 +2281,7 @@ PaddleX includes multiple pipelines, each containing several modules, and each m
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/korean_PP-OCRv5_mobile_rec.yaml">korean_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/korean_PP-OCRv5_mobile_rec.yaml">korean_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 korean_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/korean_PP-OCRv5_mobile_rec_pretrained.pdparams">Pre-trained Model</a></td>
 </tr>
@@ -2291,7 +2291,7 @@ korean_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddl
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/latin_PP-OCRv5_mobile_rec.yaml">latin_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/latin_PP-OCRv5_mobile_rec.yaml">latin_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 latin_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/latin_PP-OCRv5_mobile_rec_pretrained.pdparams">Pre-trained Model</a></td>
 </tr>
@@ -2301,7 +2301,7 @@ latin_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/eslav_PP-OCRv5_mobile_rec.yaml">eslav_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/eslav_PP-OCRv5_mobile_rec.yaml">eslav_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/eslav_PP-OCRv5_mobile_rec_pretrained.pdparams">Pre-trained Model</a></td>
 </tr>
@@ -2311,7 +2311,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.73 / 0.98</td>
 <td>8.76 / 2.91</td>
 <td>9.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/korean_PP-OCRv3_mobile_rec.yaml">korean_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/korean_PP-OCRv3_mobile_rec.yaml">korean_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/korean_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2320,7 +2320,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.86 / 1.01</td>
 <td>8.62 / 2.92</td>
 <td>8.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/japan_PP-OCRv3_mobile_rec.yaml">japan_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/japan_PP-OCRv3_mobile_rec.yaml">japan_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/japan_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2329,7 +2329,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.90 / 1.16</td>
 <td>9.24 / 3.18</td>
 <td>9.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/chinese_cht_PP-OCRv3_mobile_rec.yaml">chinese_cht_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/chinese_cht_PP-OCRv3_mobile_rec.yaml">chinese_cht_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/chinese_cht_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2338,7 +2338,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.59 / 0.81</td>
 <td>8.28 / 6.21</td>
 <td>7.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/te_PP-OCRv3_mobile_rec.yaml">te_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/te_PP-OCRv3_mobile_rec.yaml">te_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/te_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2347,7 +2347,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.49 / 0.89</td>
 <td>8.63 / 2.77</td>
 <td>17.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ka_PP-OCRv3_mobile_rec.yaml">ka_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ka_PP-OCRv3_mobile_rec.yaml">ka_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ka_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2356,7 +2356,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.49 / 0.86</td>
 <td>8.35 / 3.41</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ta_PP-OCRv3_mobile_rec.yaml">ta_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ta_PP-OCRv3_mobile_rec.yaml">ta_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ta_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2365,7 +2365,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.53 / 0.78</td>
 <td>8.50 / 6.83</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/latin_PP-OCRv3_mobile_rec.yaml">latin_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/latin_PP-OCRv3_mobile_rec.yaml">latin_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/latin_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2374,7 +2374,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.60 / 0.83</td>
 <td>8.44 / 4.69</td>
 <td>17.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/arabic_PP-OCRv3_mobile_rec.yaml">arabic_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/arabic_PP-OCRv3_mobile_rec.yaml">arabic_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/arabic_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2383,7 +2383,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.56 / 0.79</td>
 <td>8.22 / 2.76</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/cyrillic_PP-OCRv3_mobile_rec.yaml">cyrillic_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/cyrillic_PP-OCRv3_mobile_rec.yaml">cyrillic_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/cyrillic_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 <tr>
@@ -2392,7 +2392,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.60 / 0.78</td>
 <td>6.95 / 2.87</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/devanagari_PP-OCRv3_mobile_rec.yaml">devanagari_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/devanagari_PP-OCRv3_mobile_rec.yaml">devanagari_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/devanagari_PP-OCRv3_mobile_rec_infer.tar">Inference Model</a>/<a href="">Training Model</a></td>
 </tr>
 </table>
@@ -2418,7 +2418,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1311.84 / 1311.84</td>
 <td>- / 8288.07</td>
 <td>1530</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/UniMERNet.yaml">UniMERNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/UniMERNet.yaml">UniMERNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/UniMERNet_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/UniMERNet_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2428,7 +2428,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>182.25 / 182.25</td>
 <td>- / 254.39</td>
 <td>224</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet-S.yaml">PP-FormulaNet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet-S.yaml">PP-FormulaNet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2439,7 +2439,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>- / 3131.54</td>
 <td>695</td>
 </tr>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet-L.yaml">PP-FormulaNet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet-L.yaml">PP-FormulaNet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet-L_pretrained.pdparams">Training Model</a></td>
 <tr>
 <td>PP-FormulaNet_plus-S</td>
@@ -2448,7 +2448,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>179.20 / 179.20</td>
 <td>- / 260.99</td>
 <td>248</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-S.yaml">PP-FormulaNet_plus-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-S.yaml">PP-FormulaNet_plus-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2458,7 +2458,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1040.27 / 1040.27</td>
 <td>- / 1615.80</td>
 <td>592</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-M.yaml">PP-FormulaNet_plus-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-M.yaml">PP-FormulaNet_plus-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2468,7 +2468,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1476.07 / 1476.07</td>
 <td>- / 3125.58</td>
 <td>698</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-L.yaml">PP-FormulaNet_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-L.yaml">PP-FormulaNet_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2478,7 +2478,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1088.89 / 1088.89</td>
 <td>- / -</td>
 <td>99</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/LaTeX_OCR_rec.yaml">LaTeX_OCR_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/LaTeX_OCR_rec.yaml">LaTeX_OCR_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/LaTeX_OCR_rec_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/LaTeX_OCR_rec_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2502,7 +2502,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>23.96 / 21.75</td>
 <td>- / 43.12</td>
 <td>6.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANet.yaml">SLANet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANet.yaml">SLANet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANet_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANet_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2511,7 +2511,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>23.43 / 22.16</td>
 <td>- / 41.80</td>
 <td>6.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANet_plus.yaml">SLANet_plus.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANet_plus.yaml">SLANet_plus.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANet_plus_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANet_plus_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2520,12 +2520,12 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td rowspan="2">85.92 / 85.92</td>
 <td rowspan="2">- / 501.66</td>
 <td rowspan="2">351</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANeXt_wired.yaml">SLANeXt_wired.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANeXt_wired.yaml">SLANeXt_wired.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANeXt_wired_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANeXt_wired_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
 <td>SLANeXt_wireless</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANeXt_wireless.yaml">SLANeXt_wireless.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANeXt_wireless.yaml">SLANeXt_wireless.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANeXt_wireless_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANeXt_wireless_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2549,12 +2549,12 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td rowspan="2">33.47 / 27.02</td>
 <td rowspan="2">402.55 / 256.56</td>
 <td rowspan="2">124M</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wired_table_cell_det.yaml">RT-DETR-L_wired_table_cell_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wired_table_cell_det.yaml">RT-DETR-L_wired_table_cell_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_wired_table_cell_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_wired_table_cell_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
 <td>RT-DETR-L_wireless_table_cell_det</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wireless_table_cell_det.yaml">RT-DETR-L_wireless_table_cell_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wireless_table_cell_det.yaml">RT-DETR-L_wireless_table_cell_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_wireless_table_cell_det_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_wireless_table_cell_det_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2578,7 +2578,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>2.62 / 0.60</td>
 <td>3.17 / 1.14</td>
 <td>6.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_classification/PP-LCNet_x1_0_table_cls.yaml">PP-LCNet_x1_0_table_cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_classification/PP-LCNet_x1_0_table_cls.yaml">PP-LCNet_x1_0_table_cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_base_patch16_224_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_table_cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2604,7 +2604,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>19.05 / 19.05</td>
 <td>- / 869.82</td>
 <td>30.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_unwarping/UVDoc.yaml">UVDoc.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_unwarping/UVDoc.yaml">UVDoc.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/UVDoc_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/UVDoc_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2633,7 +2633,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>53.03 / 17.23</td>
 <td>634.62 / 378.32</td>
 <td>126.01</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout_plus-L.yaml">PP-DocLayout_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout_plus-L.yaml">PP-DocLayout_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout_plus-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout_plus-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2661,7 +2661,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>34.60 / 28.54</td>
 <td>506.43 / 256.83</td>
 <td>123.92</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocBlockLayout.yaml">PP-DocBlockLayout.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocBlockLayout.yaml">PP-DocBlockLayout.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBlockLayout_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocBlockLayout_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2690,7 +2690,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>33.59 / 33.59</td>
 <td>503.01 / 251.08</td>
 <td>123.76</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-L.yaml">PP-DocLayout-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-L.yaml">PP-DocLayout-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-L_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-L_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2699,7 +2699,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>13.03 / 4.72</td>
 <td>43.39 / 24.44</td>
 <td>22.578</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-M.yaml">PP-DocLayout-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-M.yaml">PP-DocLayout-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-M_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-M_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2708,7 +2708,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>11.54 / 3.86</td>
 <td>18.53 / 6.29</td>
 <td>4.834</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-S.yaml">PP-DocLayout-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-S.yaml">PP-DocLayout-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-S_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-S_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2737,7 +2737,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>9.57 / 6.63</td>
 <td>27.66 / 16.75</td>
 <td>7.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet_layout_1x_table.yaml">PicoDet_layout_1x_table.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet_layout_1x_table.yaml">PicoDet_layout_1x_table.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_layout_1x_table_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_layout_1x_table_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody></table>
@@ -2762,7 +2762,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>8.43 / 3.44</td>
 <td>17.60 / 6.51</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-S_layout_3cls.yaml">PicoDet-S_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-S_layout_3cls.yaml">PicoDet-S_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_layout_3cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_layout_3cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2771,7 +2771,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>12.80 / 9.57</td>
 <td>45.04 / 23.86</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-L_layout_3cls.yaml">PicoDet-L_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-L_layout_3cls.yaml">PicoDet-L_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_layout_3cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_layout_3cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2780,7 +2780,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>114.80 / 25.65</td>
 <td>924.38 / 924.38</td>
 <td>470.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_3cls.yaml">RT-DETR-H_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_3cls.yaml">RT-DETR-H_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_layout_3cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_layout_3cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody></table>
@@ -2806,7 +2806,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>9.62 / 6.75</td>
 <td>26.96 / 12.77</td>
 <td>7.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet_layout_1x.yaml">PicoDet_layout_1x.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet_layout_1x.yaml">PicoDet_layout_1x.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_layout_1x_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_layout_1x_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody></table>
@@ -2832,7 +2832,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>8.80 / 3.62</td>
 <td>17.51 / 6.35</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-S_layout_17cls.yaml">PicoDet-S_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-S_layout_17cls.yaml">PicoDet-S_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_layout_17cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_layout_17cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2841,7 +2841,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>12.60 / 10.27</td>
 <td>43.70 / 24.42</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-L_layout_17cls.yaml">PicoDet-L_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-L_layout_17cls.yaml">PicoDet-L_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_layout_17cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_layout_17cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
@@ -2850,7 +2850,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>115.29 / 101.18</td>
 <td>964.75 / 964.75</td>
 <td>470.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_17cls.yaml">RT-DETR-H_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_17cls.yaml">RT-DETR-H_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_layout_17cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_layout_17cls_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -2878,7 +2878,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>2.62 / 0.59</td>
 <td>3.24 / 1.19</td>
 <td>7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_text_orientation/PP-LCNet_x1_0_doc_ori.yaml">PP-LCNet_x1_0_doc_ori.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_text_orientation/PP-LCNet_x1_0_doc_ori.yaml">PP-LCNet_x1_0_doc_ori.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_doc_ori_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_doc_ori_pretrained.pdparams">Training Model</a></td>
 </tr>
 </tbody>
@@ -2907,7 +2907,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>2.16 / 0.41</td>
 <td>2.37 / 0.73</td>
 <td>7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/textline_orientation/PP-LCNet_x0_25_textline_ori.yaml">PP-LCNet_x0_25_textline_ori.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/textline_orientation/PP-LCNet_x0_25_textline_ori.yaml">PP-LCNet_x0_25_textline_ori.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_25_textline_ori_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_25_textline_ori_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2916,7 +2916,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>- / -</td>
 <td>2.98 / 2.98</td>
 <td>7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/textline_orientation/PP-LCNet_x1_0_textline_ori.yaml">PP-LCNet_x1_0_textline_ori.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/textline_orientation/PP-LCNet_x1_0_textline_ori.yaml">PP-LCNet_x1_0_textline_ori.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_textline_ori_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_textline_ori_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2946,7 +2946,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>0.34 / 0.12</td>
 <td>0.64 / 0.06</td>
 <td>0.072</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/DLinear.yaml">DLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/DLinear.yaml">DLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DLinear_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DLinear_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>NLinear</td>
@@ -2955,7 +2955,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>0.27 / 0.10</td>
 <td>0.49 / 0.08</td>
 <td>0.04</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/NLinear.yaml">NLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/NLinear.yaml">NLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/NLinear_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/NLinear_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Nonstationary</td>
@@ -2964,7 +2964,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>3.92 / 2.59</td>
 <td>18.09 / 13.36</td>
 <td>55.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/Nonstationary.yaml">Nonstationary.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/Nonstationary.yaml">Nonstationary.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Nonstationary_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Nonstationary_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PatchTST</td>
@@ -2973,7 +2973,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1.81 / 0.45</td>
 <td>5.79 / 0.77</td>
 <td>2.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/PatchTST.yaml">PatchTST.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/PatchTST.yaml">PatchTST.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PatchTST_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PatchTST_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>RLinear</td>
@@ -2982,7 +2982,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>0.39 / 0.18</td>
 <td>0.82 / 0.08</td>
 <td>0.04</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/RLinear.yaml">RLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/RLinear.yaml">RLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RLinear_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RLinear_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>TiDE</td>
@@ -2991,7 +2991,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>- / -</td>
 <td>4.54 / 1.09</td>
 <td>31.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/TiDE.yaml">TiDE.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/TiDE.yaml">TiDE.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TiDE_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TiDE_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>TimesNet</td>
@@ -3000,7 +3000,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>15.19 / 13.77</td>
 <td>23.14 / 12.42</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/TimesNet.yaml">TimesNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/TimesNet.yaml">TimesNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TimesNet_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TimesNet_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -3025,7 +3025,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>0.24 / 0.13</td>
 <td>0.41 / 0.05</td>
 <td>0.052</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/AutoEncoder_ad.yaml">AutoEncoder_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/AutoEncoder_ad.yaml">AutoEncoder_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/AutoEncoder_ad_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/AutoEncoder_ad_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>DLinear_ad</td>
@@ -3033,7 +3033,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>0.39 / 0.16</td>
 <td>0.69 / 0.08</td>
 <td>0.112</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/DLinear_ad.yaml">DLinear_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/DLinear_ad.yaml">DLinear_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DLinear_ad_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DLinear_ad_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>Nonstationary_ad</td>
@@ -3041,7 +3041,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>1.94 / 1.16</td>
 <td>5.31 / 1.66</td>
 <td>1.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/Nonstationary_ad.yaml">Nonstationary_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/Nonstationary_ad.yaml">Nonstationary_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Nonstationary_ad_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Nonstationary_ad_pretrained.pdparams">Training Model</a></td></tr>
 <tr>
 <td>PatchTST_ad</td>
@@ -3049,7 +3049,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>2.10 / 0.55</td>
 <td>6.98 / 0.63</td>
 <td>0.32</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/PatchTST_ad.yaml">PatchTST_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/PatchTST_ad.yaml">PatchTST_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PatchTST_ad_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PatchTST_ad_pretrained.pdparams">Training Model</a></td></tr>
 
 </tbody>
@@ -3071,7 +3071,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>TimesNet_cls</td>
 <td>87.5</td>
 <td>0.792</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_classification/TimesNet_cls.yaml">TimesNet_cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_classification/TimesNet_cls.yaml">TimesNet_cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TimesNet_cls_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TimesNet_cls_pretrained.pdparams">Training Model</a></td></tr>
 </tbody>
 </table>
@@ -3094,7 +3094,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>680kh</td>
 <td>5800</td>
 <td>2.7 (Librispeech)</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_large.yaml">whisper_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_large.yaml">whisper_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_large.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -3102,7 +3102,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>680kh</td>
 <td>2900</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_medium.yaml">whisper_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_medium.yaml">whisper_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_medium.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -3110,7 +3110,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>680kh</td>
 <td>923</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_small.yaml">whisper_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_small.yaml">whisper_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_small.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -3118,7 +3118,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>680kh</td>
 <td>277</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_base.yaml">whisper_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_base.yaml">whisper_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_base.tar">Inference Model</a></td>
 </tr>
 <tr>
@@ -3126,7 +3126,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>680kh</td>
 <td>145</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_tiny.yaml">whisper_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_tiny.yaml">whisper_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_tiny.tar">Inference Model</a></td>
 </tr>
 </table>
@@ -3145,21 +3145,21 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>PP-TSM-R50_8frames_uniform</td>
 <td>74.36</td>
 <td>93.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSM-R50_8frames_uniform.yaml">PP-TSM-R50_8frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSM-R50_8frames_uniform.yaml">PP-TSM-R50_8frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSM-R50_8frames_uniform_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSM-R50_8frames_uniform_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
 <td>PP-TSMv2-LCNetV2_8frames_uniform</td>
 <td>71.71</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_8frames_uniform.yaml">PP-TSMv2-LCNetV2_8frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_8frames_uniform.yaml">PP-TSMv2-LCNetV2_8frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSMv2-LCNetV2_8frames_uniform_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSMv2-LCNetV2_8frames_uniform_pretrained.pdparams">Training Model</a></td>
 </tr>
 <tr>
 <td>PP-TSMv2-LCNetV2_16frames_uniform</td>
 <td>73.11</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_16frames_uniform.yaml">PP-TSMv2-LCNetV2_16frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_16frames_uniform.yaml">PP-TSMv2-LCNetV2_16frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSMv2-LCNetV2_16frames_uniform_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSMv2-LCNetV2_16frames_uniform_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -3179,7 +3179,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>YOWO</td>
 <td>80.94</td>
 <td>462.891</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_detection/YOWO.yaml">YOWO.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_detection/YOWO.yaml">YOWO.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOWO_infer.tar">Inference Model</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOWO_pretrained.pdparams">Training Model</a></td>
 </tr>
 </table>
@@ -3199,21 +3199,21 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>PP-DocBee-2B</td>
 <td>2</td>
 <td>4.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml">PP-DocBee-2B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml">PP-DocBee-2B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee-2B_infer.tar">Inference Model</a></td>
 </tr>
 <tr>
 <td>PP-DocBee-7B</td>
 <td>7</td>
 <td>15.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml">PP-DocBee-7B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml">PP-DocBee-7B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee-7B_infer.tar">Inference Model</a></td>
 </tr>
 <tr>
 <td>PP-DocBee2-3B</td>
 <td>3</td>
 <td>7.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee2-3B.yaml">PP-DocBee2-3B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee2-3B.yaml">PP-DocBee2-3B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee2-3B_infer.tar">Inference Model</a></td>
 </tr>
 </table>
@@ -3233,7 +3233,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">Inference Model</a>/<a href="https://paddle
 <td>PP-Chart2Table</td>
 <td>0.58</td>
 <td>1.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/chart_parsing/PP-Chart2Table.yaml">PP-Chart2Table.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/chart_parsing/PP-Chart2Table.yaml">PP-Chart2Table.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-Chart2Table_infer.tar">Inference Model</a></td>
 </tr>
 </table>

--- a/docs/support_list/models_list.md
+++ b/docs/support_list/models_list.md
@@ -25,7 +25,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>12.03 / 2.49</td>
 <td>60.86 / 42.69</td>
 <td>331</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/CLIP_vit_base_patch16_224.yaml">CLIP_vit_base_patch16_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/CLIP_vit_base_patch16_224.yaml">CLIP_vit_base_patch16_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_base_patch16_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_base_patch16_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>CLIP_vit_large_patch14_224</td>
@@ -33,7 +33,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>49.15 / 9.75</td>
 <td>223.16 / 206.49</td>
 <td>1040</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/CLIP_vit_large_patch14_224.yaml">CLIP_vit_large_patch14_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/CLIP_vit_large_patch14_224.yaml">CLIP_vit_large_patch14_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_large_patch14_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_large_patch14_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_base_224</td>
@@ -41,7 +41,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.37 / 5.65</td>
 <td>143.98 / 52.31</td>
 <td>313.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_base_224.yaml">ConvNeXt_base_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_base_224.yaml">ConvNeXt_base_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_base_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_base_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_base_384</td>
@@ -49,7 +49,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>29.48 / 11.17</td>
 <td>293.76 / 134.27</td>
 <td>313.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_base_384.yaml">ConvNeXt_base_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_base_384.yaml">ConvNeXt_base_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_base_384_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_base_384_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_large_224</td>
@@ -57,7 +57,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>22.99 / 12.73</td>
 <td>220.79 / 113.24</td>
 <td>700.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_large_224.yaml">ConvNeXt_large_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_large_224.yaml">ConvNeXt_large_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_large_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_large_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_large_384</td>
@@ -65,7 +65,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>58.90 / 24.63</td>
 <td>509.48 / 260.27</td>
 <td>700.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_large_384.yaml">ConvNeXt_large_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_large_384.yaml">ConvNeXt_large_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_large_384_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_large_384_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_small</td>
@@ -73,7 +73,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.72 / 4.35</td>
 <td>95.92 / 33.34</td>
 <td>178.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_small.yaml">ConvNeXt_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_small.yaml">ConvNeXt_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_small_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_small_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ConvNeXt_tiny</td>
@@ -81,7 +81,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.00 / 2.47</td>
 <td>63.59 / 18.23</td>
 <td>101.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ConvNeXt_tiny.yaml">ConvNeXt_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ConvNeXt_tiny.yaml">ConvNeXt_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ConvNeXt_tiny_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ConvNeXt_tiny_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-L</td>
@@ -89,7 +89,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.96 / 2.68</td>
 <td>51.93 / 35.33</td>
 <td>357.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-L.yaml">FasterNet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-L.yaml">FasterNet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-M</td>
@@ -97,7 +97,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.17 / 2.16</td>
 <td>38.49 / 21.17</td>
 <td>204.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-M.yaml">FasterNet-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-M.yaml">FasterNet-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-M_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-S</td>
@@ -105,7 +105,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.70 / 1.24</td>
 <td>19.51 / 11.22</td>
 <td>119.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-S.yaml">FasterNet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-S.yaml">FasterNet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-T0</td>
@@ -113,7 +113,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.73 / 0.82</td>
 <td>6.40 / 1.96</td>
 <td>15.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T0.yaml">FasterNet-T0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T0.yaml">FasterNet-T0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-T1</td>
@@ -121,7 +121,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.80 / 0.80</td>
 <td>8.14 / 3.13</td>
 <td>29.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T1.yaml">FasterNet-T1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T1.yaml">FasterNet-T1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T1_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T1_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterNet-T2</td>
@@ -129,7 +129,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.10 / 0.88</td>
 <td>12.71 / 5.35</td>
 <td>57.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/FasterNet-T2.yaml">FasterNet-T2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/FasterNet-T2.yaml">FasterNet-T2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterNet-T2_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterNet-T2_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV1_x0_5</td>
@@ -137,7 +137,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>1.98 / 0.51</td>
 <td>2.50 / 1.04</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_5.yaml">MobileNetV1_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_5.yaml">MobileNetV1_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV1_x0_25</td>
@@ -145,7 +145,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>1.99 / 0.45</td>
 <td>1.82 / 0.73</td>
 <td>1.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_25.yaml">MobileNetV1_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_25.yaml">MobileNetV1_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_25_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_25_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV1_x0_75</td>
@@ -153,7 +153,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.33 / 0.41</td>
 <td>3.33 / 1.34</td>
 <td>9.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x0_75.yaml">MobileNetV1_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x0_75.yaml">MobileNetV1_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x0_75_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x0_75_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV1_x1_0</td>
@@ -161,7 +161,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.31 / 0.45</td>
 <td>3.91 / 1.89</td>
 <td>15.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV1_x1_0.yaml">MobileNetV1_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV1_x1_0.yaml">MobileNetV1_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV1_x1_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV1_x1_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV2_x0_5</td>
@@ -169,7 +169,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.58 / 0.62</td>
 <td>3.86 / 1.23</td>
 <td>7.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x0_5.yaml">MobileNetV2_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x0_5.yaml">MobileNetV2_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x0_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x0_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV2_x0_25</td>
@@ -177,7 +177,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.05 / 0.66</td>
 <td>3.30 / 0.98</td>
 <td>5.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x0_25.yaml">MobileNetV2_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x0_25.yaml">MobileNetV2_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x0_25_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x0_25_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV2_x1_0</td>
@@ -185,7 +185,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.85 / 0.63</td>
 <td>5.50 / 1.87</td>
 <td>12.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x1_0.yaml">MobileNetV2_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x1_0.yaml">MobileNetV2_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x1_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x1_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV2_x1_5</td>
@@ -193,7 +193,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.93 / 0.73</td>
 <td>8.84 / 3.12</td>
 <td>25.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x1_5.yaml">MobileNetV2_x1_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x1_5.yaml">MobileNetV2_x1_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x1_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x1_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV2_x2_0</td>
@@ -201,7 +201,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.89 / 0.79</td>
 <td>10.36 / 4.50</td>
 <td>41.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV2_x2_0.yaml">MobileNetV2_x2_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV2_x2_0.yaml">MobileNetV2_x2_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV2_x2_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV2_x2_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x0_5</td>
@@ -209,7 +209,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.60 / 0.77</td>
 <td>5.32 / 1.58</td>
 <td>9.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_5.yaml">MobileNetV3_large_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_5.yaml">MobileNetV3_large_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x0_35</td>
@@ -217,7 +217,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.44 / 0.75</td>
 <td>5.20 / 1.50</td>
 <td>7.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_35.yaml">MobileNetV3_large_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_35.yaml">MobileNetV3_large_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_35_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_35_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x0_75</td>
@@ -225,7 +225,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.30 / 0.85</td>
 <td>6.02 / 1.93</td>
 <td>14.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_75.yaml">MobileNetV3_large_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x0_75.yaml">MobileNetV3_large_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x0_75_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x0_75_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x1_0</td>
@@ -233,7 +233,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.38 / 0.81</td>
 <td>7.16 / 2.19</td>
 <td>19.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_0.yaml">MobileNetV3_large_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_0.yaml">MobileNetV3_large_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x1_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x1_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_large_x1_25</td>
@@ -241,7 +241,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.54 / 0.84</td>
 <td>7.06 / 2.84</td>
 <td>26.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_25.yaml">MobileNetV3_large_x1_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_large_x1_25.yaml">MobileNetV3_large_x1_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_large_x1_25_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_large_x1_25_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x0_5</td>
@@ -249,7 +249,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.87 / 0.77</td>
 <td>4.90 / 1.32</td>
 <td>6.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_5.yaml">MobileNetV3_small_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_5.yaml">MobileNetV3_small_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x0_35</td>
@@ -257,7 +257,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.68 / 0.77</td>
 <td>3.94 / 1.27</td>
 <td>6.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_35.yaml">MobileNetV3_small_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_35.yaml">MobileNetV3_small_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_35_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_35_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x0_75</td>
@@ -265,7 +265,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.92 / 0.77</td>
 <td>4.68 / 1.39</td>
 <td>8.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_75.yaml">MobileNetV3_small_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x0_75.yaml">MobileNetV3_small_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x0_75_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x0_75_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x1_0</td>
@@ -273,7 +273,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.23 / 0.78</td>
 <td>5.24 / 1.48</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_0.yaml">MobileNetV3_small_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_0.yaml">MobileNetV3_small_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x1_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x1_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV3_small_x1_25</td>
@@ -281,7 +281,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.59 / 0.79</td>
 <td>5.36 / 1.63</td>
 <td>13.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_25.yaml">MobileNetV3_small_x1_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV3_small_x1_25.yaml">MobileNetV3_small_x1_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV3_small_x1_25_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV3_small_x1_25_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV4_conv_large</td>
@@ -289,7 +289,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.04 / 2.28</td>
 <td>34.34 / 22.01</td>
 <td>125.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_large.yaml">MobileNetV4_conv_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_large.yaml">MobileNetV4_conv_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_large_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_large_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV4_conv_medium</td>
@@ -297,7 +297,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.70 / 1.05</td>
 <td>13.78 / 5.64</td>
 <td>37.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_medium.yaml">MobileNetV4_conv_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_medium.yaml">MobileNetV4_conv_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_medium_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_medium_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV4_conv_small</td>
@@ -305,7 +305,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.81 / 0.55</td>
 <td>5.24 / 1.50</td>
 <td>14.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_conv_small.yaml">MobileNetV4_conv_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_conv_small.yaml">MobileNetV4_conv_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_conv_small_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_conv_small_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV4_hybrid_large</td>
@@ -313,7 +313,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.43 / 4.28</td>
 <td>61.16 / 31.06</td>
 <td>145.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_large.yaml">MobileNetV4_hybrid_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_large.yaml">MobileNetV4_hybrid_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_hybrid_large_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_hybrid_large_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MobileNetV4_hybrid_medium</td>
@@ -321,7 +321,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.82 / 1.30</td>
 <td>22.01 / 6.06</td>
 <td>42.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_medium.yaml">MobileNetV4_hybrid_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/MobileNetV4_hybrid_medium.yaml">MobileNetV4_hybrid_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileNetV4_hybrid_medium_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileNetV4_hybrid_medium_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNet_base</td>
@@ -329,7 +329,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.43 / 3.81</td>
 <td>71.24 / 51.48</td>
 <td>249.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_base.yaml">PP-HGNet_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_base.yaml">PP-HGNet_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_base_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_base_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNet_small</td>
@@ -337,7 +337,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.87 / 1.68</td>
 <td>25.58 / 18.50</td>
 <td>86.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_small.yaml">PP-HGNet_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_small.yaml">PP-HGNet_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_small_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_small_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNet_tiny</td>
@@ -345,7 +345,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.84 / 1.38</td>
 <td>17.03 / 10.58</td>
 <td>52.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNet_tiny.yaml">PP-HGNet_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNet_tiny.yaml">PP-HGNet_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNet_tiny_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNet_tiny_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B0</td>
@@ -353,7 +353,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.41 / 0.87</td>
 <td>10.58 / 1.87</td>
 <td>21.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B0.yaml">PP-HGNetV2-B0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B0.yaml">PP-HGNetV2-B0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B1</td>
@@ -361,7 +361,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.52 / 0.73</td>
 <td>11.98 / 2.28</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B1.yaml">PP-HGNetV2-B1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B1.yaml">PP-HGNetV2-B1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B1_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B1_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B2</td>
@@ -369,7 +369,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.67 / 0.96</td>
 <td>14.22 / 4.04</td>
 <td>39.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B2.yaml">PP-HGNetV2-B2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B2.yaml">PP-HGNetV2-B2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B2_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B2_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B3</td>
@@ -377,7 +377,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.47 / 1.94</td>
 <td>17.73 / 5.63</td>
 <td>57.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B3.yaml">PP-HGNetV2-B3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B3.yaml">PP-HGNetV2-B3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B3_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B3_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B4</td>
@@ -385,7 +385,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.05 / 1.16</td>
 <td>16.23 / 7.55</td>
 <td>70.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B4.yaml">PP-HGNetV2-B4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B4.yaml">PP-HGNetV2-B4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B4_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B4_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B5</td>
@@ -393,7 +393,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.38 / 1.95</td>
 <td>31.53 / 18.02</td>
 <td>140.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B5.yaml">PP-HGNetV2-B5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B5.yaml">PP-HGNetV2-B5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B6</td>
@@ -401,7 +401,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.86 / 3.28</td>
 <td>67.25 / 56.70</td>
 <td>268.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-HGNetV2-B6.yaml">PP-HGNetV2-B6.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-HGNetV2-B6.yaml">PP-HGNetV2-B6.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B6_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B6_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x0_5</td>
@@ -409,7 +409,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.41 / 0.60</td>
 <td>2.54 / 0.90</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_5.yaml">PP-LCNet_x0_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_5.yaml">PP-LCNet_x0_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x0_25</td>
@@ -417,7 +417,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.16 / 0.60</td>
 <td>2.73 / 0.77</td>
 <td>5.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_25.yaml">PP-LCNet_x0_25.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_25.yaml">PP-LCNet_x0_25.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_25_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_25_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x0_35</td>
@@ -425,7 +425,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.18 / 0.60</td>
 <td>2.32 / 0.89</td>
 <td>5.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_35.yaml">PP-LCNet_x0_35.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_35.yaml">PP-LCNet_x0_35.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_35_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_35_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x0_75</td>
@@ -433,7 +433,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.61 / 0.58</td>
 <td>3.00 / 1.09</td>
 <td>8.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x0_75.yaml">PP-LCNet_x0_75.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x0_75.yaml">PP-LCNet_x0_75.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x0_75_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x0_75_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x1_0</td>
@@ -441,7 +441,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.59 / 0.68</td>
 <td>3.18 / 1.19</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x1_0.yaml">PP-LCNet_x1_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x1_0.yaml">PP-LCNet_x1_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x1_5</td>
@@ -449,7 +449,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.60 / 0.68</td>
 <td>3.98 / 1.66</td>
 <td>16.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x1_5.yaml">PP-LCNet_x1_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x1_5.yaml">PP-LCNet_x1_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x2_0</td>
@@ -457,7 +457,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.53 / 0.68</td>
 <td>5.21 / 2.24</td>
 <td>23.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x2_0.yaml">PP-LCNet_x2_0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x2_0.yaml">PP-LCNet_x2_0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x2_0_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x2_0_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x2_5</td>
@@ -465,7 +465,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.76 / 0.67</td>
 <td>6.78 / 3.20</td>
 <td>32.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNet_x2_5.yaml">PP-LCNet_x2_5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNet_x2_5.yaml">PP-LCNet_x2_5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x2_5_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x2_5_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNetV2_base</td>
@@ -473,7 +473,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.04 / 0.62</td>
 <td>6.80 / 2.67</td>
 <td>23.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_base.yaml">PP-LCNetV2_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_base.yaml">PP-LCNetV2_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_base_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_base_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNetV2_large</td>
@@ -481,7 +481,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.91 / 0.85</td>
 <td>10.30 / 5.38</td>
 <td>37.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_large.yaml">PP-LCNetV2_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_large.yaml">PP-LCNetV2_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_large_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_large_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNetV2_small</td>
@@ -489,7 +489,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.07 / 0.60</td>
 <td>4.28 / 1.58</td>
 <td>14.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/PP-LCNetV2_small.yaml">PP-LCNetV2_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/PP-LCNetV2_small.yaml">PP-LCNetV2_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNetV2_small_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNetV2_small_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet18_vd</td>
@@ -497,7 +497,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.87 / 0.77</td>
 <td>7.91 / 4.64</td>
 <td>41.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet18_vd.yaml">ResNet18_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet18_vd.yaml">ResNet18_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet18_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet18_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet18</td>
@@ -505,7 +505,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.63 / 0.74</td>
 <td>6.30 / 4.16</td>
 <td>41.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet18.yaml">ResNet18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet18.yaml">ResNet18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet18_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet18_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet34_vd</td>
@@ -513,7 +513,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.47 / 1.09</td>
 <td>14.30 / 8.33</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet34_vd.yaml">ResNet34_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet34_vd.yaml">ResNet34_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet34_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet34_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet34</td>
@@ -521,7 +521,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.20 / 1.07</td>
 <td>12.53 / 7.83</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet34.yaml">ResNet34.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet34.yaml">ResNet34.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet34_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet34_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet50_vd</td>
@@ -529,7 +529,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.66 / 1.23</td>
 <td>16.34 / 10.00</td>
 <td>90.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet50_vd.yaml">ResNet50_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet50_vd.yaml">ResNet50_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet50</td>
@@ -537,7 +537,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.25 / 1.17</td>
 <td>15.93 / 9.72</td>
 <td>90.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet50.yaml">ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet50.yaml">ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet101_vd</td>
@@ -545,7 +545,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.93 / 2.07</td>
 <td>32.47 / 23.62</td>
 <td>158.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet101_vd.yaml">ResNet101_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet101_vd.yaml">ResNet101_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet101_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet101_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet101</td>
@@ -553,7 +553,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.73 / 2.06</td>
 <td>29.69 / 17.72</td>
 <td>158.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet101.yaml">ResNet101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet101.yaml">ResNet101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet101_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet101_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet152_vd</td>
@@ -561,7 +561,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>20.70 / 2.82</td>
 <td>43.90 / 27.91</td>
 <td>214.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet152_vd.yaml">ResNet152_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet152_vd.yaml">ResNet152_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet152_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet152_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet152</td>
@@ -569,7 +569,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>17.86 / 2.79</td>
 <td>46.19 / 26.00</td>
 <td>214.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet152.yaml">ResNet152.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet152.yaml">ResNet152.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet152_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet152_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet200_vd</td>
@@ -577,7 +577,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>22.55 / 3.54</td>
 <td>58.54 / 35.70</td>
 <td>266.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/ResNet200_vd.yaml">ResNet200_vd.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/ResNet200_vd.yaml">ResNet200_vd.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet200_vd_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet200_vd_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>StarNet-S1</td>
@@ -585,7 +585,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.24 / 0.96</td>
 <td>8.78 / 2.44</td>
 <td>11.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S1.yaml">StarNet-S1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S1.yaml">StarNet-S1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S1_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S1_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>StarNet-S2</td>
@@ -593,7 +593,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.78 / 0.85</td>
 <td>7.24 / 2.48</td>
 <td>14.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S2.yaml">StarNet-S2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S2.yaml">StarNet-S2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S2_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S2_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>StarNet-S3</td>
@@ -601,7 +601,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.77 / 1.07</td>
 <td>9.69 / 3.35</td>
 <td>22.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S3.yaml">StarNet-S3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S3.yaml">StarNet-S3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S3_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S3_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>StarNet-S4</td>
@@ -609,7 +609,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.01 / 1.48</td>
 <td>14.79 / 4.58</td>
 <td>28.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/StarNet-S4.yaml">StarNet-S4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/StarNet-S4.yaml">StarNet-S4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/StarNet-S4_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/StarNet-S4_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_base_patch4_window7_224</td>
@@ -617,7 +617,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.04 / 10.77</td>
 <td>133.79 / 118.45</td>
 <td>340</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window7_224.yaml">SwinTransformer_base_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window7_224.yaml">SwinTransformer_base_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_base_patch4_window7_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_base_patch4_window7_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_base_patch4_window12_384</td>
@@ -625,7 +625,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>33.99 / 28.42</td>
 <td>400.19 / 317.36</td>
 <td>311.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window12_384.yaml">SwinTransformer_base_patch4_window12_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_base_patch4_window12_384.yaml">SwinTransformer_base_patch4_window12_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_base_patch4_window12_384_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_base_patch4_window12_384_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_large_patch4_window7_224</td>
@@ -633,7 +633,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>23.69 / 6.18</td>
 <td>198.60 / 177.18</td>
 <td>694.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window7_224.yaml">SwinTransformer_large_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window7_224.yaml">SwinTransformer_large_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_large_patch4_window7_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_large_patch4_window7_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_large_patch4_window12_384</td>
@@ -641,7 +641,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>68.07 / 14.84</td>
 <td>609.07 / 525.72</td>
 <td>696.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window12_384.yaml">SwinTransformer_large_patch4_window12_384.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_large_patch4_window12_384.yaml">SwinTransformer_large_patch4_window12_384.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_large_patch4_window12_384_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_large_patch4_window12_384_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_small_patch4_window7_224</td>
@@ -649,7 +649,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>12.17 / 3.51</td>
 <td>111.03 / 92.51</td>
 <td>175.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_small_patch4_window7_224.yaml">SwinTransformer_small_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_small_patch4_window7_224.yaml">SwinTransformer_small_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_small_patch4_window7_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_small_patch4_window7_224_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SwinTransformer_tiny_patch4_window7_224</td>
@@ -657,7 +657,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.11 / 2.01</td>
 <td>62.72 / 47.35</td>
 <td>100.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_classification/SwinTransformer_tiny_patch4_window7_224.yaml">SwinTransformer_tiny_patch4_window7_224.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_classification/SwinTransformer_tiny_patch4_window7_224.yaml">SwinTransformer_tiny_patch4_window7_224.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SwinTransformer_tiny_patch4_window7_224_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SwinTransformer_tiny_patch4_window7_224_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -682,7 +682,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>48.87 / 8.10</td>
 <td>275.33 / 188.48</td>
 <td>325.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/CLIP_vit_base_patch16_448_ML.yaml">CLIP_vit_base_patch16_448_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/CLIP_vit_base_patch16_448_ML.yaml">CLIP_vit_base_patch16_448_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CLIP_vit_base_patch16_448_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CLIP_vit_base_patch16_448_ML_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B0_ML</td>
@@ -690,7 +690,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>7.15 / 1.77</td>
 <td>21.35 / 8.19</td>
 <td>39.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B0_ML.yaml">PP-HGNetV2-B0_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B0_ML.yaml">PP-HGNetV2-B0_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B0_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B0_ML_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B4_ML</td>
@@ -698,7 +698,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>8.11 / 2.82</td>
 <td>44.76 / 29.38</td>
 <td>88.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B4_ML.yaml">PP-HGNetV2-B4_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B4_ML.yaml">PP-HGNetV2-B4_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B4_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B4_ML_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-HGNetV2-B6_ML</td>
@@ -706,7 +706,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>34.54 / 8.22</td>
 <td>189.17 / 189.17</td>
 <td>286.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B6_ML.yaml">PP-HGNetV2-B6_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-HGNetV2-B6_ML.yaml">PP-HGNetV2-B6_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-HGNetV2-B6_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-HGNetV2-B6_ML_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LCNet_x1_0_ML</td>
@@ -714,7 +714,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.28 / 1.62</td>
 <td>13.16 / 5.61</td>
 <td>29.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/PP-LCNet_x1_0_ML.yaml">PP-LCNet_x1_0_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/PP-LCNet_x1_0_ML.yaml">PP-LCNet_x1_0_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_ML_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet50_ML</td>
@@ -722,7 +722,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.54 / 2.97</td>
 <td>55.39 / 35.52</td>
 <td>108.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_multilabel_classification/ResNet50_ML.yaml">ResNet50_ML.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_multilabel_classification/ResNet50_ML.yaml">ResNet50_ML.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_ML_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_ML_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -747,7 +747,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.52 / 0.66</td>
 <td>2.60 / 1.07</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/pedestrian_attribute_recognition/PP-LCNet_x1_0_pedestrian_attribute.yaml">PP-LCNet_x1_0_pedestrian_attribute.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/pedestrian_attribute_recognition/PP-LCNet_x1_0_pedestrian_attribute.yaml">PP-LCNet_x1_0_pedestrian_attribute.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_pedestrian_attribute_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_pedestrian_attribute_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -772,7 +772,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>2.53 / 0.67</td>
 <td>2.73 / 1.10</td>
 <td>6.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_attribute_recognition/PP-LCNet_x1_0_vehicle_attribute.yaml">PP-LCNet_x1_0_vehicle_attribute.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_attribute_recognition/PP-LCNet_x1_0_vehicle_attribute.yaml">PP-LCNet_x1_0_vehicle_attribute.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_vehicle_attribute_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_vehicle_attribute_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -797,7 +797,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.91 / 1.06</td>
 <td>6.82 / 2.89</td>
 <td>16.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec.yaml">PP-ShiTuV2_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec.yaml">PP-ShiTuV2_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-ShiTuV2_rec_CLIP_vit_base</td>
@@ -805,7 +805,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>12.57 / 11.62</td>
 <td>67.09 / 67.09</td>
 <td>306.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_base.yaml">PP-ShiTuV2_rec_CLIP_vit_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_base.yaml">PP-ShiTuV2_rec_CLIP_vit_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_CLIP_vit_base_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_CLIP_vit_base_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-ShiTuV2_rec_CLIP_vit_large</td>
@@ -813,7 +813,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>49.85 / 49.85</td>
 <td>229.14 / 229.14</td>
 <td>1050</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_large.yaml">PP-ShiTuV2_rec_CLIP_vit_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_feature/PP-ShiTuV2_rec_CLIP_vit_large.yaml">PP-ShiTuV2_rec_CLIP_vit_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_rec_CLIP_vit_large_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_rec_CLIP_vit_large_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -841,7 +841,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>3.31 / 0.73</td>
 <td>5.93 / 1.30</td>
 <td>4.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_recognition/MobileFaceNet.yaml">MobileFaceNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_recognition/MobileFaceNet.yaml">MobileFaceNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MobileFaceNet_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MobileFaceNet_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>ResNet50_face</td>
@@ -850,7 +850,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>6.12 / 3.11</td>
 <td>15.85 / 9.44</td>
 <td>87.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_recognition/ResNet50_face.yaml">ResNet50_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_recognition/ResNet50_face.yaml">ResNet50_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ResNet50_face_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ResNet50_face_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -875,7 +875,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.81 / 4.53</td>
 <td>43.03 / 25.31</td>
 <td>27.54</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/mainbody_detection/PP-ShiTuV2_det.yaml">PP-ShiTuV2_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/mainbody_detection/PP-ShiTuV2_det.yaml">PP-ShiTuV2_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-ShiTuV2_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-ShiTuV2_det_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -900,7 +900,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>120.28 / 120.28</td>
 <td>- / 6514.61</td>
 <td>245.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-FPN.yaml">Cascade-FasterRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-FPN.yaml">Cascade-FasterRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-FasterRCNN-ResNet50-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-FasterRCNN-ResNet50-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN</td>
@@ -908,7 +908,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>124.10 / 124.10</td>
 <td>- / 6709.52</td>
 <td>246.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-FasterRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>CenterNet-DLA-34</td>
@@ -916,7 +916,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>67.19 / 67.19</td>
 <td>6622.61 / 6622.61</td>
 <td>75.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/CenterNet-DLA-34.yaml">CenterNet-DLA-34.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/CenterNet-DLA-34.yaml">CenterNet-DLA-34.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CenterNet-DLA-34_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CenterNet-DLA-34_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>CenterNet-ResNet50</td>
@@ -924,7 +924,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>216.06 / 216.06</td>
 <td>2545.79 / 2545.79</td>
 <td>319.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/CenterNet-ResNet50.yaml">CenterNet-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/CenterNet-ResNet50.yaml">CenterNet-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/CenterNet-ResNet50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/CenterNet-ResNet50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>DETR-R50</td>
@@ -932,7 +932,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>58.80 / 26.90</td>
 <td>370.96 / 208.77</td>
 <td>159.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/DETR-R50.yaml">DETR-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/DETR-R50.yaml">DETR-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DETR-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DETR-R50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet34-FPN</td>
@@ -940,7 +940,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>76.90 / 76.90</td>
 <td>- / 4136.79</td>
 <td>137.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet34-FPN.yaml">FasterRCNN-ResNet34-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet34-FPN.yaml">FasterRCNN-ResNet34-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet34-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet34-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet50-FPN</td>
@@ -948,7 +948,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>95.48 / 95.48</td>
 <td>- / 3693.90</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-FPN.yaml">FasterRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-FPN.yaml">FasterRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet50-vd-FPN</td>
@@ -956,7 +956,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>98.03 / 98.03</td>
 <td>- / 4278.36</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-FPN.yaml">FasterRCNN-ResNet50-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-FPN.yaml">FasterRCNN-ResNet50-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-vd-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-vd-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet50-vd-SSLDv2-FPN</td>
@@ -964,7 +964,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>99.23 / 99.23</td>
 <td>- / 4415.68</td>
 <td>148.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml">FasterRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet50</td>
@@ -972,7 +972,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>129.10 / 129.10</td>
 <td>- / 3868.44</td>
 <td>120.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50.yaml">FasterRCNN-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet50.yaml">FasterRCNN-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet101-FPN</td>
@@ -980,7 +980,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>131.48 / 131.48</td>
 <td>- / 4380.00</td>
 <td>216.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101-FPN.yaml">FasterRCNN-ResNet101-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101-FPN.yaml">FasterRCNN-ResNet101-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet101-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet101-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNet101</td>
@@ -988,7 +988,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>216.71 / 216.71</td>
 <td>- / 5376.45</td>
 <td>188.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101.yaml">FasterRCNN-ResNet101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNet101.yaml">FasterRCNN-ResNet101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNet101_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNet101_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-ResNeXt101-vd-FPN</td>
@@ -996,7 +996,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>234.38 / 234.38</td>
 <td>- / 6154.61</td>
 <td>360.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-ResNeXt101-vd-FPN.yaml">FasterRCNN-ResNeXt101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-ResNeXt101-vd-FPN.yaml">FasterRCNN-ResNeXt101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-ResNeXt101-vd-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-ResNeXt101-vd-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FasterRCNN-Swin-Tiny-FPN</td>
@@ -1004,7 +1004,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>65.92 / 65.92</td>
 <td>- / 2468.98</td>
 <td>159.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FasterRCNN-Swin-Tiny-FPN.yaml">FasterRCNN-Swin-Tiny-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FasterRCNN-Swin-Tiny-FPN.yaml">FasterRCNN-Swin-Tiny-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FasterRCNN-Swin-Tiny-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FasterRCNN-Swin-Tiny-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>FCOS-ResNet50</td>
@@ -1012,7 +1012,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>101.02 / 34.42</td>
 <td>752.15 / 752.15</td>
 <td>124.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml">FCOS-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/FCOS-ResNet50.yaml">FCOS-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/FCOS-ResNet50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/FCOS-ResNet50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PicoDet-L</td>
@@ -1020,7 +1020,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>14.31 / 11.06</td>
 <td>45.95 / 25.06</td>
 <td>20.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-L.yaml">PicoDet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-L.yaml">PicoDet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PicoDet-M</td>
@@ -1028,7 +1028,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.48 / 5.00</td>
 <td>22.88 / 9.03</td>
 <td>16.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-M.yaml">PicoDet-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-M.yaml">PicoDet-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-M_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PicoDet-S</td>
@@ -1036,7 +1036,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.15 / 3.26</td>
 <td>16.06 / 4.04</td>
 <td>4.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-S.yaml">PicoDet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-S.yaml">PicoDet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PicoDet-XS</td>
@@ -1044,7 +1044,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.54 / 3.52</td>
 <td>17.96 / 5.38</td>
 <td>5.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PicoDet-XS.yaml">PicoDet-XS.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PicoDet-XS.yaml">PicoDet-XS.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-XS_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-XS_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-L</td>
@@ -1052,7 +1052,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>32.06 / 28.00</td>
 <td>185.32 / 116.21</td>
 <td>185.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-L.yaml">PP-YOLOE_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-L.yaml">PP-YOLOE_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-M</td>
@@ -1060,7 +1060,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>18.37 / 15.04</td>
 <td>108.77 / 63.48</td>
 <td>83.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-M.yaml">PP-YOLOE_plus-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-M.yaml">PP-YOLOE_plus-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-M_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-S</td>
@@ -1068,7 +1068,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.43 / 7.52</td>
 <td>60.16 / 26.94</td>
 <td>28.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-S.yaml">PP-YOLOE_plus-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-S.yaml">PP-YOLOE_plus-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-X</td>
@@ -1076,7 +1076,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>56.28 / 50.60</td>
 <td>292.08 / 212.24</td>
 <td>349.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/PP-YOLOE_plus-X.yaml">PP-YOLOE_plus-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/PP-YOLOE_plus-X.yaml">PP-YOLOE_plus-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-X_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-X_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RT-DETR-H</td>
@@ -1084,7 +1084,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>114.57 / 101.56</td>
 <td>938.20 / 938.20</td>
 <td>435.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-H.yaml">RT-DETR-H.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-H.yaml">RT-DETR-H.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RT-DETR-L</td>
@@ -1092,7 +1092,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>34.76 / 27.60</td>
 <td>495.39 / 247.68</td>
 <td>113.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-L.yaml">RT-DETR-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-L.yaml">RT-DETR-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RT-DETR-R18</td>
@@ -1100,7 +1100,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>19.11 / 14.82</td>
 <td>263.13 / 143.05</td>
 <td>70.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-R18.yaml">RT-DETR-R18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-R18.yaml">RT-DETR-R18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-R18_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-R18_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RT-DETR-R50</td>
@@ -1108,7 +1108,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>41.11 / 10.12</td>
 <td>536.20 / 482.86</td>
 <td>149.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-R50.yaml">RT-DETR-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-R50.yaml">RT-DETR-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-R50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RT-DETR-X</td>
@@ -1116,7 +1116,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>61.91 / 51.41</td>
 <td>639.79 / 639.79</td>
 <td>232.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/RT-DETR-X.yaml">RT-DETR-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/RT-DETR-X.yaml">RT-DETR-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-X_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-X_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOv3-DarkNet53</td>
@@ -1124,7 +1124,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>39.62 / 35.54</td>
 <td>166.57 / 136.34</td>
 <td>219.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-DarkNet53.yaml">YOLOv3-DarkNet53.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-DarkNet53.yaml">YOLOv3-DarkNet53.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-DarkNet53_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-DarkNet53_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOv3-MobileNetV3</td>
@@ -1132,7 +1132,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>16.54 / 6.21</td>
 <td>64.37 / 45.55</td>
 <td>83.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-MobileNetV3.yaml">YOLOv3-MobileNetV3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-MobileNetV3.yaml">YOLOv3-MobileNetV3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-MobileNetV3_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-MobileNetV3_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOv3-ResNet50_vd_DCN</td>
@@ -1140,7 +1140,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>31.64 / 26.72</td>
 <td>226.75 / 226.75</td>
 <td>163.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOv3-ResNet50_vd_DCN.yaml">YOLOv3-ResNet50_vd_DCN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOv3-ResNet50_vd_DCN.yaml">YOLOv3-ResNet50_vd_DCN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOv3-ResNet50_vd_DCN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOv3-ResNet50_vd_DCN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-L</td>
@@ -1148,7 +1148,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>49.68 / 45.03</td>
 <td>232.52 / 156.24</td>
 <td>192.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-L.yaml">YOLOX-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-L.yaml">YOLOX-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-M</td>
@@ -1156,7 +1156,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>43.46 / 29.52</td>
 <td>147.64 / 80.06</td>
 <td>90.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-M.yaml">YOLOX-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-M.yaml">YOLOX-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-M_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-N</td>
@@ -1164,7 +1164,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>42.94 / 17.79</td>
 <td>64.15 / 7.19</td>
 <td>3.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-N.yaml">YOLOX-N.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-N.yaml">YOLOX-N.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-N_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-N_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-S</td>
@@ -1172,7 +1172,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>46.53 / 29.34</td>
 <td>98.37 / 35.02</td>
 <td>32.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-S.yaml">YOLOX-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-S.yaml">YOLOX-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-T</td>
@@ -1180,7 +1180,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>31.81 / 18.91</td>
 <td>55.34 / 11.63</td>
 <td>18.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-T.yaml">YOLOX-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-T.yaml">YOLOX-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-T_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-T_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>YOLOX-X</td>
@@ -1188,7 +1188,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>84.06 / 77.28</td>
 <td>390.38 / 272.88</td>
 <td>351.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/YOLOX-X.yaml">YOLOX-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/YOLOX-X.yaml">YOLOX-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLOX-X_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOLOX-X_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Co-Deformable-DETR-R50</td>
@@ -1196,7 +1196,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>259.62 / 259.62</td>
 <td>32413.76 / 32413.76</td>
 <td>184</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-Deformable-DETR-R50.yaml">Co-Deformable-DETR-R50.yaml.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-Deformable-DETR-R50.yaml">Co-Deformable-DETR-R50.yaml.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-Deformable-DETR-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-Deformable-DETR-R50_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1205,7 +1205,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>120.17 / 120.17</td>
 <td>- / 15620.29</td>
 <td>187</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-Deformable-DETR-Swin-T.yaml">Co-Deformable-Swin-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-Deformable-DETR-Swin-T.yaml">Co-Deformable-Swin-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-Deformable-DETR-Swin-T_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-Deformable-DETR-Swin-T_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1214,7 +1214,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>1123.23 / 1123.23</td>
 <td>- / -</td>
 <td>186</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-DINO-R50.yaml">Co-DINO-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-DINO-R50.yaml">Co-DINO-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-DINO-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-DINO-R50_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1223,7 +1223,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>- / -</td>
 <td>- / -</td>
 <td>840</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/object_detection/Co-DINO-Swin-L.yaml">Co-DINO-Swin-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/object_detection/Co-DINO-Swin-L.yaml">Co-DINO-Swin-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Co-DINO-Swin-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Co-DINO-Swin-L_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -1249,7 +1249,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>116.07 / 20.10</td>
 <td>176.44 / 40.21</td>
 <td>77.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml">PP-YOLOE_plus_SOD-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-S.yaml">PP-YOLOE_plus_SOD-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus_SOD-L</td>
@@ -1257,7 +1257,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>100.02 / 48.33</td>
 <td>271.29 / 151.20</td>
 <td>325.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml">PP-YOLOE_plus_SOD-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-L.yaml">PP-YOLOE_plus_SOD-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus_SOD-largesize-L</td>
@@ -1265,7 +1265,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>515.69 / 460.17</td>
 <td>2816.08 / 1736.00</td>
 <td>340.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-largesize-L.yaml">PP-YOLOE_plus_SOD-largesize-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/small_object_detection/PP-YOLOE_plus_SOD-largesize-L.yaml">PP-YOLOE_plus_SOD-largesize-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus_SOD-largesize-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus_SOD-largesize-L_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1291,7 +1291,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>- / -</td>
 <td>- / -</td>
 <td>658.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_detection/GroundingDINO-T.yaml">GroundingDINO-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_detection/GroundingDINO-T.yaml">GroundingDINO-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/GroundingDINO-T_infer.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -1301,7 +1301,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>- / -</td>
 <td>292.14 / 292.14</td>
 <td>421.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_detection/YOLO-Worldv2-L.yaml">YOLO-Worldv2-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_detection/YOLO-Worldv2-L.yaml">YOLO-Worldv2-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOLO-Worldv2-L_infer.tar">推理模型</a></td>
 </tr>
 </table>
@@ -1323,7 +1323,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>- / -</td>
 <td>- / -</td>
 <td>2433.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_box.yaml">SAM-H_box.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_box.yaml">SAM-H_box.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SAM-H_box_infer.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -1331,7 +1331,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>- / -</td>
 <td>- / -</td>
 <td>2433.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_point.yaml">SAM-H_point.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/open_vocabulary_segmentation/SAM-H_point.yaml">SAM-H_point.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SAM-H_point_infer.tar">推理模型</a></td>
 </tr>
 </table>
@@ -1355,7 +1355,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>67.50 / 61.15</td>
 <td>414.79 / 414.79</td>
 <td>211.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/rotated_object_detection/PP-YOLOE-R-L.yaml">PP-YOLOE-R-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/rotated_object_detection/PP-YOLOE-R-L.yaml">PP-YOLOE-R-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-R-L_infer.tar">推理模型</a>/<a href="https://paddledet.bj.bcebos.com/models/ppyoloe_r_crn_l_3x_dota.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -1380,7 +1380,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>30.59 / 26.64</td>
 <td>180.05 / 112.70</td>
 <td>196.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/human_detection/PP-YOLOE-L_human.yaml">PP-YOLOE-L_human.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/human_detection/PP-YOLOE-L_human.yaml">PP-YOLOE-L_human.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-L_human_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-L_human_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE-S_human</td>
@@ -1388,7 +1388,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.26 / 6.66</td>
 <td>54.01 / 23.48</td>
 <td>28.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/human_detection/PP-YOLOE-S_human.yaml">PP-YOLOE-S_human.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/human_detection/PP-YOLOE-S_human.yaml">PP-YOLOE-S_human.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-S_human_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-S_human_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1413,7 +1413,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>30.30 / 26.27</td>
 <td>169.28 / 111.88</td>
 <td>196.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_detection/PP-YOLOE-L_vehicle.yaml">PP-YOLOE-L_vehicle.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_detection/PP-YOLOE-L_vehicle.yaml">PP-YOLOE-L_vehicle.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-L_vehicle_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-L_vehicle_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE-S_vehicle</td>
@@ -1421,7 +1421,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.54 / 6.69</td>
 <td>52.73 / 23.58</td>
 <td>28.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/vehicle_detection/PP-YOLOE-S_vehicle.yaml">PP-YOLOE-S_vehicle.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/vehicle_detection/PP-YOLOE-S_vehicle.yaml">PP-YOLOE-S_vehicle.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE-S_vehicle_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE-S_vehicle_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1446,7 +1446,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>50.90 / 45.74</td>
 <td>71.92 / 71.92</td>
 <td>0.447</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/BlazeFace.yaml">BlazeFace.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/BlazeFace.yaml">BlazeFace.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BlazeFace_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BlazeFace_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>BlazeFace-FPN-SSH</td>
@@ -1454,7 +1454,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>58.99 / 51.75</td>
 <td>87.39 / 87.39</td>
 <td>0.606</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/BlazeFace-FPN-SSH.yaml">BlazeFace-FPN-SSH.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/BlazeFace-FPN-SSH.yaml">BlazeFace-FPN-SSH.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BlazeFace-FPN-SSH_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BlazeFace-FPN-SSH_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PicoDet_LCNet_x2_5_face</td>
@@ -1462,7 +1462,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>33.91 / 26.53</td>
 <td>153.56 / 79.21</td>
 <td>28.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/PicoDet_LCNet_x2_5_face.yaml">PicoDet_LCNet_x2_5_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/PicoDet_LCNet_x2_5_face.yaml">PicoDet_LCNet_x2_5_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_LCNet_x2_5_face_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_LCNet_x2_5_face_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_plus-S_face</td>
@@ -1470,7 +1470,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>21.28 / 11.09</td>
 <td>137.26 / 72.09</td>
 <td>26.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/face_detection/PP-YOLOE_plus-S_face.yaml">PP-YOLOE_plus-S_face.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/face_detection/PP-YOLOE_plus-S_face.yaml">PP-YOLOE_plus-S_face.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_plus-S_face_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_plus-S_face_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1496,7 +1496,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>4.94 / 1.63</td>
 <td>34.88 / 34.88</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_anomaly_detection/STFPM.yaml">STFPM.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_anomaly_detection/STFPM.yaml">STFPM.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/STFPM_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/STFPM_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1524,7 +1524,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>24.22 / 4.34</td>
 <td>- / 6.19</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/keypoint_detection/PP-TinyPose_128x96.yaml">PP-TinyPose_128x96.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/keypoint_detection/PP-TinyPose_128x96.yaml">PP-TinyPose_128x96.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TinyPose_128x96_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TinyPose_128x96_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1534,7 +1534,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>21.73 / 3.59</td>
 <td>- / 10.18</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/keypoint_detection/PP-TinyPose_256x192.yaml">PP-TinyPose_256x192.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/keypoint_detection/PP-TinyPose_256x192.yaml">PP-TinyPose_256x192.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TinyPose_256x192_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TinyPose_256x192_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -1555,7 +1555,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>BEVFusion</td>
 <td>53.9</td>
 <td>60.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/3d_bev_detection/BEVFusion.yaml">BEVFusion.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/3d_bev_detection/BEVFusion.yaml">BEVFusion.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/BEVFusion_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/BEVFusion_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1581,7 +1581,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>481.33 / 446.18</td>
 <td>2952.95 / 1907.07</td>
 <td>94.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R50.yaml">Deeplabv3_Plus-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R50.yaml">Deeplabv3_Plus-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3_Plus-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3_Plus-R50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Deeplabv3_Plus-R101</td>
@@ -1589,7 +1589,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>766.70 / 194.42</td>
 <td>4441.56 / 2984.19</td>
 <td>162.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R101.yaml">Deeplabv3_Plus-R101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3_Plus-R101.yaml">Deeplabv3_Plus-R101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3_Plus-R101_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3_Plus-R101_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Deeplabv3-R50</td>
@@ -1597,7 +1597,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>681.65 / 602.10</td>
 <td>3786.41 / 3093.10</td>
 <td>138.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R50.yaml">Deeplabv3-R50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R50.yaml">Deeplabv3-R50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3-R50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3-R50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Deeplabv3-R101</td>
@@ -1605,7 +1605,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>974.62 / 896.99</td>
 <td>5222.60 / 4230.79</td>
 <td>205.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R101.yaml">Deeplabv3-R101.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/Deeplabv3-R101.yaml">Deeplabv3-R101.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Deeplabv3-R101_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Deeplabv3-R101_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>OCRNet_HRNet-W18</td>
@@ -1613,7 +1613,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>271.02 / 221.38</td>
 <td>1791.52 / 1061.62</td>
 <td>43.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W18.yaml">OCRNet_HRNet-W18.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W18.yaml">OCRNet_HRNet-W18.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/OCRNet_HRNet-W18_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/OCRNet_HRNet-W18_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>OCRNet_HRNet-W48</td>
@@ -1621,7 +1621,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>582.92 / 536.28</td>
 <td>3513.72 / 2543.10</td>
 <td>270</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W48.yaml">OCRNet_HRNet-W48.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/OCRNet_HRNet-W48.yaml">OCRNet_HRNet-W48.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/OCRNet_HRNet-W48_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/OCRNet_HRNet-W48_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LiteSeg-T</td>
@@ -1629,7 +1629,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>28.12 / 23.84</td>
 <td>398.31 / 398.31</td>
 <td>28.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-T.yaml">PP-LiteSeg-T.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-T.yaml">PP-LiteSeg-T.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LiteSeg-T_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LiteSeg-T_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-LiteSeg-B</td>
@@ -1637,7 +1637,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>35.69 / 35.69</td>
 <td>485.10 / 485.10</td>
 <td>47.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-B.yaml">PP-LiteSeg-B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/PP-LiteSeg-B.yaml">PP-LiteSeg-B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LiteSeg-B_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LiteSeg-B_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B0 (slice)</td>
@@ -1645,7 +1645,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>11.1946</td>
 <td>268.929</td>
 <td>13.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B0.yaml">SegFormer-B0.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B0.yaml">SegFormer-B0.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B0 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B0 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B1 (slice)</td>
@@ -1653,7 +1653,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>17.9998</td>
 <td>403.393</td>
 <td>48.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B1.yaml">SegFormer-B1.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B1.yaml">SegFormer-B1.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B1 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B1 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B2 (slice)</td>
@@ -1661,7 +1661,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>48.0371</td>
 <td>1248.52</td>
 <td>96.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B2.yaml">SegFormer-B2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B2.yaml">SegFormer-B2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B2 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B2 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B3 (slice)</td>
@@ -1669,7 +1669,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>64.341</td>
 <td>1666.35</td>
 <td>167.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B3.yaml">SegFormer-B3.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B3.yaml">SegFormer-B3.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B3 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B3 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B4 (slice)</td>
@@ -1677,7 +1677,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>82.4336</td>
 <td>1995.42</td>
 <td>226.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B4.yaml">SegFormer-B4.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B4.yaml">SegFormer-B4.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B4 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B4 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SegFormer-B5 (slice)</td>
@@ -1685,7 +1685,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>97.3717</td>
 <td>2420.19</td>
 <td>229.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SegFormer-B5.yaml">SegFormer-B5.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SegFormer-B5.yaml">SegFormer-B5.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SegFormer-B5 (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SegFormer-B5 (slice)_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1708,7 +1708,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>24.4073</td>
 <td>397.574</td>
 <td>30.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_base.yaml">SeaFormer_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_base.yaml">SeaFormer_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_base(slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_base(slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SeaFormer_large (slice)</td>
@@ -1716,7 +1716,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>27.8123</td>
 <td>550.464</td>
 <td>49.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_large.yaml">SeaFormer_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_large.yaml">SeaFormer_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_large (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_large (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SeaFormer_small (slice)</td>
@@ -1724,7 +1724,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>19.2295</td>
 <td>358.343</td>
 <td>14.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_small.yaml">SeaFormer_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_small.yaml">SeaFormer_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_small (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_small (slice)_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SeaFormer_tiny (slice)</td>
@@ -1732,7 +1732,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>13.9496</td>
 <td>330.132</td>
 <td>6.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/SeaFormer_tiny.yaml">SeaFormer_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/SeaFormer_tiny.yaml">SeaFormer_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SeaFormer_tiny (slice)_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SeaFormer_tiny (slice)_pretrained.pdparams">训练模型</a></td></tr>
 
 <tr>
@@ -1741,7 +1741,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>65.21 / 65.21</td>
 <td>- / 629.85</td>
 <td>242.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/MaskFormer_small.yaml">MaskFormer_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/MaskFormer_small.yaml">MaskFormer_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskFormer_small_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskFormer_small_pretrained.pdparams">训练模型</a></td></tr>
 
 <tr>
@@ -1750,7 +1750,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>47.95 / 47.95</td>
 <td>- / 492.67</td>
 <td>160.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/semantic_segmentation/MaskFormer_tiny.yaml">MaskFormer_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/semantic_segmentation/MaskFormer_tiny.yaml">MaskFormer_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskFormer_tiny_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskFormer_tiny_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1775,7 +1775,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>180.83 / 180.83</td>
 <td>1711.24 / 1711.24</td>
 <td>449.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-H.yaml">Mask-RT-DETR-H.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-H.yaml">Mask-RT-DETR-H.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-H_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-H_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-L</td>
@@ -1783,7 +1783,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>113.20 / 113.20</td>
 <td>1179.56 / 1179.56</td>
 <td>113.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-L.yaml">Mask-RT-DETR-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-L.yaml">Mask-RT-DETR-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-L_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-M</td>
@@ -1791,7 +1791,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>87.08 / 87.08</td>
 <td>- / 2090.73</td>
 <td>66.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-M.yaml">Mask-RT-DETR-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-M.yaml">Mask-RT-DETR-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-M_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-S</td>
@@ -1799,7 +1799,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>120.86 / 120.86</td>
 <td>- / 2163.07</td>
 <td>51.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-S.yaml">Mask-RT-DETR-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-S.yaml">Mask-RT-DETR-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Mask-RT-DETR-X</td>
@@ -1807,7 +1807,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>141.43 / 141.43</td>
 <td>1379.14 / 1379.14</td>
 <td>237.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-X.yaml">Mask-RT-DETR-X.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Mask-RT-DETR-X.yaml">Mask-RT-DETR-X.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Mask-RT-DETR-X_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Mask-RT-DETR-X_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Cascade-MaskRCNN-ResNet50-FPN</td>
@@ -1815,7 +1815,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>136.79 / 136.79</td>
 <td>- / 5935.41</td>
 <td>254.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-FPN.yaml">Cascade-MaskRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-FPN.yaml">Cascade-MaskRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-MaskRCNN-ResNet50-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-MaskRCNN-ResNet50-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN</td>
@@ -1823,7 +1823,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>137.40 / 137.40</td>
 <td>- / 6816.68</td>
 <td>254.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml">Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Cascade-MaskRCNN-ResNet50-vd-SSLDv2-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNet50-FPN</td>
@@ -1831,7 +1831,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>112.79 / 112.79</td>
 <td>- / 4912.37</td>
 <td>157.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-FPN.yaml">MaskRCNN-ResNet50-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-FPN.yaml">MaskRCNN-ResNet50-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNet50-vd-FPN</td>
@@ -1839,7 +1839,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>112.88 / 112.88</td>
 <td>- / 5204.97</td>
 <td>157.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-vd-FPN.yaml">MaskRCNN-ResNet50-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50-vd-FPN.yaml">MaskRCNN-ResNet50-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50-vd-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50-vd-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNet50</td>
@@ -1847,7 +1847,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>181.60 / 181.60</td>
 <td>- / 5523.45</td>
 <td>127.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50.yaml">MaskRCNN-ResNet50.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet50.yaml">MaskRCNN-ResNet50.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet50_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet50_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNet101-FPN</td>
@@ -1855,7 +1855,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>138.84 / 138.84</td>
 <td>- / 5107.74</td>
 <td>225.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-FPN.yaml">MaskRCNN-ResNet101-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-FPN.yaml">MaskRCNN-ResNet101-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet101-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet101-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNet101-vd-FPN</td>
@@ -1863,7 +1863,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>141.73 / 141.73</td>
 <td>- / 5592.76</td>
 <td>225.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-vd-FPN.yaml">MaskRCNN-ResNet101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNet101-vd-FPN.yaml">MaskRCNN-ResNet101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNet101-vd-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNet101-vd-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>MaskRCNN-ResNeXt101-vd-FPN</td>
@@ -1871,7 +1871,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>220.83 / 220.83</td>
 <td>- / 5932.59</td>
 <td>370.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNeXt101-vd-FPN.yaml">MaskRCNN-ResNeXt101-vd-FPN.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/MaskRCNN-ResNeXt101-vd-FPN.yaml">MaskRCNN-ResNeXt101-vd-FPN.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/MaskRCNN-ResNeXt101-vd-FPN_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/MaskRCNN-ResNeXt101-vd-FPN_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-YOLOE_seg-S</td>
@@ -1879,7 +1879,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>243.41 / 222.30</td>
 <td>2507.70 / 1282.35</td>
 <td>31.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/instance_segmentation/PP-YOLOE_seg-S.yaml">PP-YOLOE_seg-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/PP-YOLOE_seg-S.yaml">PP-YOLOE_seg-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-YOLOE_seg-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-YOLOE_seg-S_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>SOLOv2</td>
@@ -1887,7 +1887,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>131.99 / 131.99</td>
 <td>- / 2369.98</td>
 <td>179.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/release/3.0-beta2/paddlex/configs/modules/instance_segmentation/SOLOv2.yaml">SOLOv2.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/instance_segmentation/SOLOv2.yaml">SOLOv2.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SOLOv2_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SOLOv2_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -1914,7 +1914,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>89.55 / 70.19</td>
 <td>383.15 / 383.15</td>
 <td>84.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv5_server_det.yaml">PP-OCRv5_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv5_server_det.yaml">PP-OCRv5_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_server_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv5_server_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1923,7 +1923,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>10.67 / 6.36</td>
 <td>57.77 / 28.15</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv5_mobile_det.yaml">PP-OCRv5_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv5_mobile_det.yaml">PP-OCRv5_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_mobile_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv5_mobile_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1932,7 +1932,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>127.82 / 98.87</td>
 <td>585.95 / 489.77</td>
 <td>109</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv4_server_det.yaml">PP-OCRv4_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv4_server_det.yaml">PP-OCRv4_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1941,7 +1941,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.87 / 4.17</td>
 <td>56.60 / 20.79</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv4_mobile_det.yaml">PP-OCRv4_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv4_mobile_det.yaml">PP-OCRv4_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1950,7 +1950,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.90 / 3.60</td>
 <td>41.93 / 20.76</td>
 <td>2.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv3_mobile_det.yaml">PP-OCRv3_mobile_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv3_mobile_det.yaml">PP-OCRv3_mobile_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv3_mobile_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv3_mobile_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -1959,7 +1959,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>119.50 / 75.00</td>
 <td>379.35 / 318.35</td>
 <td>102.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_detection/PP-OCRv3_server_det.yaml">PP-OCRv3_server_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_detection/PP-OCRv3_server_det.yaml">PP-OCRv3_server_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv3_server_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv3_server_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -1985,7 +1985,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>9.70 / 3.56</td>
 <td>50.38 / 19.64</td>
 <td>4.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/seal_text_detection/PP-OCRv4_mobile_seal_det.yaml">PP-OCRv4_mobile_seal_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/seal_text_detection/PP-OCRv4_mobile_seal_det.yaml">PP-OCRv4_mobile_seal_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_seal_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_seal_det_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PP-OCRv4_server_seal_det</td>
@@ -1993,7 +1993,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>124.64 / 91.57</td>
 <td>545.68 / 439.86</td>
 <td>109</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/seal_text_detection/PP-OCRv4_server_seal_det.yaml">PP-OCRv4_server_seal_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/seal_text_detection/PP-OCRv4_server_seal_det.yaml">PP-OCRv4_server_seal_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_seal_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_seal_det_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -2018,7 +2018,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>8.46 / 2.36</td>
 <td>31.21 / 31.21</td>
 <td>81</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv5_server_rec.yaml">PP-OCRv5_server_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv5_server_rec.yaml">PP-OCRv5_server_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_server_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
 <tr>
@@ -2027,7 +2027,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>16</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv5_mobile_rec.yaml">PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv5_mobile_rec.yaml">PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
 <tr>
@@ -2036,7 +2036,7 @@ PaddleX 内置了多条产线，每条产线都包含了若干模块，每个模
 <td>8.69 / 2.78</td>
 <td>37.93 / 37.93</td>
 <td>182</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec_doc.yaml">PP-OCRv4_server_rec_doc.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec_doc.yaml">PP-OCRv4_server_rec_doc.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 PP-OCRv4_server_rec_doc_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2046,7 +2046,7 @@ PP-OCRv4_server_rec_doc_infer.tar">推理模型</a>/<a href="">训练模型</a><
 <td>5.26 / 1.12</td>
 <td>17.48 / 3.61</td>
 <td>10.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_mobile_rec.yaml">PP-OCRv4_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_mobile_rec.yaml">PP-OCRv4_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_mobile_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2055,7 +2055,7 @@ PP-OCRv4_server_rec_doc_infer.tar">推理模型</a>/<a href="">训练模型</a><
 <td>8.75 / 2.49</td>
 <td>36.93 / 36.93</td>
 <td>173</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec.yaml">PP-OCRv4_server_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv4_server_rec.yaml">PP-OCRv4_server_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv4_server_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-OCRv4_server_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2064,7 +2064,7 @@ PP-OCRv4_server_rec_doc_infer.tar">推理模型</a>/<a href="">训练模型</a><
 <td>3.89 / 1.16</td>
 <td>8.72 / 3.56</td>
 <td>10.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/PP-OCRv3_mobile_rec.yaml">PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/PP-OCRv3_mobile_rec.yaml">PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2086,7 +2086,7 @@ PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 <td>10.38 / 8.31</td>
 <td>66.52 / 30.83</td>
 <td>80.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ch_SVTRv2_rec.yaml">ch_SVTRv2_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ch_SVTRv2_rec.yaml">ch_SVTRv2_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ch_SVTRv2_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ch_SVTRv2_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2107,7 +2107,7 @@ PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 <td>6.29 / 1.57</td>
 <td>20.64 / 5.40</td>
 <td>48.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ch_RepSVTR_rec.yaml">ch_RepSVTR_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ch_RepSVTR_rec.yaml">ch_RepSVTR_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/ch_RepSVTR_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/ch_RepSVTR_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2130,7 +2130,7 @@ PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 <td>4.81 / 1.23</td>
 <td>17.20 / 4.18</td>
 <td>7.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/en_PP-OCRv4_mobile_rec.yaml">en_PP-OCRv4_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/en_PP-OCRv4_mobile_rec.yaml">en_PP-OCRv4_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 en_PP-OCRv4_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2140,7 +2140,7 @@ en_PP-OCRv4_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></
 <td>3.56 / 0.78</td>
 <td>8.44 / 5.78</td>
 <td>17.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/en_PP-OCRv3_mobile_rec.yaml">en_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/en_PP-OCRv3_mobile_rec.yaml">en_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 en_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2165,7 +2165,7 @@ en_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/korean_PP-OCRv5_mobile_rec.yaml">korean_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/korean_PP-OCRv5_mobile_rec.yaml">korean_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 korean_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/korean_PP-OCRv5_mobile_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
@@ -2175,7 +2175,7 @@ korean_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-m
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/latin_PP-OCRv5_mobile_rec.yaml">latin_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/latin_PP-OCRv5_mobile_rec.yaml">latin_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 latin_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/latin_PP-OCRv5_mobile_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
@@ -2185,7 +2185,7 @@ latin_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-mo
 <td>5.43 / 1.46</td>
 <td>21.20 / 5.32</td>
 <td>14</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/eslav_PP-OCRv5_mobile_rec.yaml">eslav_PP-OCRv5_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/eslav_PP-OCRv5_mobile_rec.yaml">eslav_PP-OCRv5_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 eslav_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/eslav_PP-OCRv5_mobile_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
@@ -2195,7 +2195,7 @@ eslav_PP-OCRv5_mobile_rec_infer.tar">推理模型</a>/<a href="https://paddle-mo
 <td>3.73 / 0.98</td>
 <td>8.76 / 2.91</td>
 <td>9.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/korean_PP-OCRv3_mobile_rec.yaml">korean_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/korean_PP-OCRv3_mobile_rec.yaml">korean_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 korean_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2205,7 +2205,7 @@ korean_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</
 <td>3.86 / 1.01</td>
 <td>8.62 / 2.92</td>
 <td>9.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/japan_PP-OCRv3_mobile_rec.yaml">japan_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/japan_PP-OCRv3_mobile_rec.yaml">japan_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 japan_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2215,7 +2215,7 @@ japan_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a
 <td>3.90 / 1.16</td>
 <td>9.24 / 3.18</td>
 <td>10.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/chinese_cht_PP-OCRv3_mobile_rec.yaml">chinese_cht_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/chinese_cht_PP-OCRv3_mobile_rec.yaml">chinese_cht_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 chinese_cht_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2225,7 +2225,7 @@ chinese_cht_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模
 <td>3.59 / 0.81</td>
 <td>8.28 / 6.21</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/te_PP-OCRv3_mobile_rec.yaml">te_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/te_PP-OCRv3_mobile_rec.yaml">te_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 te_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2235,7 +2235,7 @@ te_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></
 <td>3.49 / 0.89</td>
 <td>8.63 / 2.77</td>
 <td>17.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ka_PP-OCRv3_mobile_rec.yaml">ka_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ka_PP-OCRv3_mobile_rec.yaml">ka_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 ka_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2245,7 +2245,7 @@ ka_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></
 <td>3.49 / 0.86</td>
 <td>8.35 / 3.41</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/ta_PP-OCRv3_mobile_rec.yaml">ta_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/ta_PP-OCRv3_mobile_rec.yaml">ta_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 ta_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2255,7 +2255,7 @@ ta_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></
 <td>3.53 / 0.78</td>
 <td>8.50 / 6.83</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/latin_PP-OCRv3_mobile_rec.yaml">latin_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/latin_PP-OCRv3_mobile_rec.yaml">latin_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 latin_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2265,7 +2265,7 @@ latin_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a
 <td>3.60 / 0.83</td>
 <td>8.44 / 4.69</td>
 <td>17.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/arabic_PP-OCRv3_mobile_rec.yaml">arabic_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/arabic_PP-OCRv3_mobile_rec.yaml">arabic_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 arabic_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2275,7 +2275,7 @@ arabic_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</
 <td>3.56 / 0.79</td>
 <td>8.22 / 2.76</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/cyrillic_PP-OCRv3_mobile_rec.yaml">cyrillic_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/cyrillic_PP-OCRv3_mobile_rec.yaml">cyrillic_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 cyrillic_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2285,7 +2285,7 @@ cyrillic_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型
 <td>3.60 / 0.78</td>
 <td>6.95 / 2.87</td>
 <td>8.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/text_recognition/devanagari_PP-OCRv3_mobile_rec.yaml">devanagari_PP-OCRv3_mobile_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/text_recognition/devanagari_PP-OCRv3_mobile_rec.yaml">devanagari_PP-OCRv3_mobile_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/\
 devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模型</a></td>
 </tr>
@@ -2311,7 +2311,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1311.84 / 1311.84</td>
 <td>- / 8288.07</td>
 <td>1530</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/UniMERNet.yaml">UniMERNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/UniMERNet.yaml">UniMERNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/UniMERNet_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/UniMERNet_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2321,7 +2321,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>182.25 / 182.25</td>
 <td>- / 254.39</td>
 <td>224</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet-S.yaml">PP-FormulaNet-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet-S.yaml">PP-FormulaNet-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet-S_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2332,7 +2332,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>- / 3131.54</td>
 <td>695</td>
 </tr>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet-L.yaml">PP-FormulaNet-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet-L.yaml">PP-FormulaNet-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet-L_pretrained.pdparams">训练模型</a></td>
 <tr>
 <td>PP-FormulaNet_plus-S</td>
@@ -2341,7 +2341,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>179.20 / 179.20</td>
 <td>- / 260.99</td>
 <td>248</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-S.yaml">PP-FormulaNet_plus-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-S.yaml">PP-FormulaNet_plus-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-S_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2351,7 +2351,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1040.27 / 1040.27</td>
 <td>- / 1615.80</td>
 <td>592</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-M.yaml">PP-FormulaNet_plus-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-M.yaml">PP-FormulaNet_plus-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-M_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2361,7 +2361,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1476.07 / 1476.07</td>
 <td>- / 3125.58</td>
 <td>698</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-L.yaml">PP-FormulaNet_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/PP-FormulaNet_plus-L.yaml">PP-FormulaNet_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-FormulaNet_plus-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-FormulaNet_plus-L_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2371,7 +2371,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1088.89 / 1088.89</td>
 <td>- / -</td>
 <td>99</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/formula_recognition/LaTeX_OCR_rec.yaml">LaTeX_OCR_rec.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/formula_recognition/LaTeX_OCR_rec.yaml">LaTeX_OCR_rec.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/LaTeX_OCR_rec_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/LaTeX_OCR_rec_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2395,7 +2395,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>23.96 / 21.75</td>
 <td>- / 43.12</td>
 <td>6.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANet.yaml">SLANet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANet.yaml">SLANet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANet_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANet_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2404,7 +2404,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>23.43 / 22.16</td>
 <td>- / 41.80</td>
 <td>6.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANet_plus.yaml">SLANet_plus.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANet_plus.yaml">SLANet_plus.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANet_plus_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANet_plus_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2413,12 +2413,12 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td rowspan="2">85.92 / 85.92</td>
 <td rowspan="2">- / 501.66</td>
 <td rowspan="2">351</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANeXt_wired.yaml">SLANeXt_wired.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANeXt_wired.yaml">SLANeXt_wired.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANeXt_wired_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANeXt_wired_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
 <td>SLANeXt_wireless</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_structure_recognition/SLANeXt_wireless.yaml">SLANeXt_wireless.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_structure_recognition/SLANeXt_wireless.yaml">SLANeXt_wireless.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/SLANeXt_wireless_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/SLANeXt_wireless_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2443,12 +2443,12 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td rowspan="2">33.47 / 27.02</td>
 <td rowspan="2">402.55 / 256.56</td>
 <td rowspan="2">124M</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wired_table_cell_det.yaml">RT-DETR-L_wired_table_cell_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wired_table_cell_det.yaml">RT-DETR-L_wired_table_cell_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_wired_table_cell_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_wired_table_cell_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
 <td>RT-DETR-L_wireless_table_cell_det</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wireless_table_cell_det.yaml">RT-DETR-L_wireless_table_cell_det.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_cells_detection/RT-DETR-L_wireless_table_cell_det.yaml">RT-DETR-L_wireless_table_cell_det.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-L_wireless_table_cell_det_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-L_wireless_table_cell_det_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2472,7 +2472,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>2.62 / 0.60</td>
 <td>3.17 / 1.14</td>
 <td>6.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/table_classification/PP-LCNet_x1_0_table_cls.yaml">PP-LCNet_x1_0_table_cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/table_classification/PP-LCNet_x1_0_table_cls.yaml">PP-LCNet_x1_0_table_cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_table_cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_table_cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -2497,7 +2497,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>19.05 / 19.05</td>
 <td>- / 869.82</td>
 <td>30.3</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/image_unwarping/UVDoc.yaml">UVDoc.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/image_unwarping/UVDoc.yaml">UVDoc.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/UVDoc_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/UVDoc_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -2525,7 +2525,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>53.03 / 17.23</td>
 <td>634.62 / 378.32</td>
 <td>126.01</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout_plus-L.yaml">PP-DocLayout_plus-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout_plus-L.yaml">PP-DocLayout_plus-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout_plus-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout_plus-L_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2553,7 +2553,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>34.60 / 28.54</td>
 <td>506.43 / 256.83</td>
 <td>123.92</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocBlockLayout.yaml">PP-DocBlockLayout.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocBlockLayout.yaml">PP-DocBlockLayout.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBlockLayout_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocBlockLayout_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2582,7 +2582,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>33.59 / 33.59</td>
 <td>503.01 / 251.08</td>
 <td>123.76</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-L.yaml">PP-DocLayout-L.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-L.yaml">PP-DocLayout-L.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-L_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-L_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2591,7 +2591,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>13.03 / 4.72</td>
 <td>43.39 / 24.44</td>
 <td>22.578</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-M.yaml">PP-DocLayout-M.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-M.yaml">PP-DocLayout-M.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-M_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-M_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2600,7 +2600,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>11.54 / 3.86</td>
 <td>18.53 / 6.29</td>
 <td>4.834</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PP-DocLayout-S.yaml">PP-DocLayout-S.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PP-DocLayout-S.yaml">PP-DocLayout-S.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocLayout-S_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-DocLayout-S_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2628,7 +2628,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>9.57 / 6.63</td>
 <td>27.66 / 16.75</td>
 <td>7.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet_layout_1x_table.yaml">PicoDet_layout_1x_table.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet_layout_1x_table.yaml">PicoDet_layout_1x_table.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_layout_1x_table_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_layout_1x_table_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody></table>
@@ -2654,7 +2654,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>8.43 / 3.44</td>
 <td>17.60 / 6.51</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-S_layout_3cls.yaml">PicoDet-S_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-S_layout_3cls.yaml">PicoDet-S_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_layout_3cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_layout_3cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2663,7 +2663,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>12.80 / 9.57</td>
 <td>45.04 / 23.86</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-L_layout_3cls.yaml">PicoDet-L_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-L_layout_3cls.yaml">PicoDet-L_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_layout_3cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_layout_3cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2672,7 +2672,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>114.80 / 25.65</td>
 <td>924.38 / 924.38</td>
 <td>470.1</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_3cls.yaml">RT-DETR-H_layout_3cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_3cls.yaml">RT-DETR-H_layout_3cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_layout_3cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_layout_3cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody></table>
@@ -2698,7 +2698,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>9.62 / 6.75</td>
 <td>26.96 / 12.77</td>
 <td>7.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet_layout_1x.yaml">PicoDet_layout_1x.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet_layout_1x.yaml">PicoDet_layout_1x.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet_layout_1x_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet_layout_1x_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody></table>
@@ -2724,7 +2724,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>8.80 / 3.62</td>
 <td>17.51 / 6.35</td>
 <td>4.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-S_layout_17cls.yaml">PicoDet-S_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-S_layout_17cls.yaml">PicoDet-S_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-S_layout_17cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-S_layout_17cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2733,7 +2733,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>12.60 / 10.27</td>
 <td>43.70 / 24.42</td>
 <td>22.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/PicoDet-L_layout_17cls.yaml">PicoDet-L_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/PicoDet-L_layout_17cls.yaml">PicoDet-L_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PicoDet-L_layout_17cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PicoDet-L_layout_17cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
@@ -2742,7 +2742,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>115.29 / 101.18</td>
 <td>964.75 / 964.75</td>
 <td>470.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_17cls.yaml">RT-DETR-H_layout_17cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/layout_detection/RT-DETR-H_layout_17cls.yaml">RT-DETR-H_layout_17cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RT-DETR-H_layout_17cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RT-DETR-H_layout_17cls_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2770,7 +2770,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>2.62 / 0.59</td>
 <td>3.24 / 1.19</td>
 <td>7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_text_orientation/PP-LCNet_x1_0_doc_ori.yaml">PP-LCNet_x1_0_doc_ori.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_text_orientation/PP-LCNet_x1_0_doc_ori.yaml">PP-LCNet_x1_0_doc_ori.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-LCNet_x1_0_doc_ori_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-LCNet_x1_0_doc_ori_pretrained.pdparams">训练模型</a></td>
 </tr>
 </tbody>
@@ -2839,7 +2839,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>0.34 / 0.12</td>
 <td>0.64 / 0.06</td>
 <td>0.072</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/DLinear.yaml">DLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/DLinear.yaml">DLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DLinear_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DLinear_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>NLinear</td>
@@ -2848,7 +2848,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>0.27 / 0.10</td>
 <td>0.49 / 0.08</td>
 <td>0.04</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/NLinear.yaml">NLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/NLinear.yaml">NLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/NLinear_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/NLinear_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Nonstationary</td>
@@ -2857,7 +2857,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>3.92 / 2.59</td>
 <td>18.09 / 13.36</td>
 <td>55.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/Nonstationary.yaml">Nonstationary.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/Nonstationary.yaml">Nonstationary.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Nonstationary_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Nonstationary_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PatchTST</td>
@@ -2866,7 +2866,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1.81 / 0.45</td>
 <td>5.79 / 0.77</td>
 <td>2.0</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/PatchTST.yaml">PatchTST.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/PatchTST.yaml">PatchTST.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PatchTST_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PatchTST_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>RLinear</td>
@@ -2875,7 +2875,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>0.39 / 0.18</td>
 <td>0.82 / 0.08</td>
 <td>0.04</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/RLinear.yaml">RLinear.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/RLinear.yaml">RLinear.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/RLinear_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/RLinear_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>TiDE</td>
@@ -2884,7 +2884,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>- / -</td>
 <td>4.54 / 1.09</td>
 <td>31.7</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/TiDE.yaml">TiDE.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/TiDE.yaml">TiDE.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TiDE_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TiDE_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>TimesNet</td>
@@ -2893,7 +2893,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>15.19 / 13.77</td>
 <td>23.14 / 12.42</td>
 <td>4.9</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_forecast/TimesNet.yaml">TimesNet.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_forecast/TimesNet.yaml">TimesNet.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TimesNet_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TimesNet_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -2918,7 +2918,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>0.24 / 0.13</td>
 <td>0.41 / 0.05</td>
 <td>0.052</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/AutoEncoder_ad.yaml">AutoEncoder_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/AutoEncoder_ad.yaml">AutoEncoder_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/AutoEncoder_ad_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/AutoEncoder_ad_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>DLinear_ad</td>
@@ -2926,7 +2926,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>0.39 / 0.16</td>
 <td>0.69 / 0.08</td>
 <td>0.112</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/DLinear_ad.yaml">DLinear_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/DLinear_ad.yaml">DLinear_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/DLinear_ad_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/DLinear_ad_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>Nonstationary_ad</td>
@@ -2934,7 +2934,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>1.94 / 1.16</td>
 <td>5.31 / 1.66</td>
 <td>1.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/Nonstationary_ad.yaml">Nonstationary_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/Nonstationary_ad.yaml">Nonstationary_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/Nonstationary_ad_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/Nonstationary_ad_pretrained.pdparams">训练模型</a></td></tr>
 <tr>
 <td>PatchTST_ad</td>
@@ -2942,7 +2942,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>2.10 / 0.55</td>
 <td>6.98 / 0.63</td>
 <td>0.32</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_anomaly_detection/PatchTST_ad.yaml">PatchTST_ad.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_anomaly_detection/PatchTST_ad.yaml">PatchTST_ad.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PatchTST_ad_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PatchTST_ad_pretrained.pdparams">训练模型</a></td></tr>
 
 
@@ -2965,7 +2965,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>TimesNet_cls</td>
 <td>87.5</td>
 <td>0.792</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/ts_classification/TimesNet_cls.yaml">TimesNet_cls.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/ts_classification/TimesNet_cls.yaml">TimesNet_cls.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/TimesNet_cls_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/TimesNet_cls_pretrained.pdparams">训练模型</a></td></tr>
 </tbody>
 </table>
@@ -2988,7 +2988,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>680kh</td>
 <td>5800</td>
 <td>2.7 (Librispeech)</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_large.yaml">whisper_large.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_large.yaml">whisper_large.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_large.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -2996,7 +2996,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>680kh</td>
 <td>2900</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_medium.yaml">whisper_medium.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_medium.yaml">whisper_medium.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_medium.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -3004,7 +3004,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>680kh</td>
 <td>923</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_small.yaml">whisper_small.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_small.yaml">whisper_small.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_small.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -3012,7 +3012,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>680kh</td>
 <td>277</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_base.yaml">whisper_base.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_base.yaml">whisper_base.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_base.tar">推理模型</a></td>
 </tr>
 <tr>
@@ -3020,7 +3020,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>680kh</td>
 <td>145</td>
 <td>-</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/multilingual_speech_recognition/whisper_tiny.yaml">whisper_tiny.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/multilingual_speech_recognition/whisper_tiny.yaml">whisper_tiny.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/whisper_tiny.tar">推理模型</a></td>
 </tr>
 </table>
@@ -3039,21 +3039,21 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>PP-TSM-R50_8frames_uniform</td>
 <td>74.36</td>
 <td>93.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSM-R50_8frames_uniform.yaml">PP-TSM-R50_8frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSM-R50_8frames_uniform.yaml">PP-TSM-R50_8frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSM-R50_8frames_uniform_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSM-R50_8frames_uniform_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
 <td>PP-TSMv2-LCNetV2_8frames_uniform</td>
 <td>71.71</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_8frames_uniform.yaml">PP-TSMv2-LCNetV2_8frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_8frames_uniform.yaml">PP-TSMv2-LCNetV2_8frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSMv2-LCNetV2_8frames_uniform_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSMv2-LCNetV2_8frames_uniform_pretrained.pdparams">训练模型</a></td>
 </tr>
 <tr>
 <td>PP-TSMv2-LCNetV2_16frames_uniform</td>
 <td>73.11</td>
 <td>22.5</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_16frames_uniform.yaml">PP-TSMv2-LCNetV2_16frames_uniform.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_classification/PP-TSMv2-LCNetV2_16frames_uniform.yaml">PP-TSMv2-LCNetV2_16frames_uniform.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-TSMv2-LCNetV2_16frames_uniform_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/PP-TSMv2-LCNetV2_16frames_uniform_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -3073,7 +3073,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>YOWO</td>
 <td>80.94</td>
 <td>462.891</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/video_detection/YOWO.yaml">YOWO.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/video_detection/YOWO.yaml">YOWO.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/YOWO_infer.tar">推理模型</a>/<a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_pretrained_model/YOWO_pretrained.pdparams">训练模型</a></td>
 </tr>
 </table>
@@ -3093,21 +3093,21 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>PP-DocBee-2B</td>
 <td>2</td>
 <td>4.2</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml">PP-DocBee-2B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee-2B.yaml">PP-DocBee-2B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee-2B_infer.tar">推理模型</a></td>
 </tr>
 <tr>
 <td>PP-DocBee-7B</td>
 <td>7</td>
 <td>15.8</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml">PP-DocBee-7B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee-7B.yaml">PP-DocBee-7B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee-7B_infer.tar">推理模型</a></td>
 </tr>
 <tr>
 <td>PP-DocBee2-3B</td>
 <td>3</td>
 <td>7.6</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/doc_vlm/PP-DocBee2-3B.yaml">PP-DocBee2-3B.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/doc_vlm/PP-DocBee2-3B.yaml">PP-DocBee2-3B.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-DocBee2-3B_infer.tar">推理模型</a></td>
 </tr>
 </table>
@@ -3126,7 +3126,7 @@ devanagari_PP-OCRv3_mobile_rec_infer.tar">推理模型</a>/<a href="">训练模�
 <td>PP-Chart2Table</td>
 <td>0.58</td>
 <td>1.4</td>
-<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/configs/modules/chart_parsing/PP-Chart2Table.yaml">PP-Chart2Table.yaml</a></td>
+<td><a href="https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/configs/modules/chart_parsing/PP-Chart2Table.yaml">PP-Chart2Table.yaml</a></td>
 <td><a href="https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-Chart2Table_infer.tar">推理模型</a></td>
 </tr>
 </table>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://paddlepaddle.github.io/PaddleX/
 docs_dir: docs # 文档路径
  
 repo_url: https://github.com/PaddlePaddle/PaddleX #仓库地址
-edit_uri: edit/develop/docs/ #修改文件的路径
+edit_uri: !ENV [DOCS_EDIT_URI, edit/develop/docs/] #修改文件的路径
 theme:
   name: material
   # logo: ./static/images/logo.jpg #设置左上角logo

--- a/tests/test_docs_github_links.py
+++ b/tests/test_docs_github_links.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_tool(name):
+    spec = importlib.util.spec_from_file_location(
+        name, REPO_ROOT / "tools" / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_docs_github_links_rejects_moving_source_refs(tmp_path):
+    checker = _load_tool("check_docs_github_links")
+    doc_path = tmp_path / "doc.md"
+    doc_path.write_text(
+        "[config](https://github.com/PaddlePaddle/PaddleX/blob/develop/paddlex/config.yaml)\n",
+        encoding="utf-8",
+    )
+
+    violations = checker.find_forbidden_links(
+        tmp_path,
+        repo_slug="PaddlePaddle/PaddleX",
+        forbidden_refs={"develop", "main", "master"},
+    )
+
+    assert len(violations) == 1
+    assert violations[0].path == doc_path
+    assert violations[0].ref == "develop"
+    assert violations[0].line_number == 1
+
+
+def test_check_docs_github_links_allows_versioned_and_placeholder_refs(tmp_path):
+    checker = _load_tool("check_docs_github_links")
+    doc_path = tmp_path / "doc.md"
+    doc_path.write_text(
+        "\n".join(
+            [
+                "[release](https://github.com/PaddlePaddle/PaddleX/blob/release/3.5/paddlex/config.yaml)",
+                "[placeholder](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/config.yaml)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = checker.find_forbidden_links(
+        tmp_path,
+        repo_slug="PaddlePaddle/PaddleX",
+        forbidden_refs={"develop", "main", "master"},
+    )
+
+    assert violations == []
+
+
+def test_resolve_doc_github_refs_replaces_placeholders(tmp_path):
+    resolver = _load_tool("resolve_doc_github_refs")
+    doc_path = tmp_path / "doc.md"
+    doc_path.write_text(
+        "[config](https://github.com/PaddlePaddle/PaddleX/blob/{{PADDLEX_GITHUB_REF}}/paddlex/config.yaml)\n",
+        encoding="utf-8",
+    )
+
+    changed = resolver.resolve_placeholders(
+        tmp_path,
+        placeholder="{{PADDLEX_GITHUB_REF}}",
+        source_ref="release/3.5",
+    )
+
+    assert changed == [doc_path]
+    assert (
+        doc_path.read_text(encoding="utf-8")
+        == "[config](https://github.com/PaddlePaddle/PaddleX/blob/release/3.5/paddlex/config.yaml)\n"
+    )

--- a/tools/check_docs_github_links.py
+++ b/tools/check_docs_github_links.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Violation(NamedTuple):
+    path: Path
+    line_number: int
+    ref: str
+    url: str
+
+
+def _compile_link_pattern(repo_slug):
+    escaped_repo = re.escape(repo_slug)
+    return re.compile(
+        rf"https://github\.com/{escaped_repo}/(?:blob|tree)/(?P<ref>[^/\s)\]\"'<>]+)"
+        rf"(?P<rest>/[^\s)\]\"'<>]*)?"
+    )
+
+
+def find_forbidden_links(root, repo_slug, forbidden_refs):
+    root = Path(root)
+    forbidden_refs = set(forbidden_refs)
+    link_pattern = _compile_link_pattern(repo_slug)
+    violations = []
+
+    for path in sorted(root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            for match in link_pattern.finditer(line):
+                ref = match.group("ref")
+                if ref in forbidden_refs:
+                    violations.append(
+                        Violation(
+                            path=path,
+                            line_number=line_number,
+                            ref=ref,
+                            url=match.group(0),
+                        )
+                    )
+    return violations
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Reject docs links that point to moving GitHub source refs."
+    )
+    parser.add_argument("--root", default="docs", help="Directory to scan.")
+    parser.add_argument(
+        "--repo-slug", required=True, help="Example: PaddlePaddle/PaddleX"
+    )
+    parser.add_argument(
+        "--forbidden-ref",
+        action="append",
+        required=True,
+        help="Moving source ref to reject. Can be passed multiple times.",
+    )
+    args = parser.parse_args(argv)
+
+    violations = find_forbidden_links(
+        args.root,
+        repo_slug=args.repo_slug,
+        forbidden_refs=set(args.forbidden_ref),
+    )
+    if violations:
+        for violation in violations:
+            print(
+                f"{violation.path}:{violation.line_number}: "
+                f"forbidden GitHub ref '{violation.ref}' in {violation.url}"
+            )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/resolve_doc_github_refs.py
+++ b/tools/resolve_doc_github_refs.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+
+
+TEXT_SUFFIXES = {".md", ".yml", ".yaml"}
+
+
+def resolve_placeholders(root, placeholder, source_ref):
+    if (
+        not source_ref
+        or source_ref.strip() != source_ref
+        or any(c.isspace() for c in source_ref)
+    ):
+        raise ValueError("source_ref must be a non-empty ref without whitespace")
+
+    root = Path(root)
+    changed = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in TEXT_SUFFIXES:
+            continue
+        content = path.read_text(encoding="utf-8")
+        if placeholder not in content:
+            continue
+        path.write_text(content.replace(placeholder, source_ref), encoding="utf-8")
+        changed.append(path)
+    return changed
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Resolve docs GitHub source-ref placeholders before building docs."
+    )
+    parser.add_argument("--root", default="docs", help="Directory to rewrite.")
+    parser.add_argument("--placeholder", required=True)
+    parser.add_argument("--source-ref", required=True)
+    args = parser.parse_args(argv)
+
+    changed = resolve_placeholders(
+        args.root,
+        placeholder=args.placeholder,
+        source_ref=args.source_ref,
+    )
+    print(f"Resolved {len(changed)} file(s) under {args.root}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Replace hard-coded PaddleX GitHub source links in active docs with a build-time source ref placeholder.
- Resolve the placeholder during release docs deployment and make `edit_uri` configurable per build.
- Add a docs link checker and focused tests to prevent reintroducing `develop`/`main`/`master` source links.

## Test plan
- `python -m pytest tests/test_docs_github_links.py -q`
- `python tools/check_docs_github_links.py --repo-slug PaddlePaddle/PaddleX --forbidden-ref develop --forbidden-ref main --forbidden-ref master`


Made with [Cursor](https://cursor.com)