### PR TITLE
fix(layout_parsing): validate chart and formula model settings

### DIFF
--- a/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/pipeline_v2.py
@@ -295,6 +295,18 @@ class _LayoutParsingPipelineV2(BasePipeline):
             )
             return False
 
+        if input_params["use_formula_recognition"] and not self.use_formula_recognition:
+            logging.error(
+                "Set use_formula_recognition, but the models for formula recognition are not initialized.",
+            )
+            return False
+
+        if input_params["use_chart_recognition"] and not self.use_chart_recognition:
+            logging.error(
+                "Set use_chart_recognition, but the models for chart recognition are not initialized.",
+            )
+            return False
+
         return True
 
     def standardized_data(


### PR DESCRIPTION
Return a clear error when predict requests chart or formula recognition but the corresponding models were not initialized at pipeline startup.

问题：启动 use_chart_recognition=False，API 传 True 时 upstream 会 AttributeError
修复：在 check_model_settings_valid 补 chart / formula 校验
影响：HTTP 返回明确 500，而非 Internal server error