### PR TITLE
docs: fix invalid OCR arguments and PP-ChatOCR config paths

### DIFF
--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.en.md
@@ -449,7 +449,6 @@ visual_predict_res = pipeline.visual_predict(
     input="vehicle_certificate-1.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v3.md
@@ -447,7 +447,6 @@ visual_predict_res = pipeline.visual_predict(
     input="vehicle_certificate-1.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.en.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.en.md
@@ -774,7 +774,6 @@ visual_predict_res = pipeline.visual_predict(
     input="vehicle_certificate-1.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.md
+++ b/docs/pipeline_usage/tutorials/information_extraction_pipelines/document_scene_information_extraction_v4.md
@@ -727,7 +727,6 @@ visual_predict_res = pipeline.visual_predict(
     input="vehicle_certificate-1.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-DocTranslation.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-DocTranslation.en.md
@@ -679,7 +679,6 @@ else:
         input_path,
         use_doc_orientation_classify=False,
         use_doc_unwarping=False,
-        use_common_ocr=True,
         use_seal_recognition=True,
         use_table_recognition=True,
 )
@@ -1480,7 +1479,6 @@ visual_predict_res = pipeline.visual_predict(
     img_path,
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-DocTranslation.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-DocTranslation.md
@@ -714,7 +714,6 @@ else:
         input_path,
         use_doc_orientation_classify=False,
         use_doc_unwarping=False,
-        use_common_ocr=True,
         use_seal_recognition=True,
         use_table_recognition=True,
     )
@@ -1534,7 +1533,6 @@ visual_predict_res = pipeline.visual_predict(
     img_path,
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True,
 )

--- a/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
+++ b/docs/pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md
@@ -2168,7 +2168,7 @@ If you have obtained the configuration file, you can customize the PP-StructureV
 from paddlex import create_pipeline
 pipeline = create_pipeline(pipeline="./my_path/PP-StructureV3.yaml")
 output = pipeline.predict(
-    input="./pp_structure_v3_demo.png",,
+    input="./pp_structure_v3_demo.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
     use_textline_orientation=False,

--- a/docs/practical_tutorials/document_scene_information_extraction(layout_detection)_tutorial.en.md
+++ b/docs/practical_tutorials/document_scene_information_extraction(layout_detection)_tutorial.en.md
@@ -550,22 +550,17 @@ First, obtain and update the configuration file for the Document Information Ext
 paddlex --get_pipeline_config PP-ChatOCRv3-doc --save_path ./my_path
 ```
 
-Modify the `Pipeline.layout_model` field in `PP-ChatOCRv3-doc.yaml` to the path of the fine-tuned model mentioned above. The modified configuration is as follows:
+Modify the `SubPipelines.LayoutParser.SubModules.LayoutDetection.model_dir` field in `PP-ChatOCRv3-doc.yaml` to the path of the fine-tuned model mentioned above. The relevant configuration is as follows:
 
 ```yaml
-Pipeline:
-  layout_model: ./output/best_model/inference
-  table_model: SLANet_plus
-  text_det_model: PP-OCRv4_server_det
-  text_rec_model: PP-OCRv4_server_rec
-  seal_text_det_model: PP-OCRv4_server_seal_det
-  doc_image_ori_cls_model: null
-  doc_image_unwarp_model: null
-  llm_name: "ernie-3.5"
-  llm_params:
-    api_type: qianfan
-    ak:
-    sk:
+SubPipelines:
+  LayoutParser:
+    # ...
+    SubModules:
+      LayoutDetection:
+        module_name: layout_detection
+        model_name: RT-DETR-H_layout_3cls
+        model_dir: ./output/best_model/inference
 ```
 
 After making the modifications, you only need to change the value of the `pipeline` parameter in the `create_pipeline` method to the path of the pipeline configuration file to apply the configuration.

--- a/docs/practical_tutorials/document_scene_information_extraction(layout_detection)_tutorial.md
+++ b/docs/practical_tutorials/document_scene_information_extraction(layout_detection)_tutorial.md
@@ -64,7 +64,6 @@ pipeline = create_pipeline(pipeline="./PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_layout/test.jpg",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 
@@ -581,16 +580,19 @@ python main.py -c paddlex/configs/modules/layout_detection/RT-DETR-H_layout_3cls
 paddlex --get_pipeline_config PP-ChatOCRv3-doc --save_path ./my_path
 ```
 
-参考2.1 填写大语言模型的 ak/sk(access_token)， 同时将`PP-ChatOCRv3-doc.yaml`中的`LayoutDetection.model_dir`字段修改为上面微调后的模型路径，修改后版面模型部分的配置如下：
+参考2.1 填写大语言模型的 ak/sk(access_token)， 同时将`PP-ChatOCRv3-doc.yaml`中的`SubPipelines.LayoutParser.SubModules.LayoutDetection.model_dir`字段修改为上面微调后的模型路径，修改后版面模型部分的配置如下：
 
 ```yaml
-......
+# ...
+SubPipelines:
+  LayoutParser:
+    # ...
     SubModules:
       LayoutDetection:
         module_name: layout_detection
         model_name: RT-DETR-H_layout_3cls
         model_dir: output/best_model/inference
-......
+# ...
 ```
 
 修改后，只需要修改 `create_pipeline` 方法中的 `pipeline` 参数值为产线配置文件路径即可应用配置。
@@ -603,7 +605,6 @@ pipeline = create_pipeline(pipeline="./my_path/PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_layout/test.jpg",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 
@@ -646,7 +647,6 @@ pipeline = create_pipeline(pipeline="./my_path/PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_layout/test.jpg",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 

--- a/docs/practical_tutorials/document_scene_information_extraction(seal_recognition)_tutorial.en.md
+++ b/docs/practical_tutorials/document_scene_information_extraction(seal_recognition)_tutorial.en.md
@@ -368,22 +368,23 @@ First, obtain and update the configuration file for the Document Information Ext
 paddlex --get_pipeline_config PP-ChatOCRv3-doc --save_path ./my_path
 ```
 
-Modify the `Pipeline.seal_text_det_model` field in `PP-ChatOCRv3-doc.yaml` to the path of the fine-tuned model mentioned above. The modified configuration is as follows:
+Modify the `SubPipelines.LayoutParser.SubPipelines.SealRecognition.SubPipelines.SealOCR.SubModules.TextDetection.model_dir` field in `PP-ChatOCRv3-doc.yaml` to the path of the fine-tuned model mentioned above. The relevant configuration is as follows:
 
 ```yaml
-Pipeline:
-  layout_model: RT-DETR-H_layout_3cls
-  table_model: SLANet_plus
-  text_det_model: PP-OCRv4_server_det
-  text_rec_model: PP-OCRv4_server_rec
-  seal_text_det_model: ./output/best_accuracy/inference
-  doc_image_ori_cls_model: null
-  doc_image_unwarp_model: null
-  llm_name: "ernie-3.5"
-  llm_params:
-    api_type: qianfan
-    ak:
-    sk:
+SubPipelines:
+  LayoutParser:
+    # ...
+    SubPipelines:
+      SealRecognition:
+        # ...
+        SubPipelines:
+          SealOCR:
+            # ...
+            SubModules:
+              TextDetection:
+                module_name: seal_text_detection
+                model_name: PP-OCRv4_server_seal_det
+                model_dir: ./output/best_accuracy/inference
 ```
 
 After making the modifications, you only need to change the value of the `pipeline` parameter in the `create_pipeline` method to the path of the pipeline configuration file to apply the configuration.

--- a/docs/practical_tutorials/document_scene_information_extraction(seal_recognition)_tutorial.md
+++ b/docs/practical_tutorials/document_scene_information_extraction(seal_recognition)_tutorial.md
@@ -66,7 +66,6 @@ pipeline = create_pipeline(pipeline="./PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_seal/test.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 
@@ -392,16 +391,19 @@ python main.py -c paddlex/configs/modules/seal_text_detection/PP-OCRv4_server_se
 paddlex --get_pipeline_config PP-ChatOCRv3-doc --save_path ./my_path
 ```
 
-参考2.1 填写大语言模型的 ak/sk(access_token)， 并将`PP-ChatOCRv3-doc.yaml`中的`SubPipelines.SealRecognition.SealOCR.SubModules.TextDetection.model_dir`字段修改为上面微调后的模型路径，修改后配置如下：
+参考2.1 填写大语言模型的 ak/sk(access_token)， 并将`PP-ChatOCRv3-doc.yaml`中的`SubPipelines.LayoutParser.SubPipelines.SealRecognition.SubPipelines.SealOCR.SubModules.TextDetection.model_dir`字段修改为上面微调后的模型路径，修改后配置如下：
 
 ```yaml
-......
+# ...
 SubPipelines:
-    ...
-    SealRecognition:
-        ...
+  LayoutParser:
+    # ...
+    SubPipelines:
+      SealRecognition:
+        # ...
+        SubPipelines:
           SealOCR:
-            ...
+            # ...
             SubModules:
               TextDetection:
                 module_name: seal_text_detection
@@ -413,7 +415,7 @@ SubPipelines:
                 thresh: 0.2
                 box_thresh: 0.6
                 unclip_ratio: 0.5
-......
+# ...
 ```
 
 修改后，只需要修改 `create_pipeline` 方法中的 `pipeline` 参数值为产线配置文件路径即可应用配置。
@@ -426,7 +428,6 @@ pipeline = create_pipeline(pipeline="./my_path/PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_seal/test.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 
@@ -470,7 +471,6 @@ pipeline = create_pipeline(pipeline="./my_path/PP-ChatOCRv3-doc.yaml")
 visual_predict_res = pipeline.visual_predict(input="https://paddle-model-ecology.bj.bcebos.com/paddlex/PaddleX3.0/doc_images/practical_tutorial/PP-ChatOCRv3_doc_seal/test.png",
     use_doc_orientation_classify=False,
     use_doc_unwarping=False,
-    use_common_ocr=True,
     use_seal_recognition=True,
     use_table_recognition=True)
 

--- a/tests/test_docs_pr5145_regressions.py
+++ b/tests/test_docs_pr5145_regressions.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
+
+
+def _read(relative_path):
+    return (DOCS_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_docs_do_not_pass_removed_use_common_ocr_argument():
+    offenders = []
+    for path in DOCS_ROOT.rglob("*.md"):
+        if "use_common_ocr=" in path.read_text(encoding="utf-8"):
+            offenders.append(path.relative_to(REPO_ROOT))
+
+    assert offenders == []
+
+
+def test_pp_structure_v3_example_has_valid_keyword_separator():
+    text = _read("pipeline_usage/tutorials/ocr_pipelines/PP-StructureV3.en.md")
+
+    assert 'input="./pp_structure_v3_demo.png",,' not in text
+
+
+def test_pp_chatocr_model_paths_include_the_full_config_hierarchy():
+    layout_path = "SubPipelines.LayoutParser.SubModules.LayoutDetection.model_dir"
+    seal_path = (
+        "SubPipelines.LayoutParser.SubPipelines.SealRecognition."
+        "SubPipelines.SealOCR.SubModules.TextDetection.model_dir"
+    )
+    layout_docs = (
+        "practical_tutorials/"
+        "document_scene_information_extraction(layout_detection)_tutorial"
+    )
+    seal_docs = (
+        "practical_tutorials/"
+        "document_scene_information_extraction(seal_recognition)_tutorial"
+    )
+
+    layout_snippet = (
+        "SubPipelines:\n"
+        "  LayoutParser:\n"
+        "    # ...\n"
+        "    SubModules:\n"
+        "      LayoutDetection:"
+    )
+    seal_snippet = (
+        "SubPipelines:\n"
+        "  LayoutParser:\n"
+        "    # ...\n"
+        "    SubPipelines:\n"
+        "      SealRecognition:\n"
+        "        # ...\n"
+        "        SubPipelines:\n"
+        "          SealOCR:\n"
+        "            # ...\n"
+        "            SubModules:\n"
+        "              TextDetection:"
+    )
+
+    for suffix in (".md", ".en.md"):
+        layout_text = _read(f"{layout_docs}{suffix}")
+        seal_text = _read(f"{seal_docs}{suffix}")
+        assert layout_path in layout_text
+        assert layout_snippet in layout_text
+        assert seal_path in seal_text
+        assert seal_snippet in seal_text


### PR DESCRIPTION
## Scope

This PR originally contained a broad 179-item documentation sweep. It has been narrowed to a small set of mechanically verified fixes against the current `develop` branch so each behavior can be reviewed directly.

- Remove 14 unsupported `use_common_ocr` arguments from current examples.
- Fix the full PP-ChatOCRv3 layout and seal model configuration hierarchy in Chinese and English tutorials.
- Fix the duplicate comma in the PP-StructureV3 Python example.
- Add focused regression coverage for the invalid argument, syntax, and configuration paths.

The remaining items from the original broad sweep are intentionally excluded and should be reconsidered separately.

## Verification

- `python3 -m pytest -q -p no:cacheprovider tests/test_docs_pr5145_regressions.py tests/test_docs_github_links.py`
- Result: `6 passed`
- `git diff --check`