### PR TITLE
Register missing korean/el/th PP-OCRv5_mobile_rec for HPI (gpu_cuda12/paddle311)

### DIFF
--- a/paddlex/inference/models/runners/hpi/hpi_model_info_collection.json
+++ b/paddlex/inference/models/runners/hpi/hpi_model_info_collection.json
@@ -11924,6 +11924,10 @@
         "onnxruntime",
         "paddle"
       ],
+      "korean_PP-OCRv5_mobile_rec": [
+        "onnxruntime",
+        "paddle"
+      ],
       "latin_PP-OCRv5_mobile_rec": [
         "onnxruntime",
         "paddle"
@@ -11933,6 +11937,14 @@
         "paddle"
       ],
       "eslav_PP-OCRv5_mobile_rec": [
+        "onnxruntime",
+        "paddle"
+      ],
+      "th_PP-OCRv5_mobile_rec": [
+        "onnxruntime",
+        "paddle"
+      ],
+      "el_PP-OCRv5_mobile_rec": [
         "onnxruntime",
         "paddle"
       ],


### PR DESCRIPTION
## Summary

`gpu_cuda12/paddle311` in `paddlex/inference/models/runners/hpi/hpi_model_info_collection.json` is missing three PP-OCRv5 multilingual recognition models — `korean_PP-OCRv5_mobile_rec`, `el_PP-OCRv5_mobile_rec`, `th_PP-OCRv5_mobile_rec` — that are present in every other environment/version bucket. As a result, HPI backend selection fails for these models on CUDA 12 with PaddlePaddle ≥ 3.1.0.

## Symptom

Building an HPI predictor for `korean_PP-OCRv5_mobile_rec` on a GPU + CUDA 12 environment with PaddlePaddle ≥ 3.1.0 raises:

```
RuntimeError: No inference backend and configuration could be suggested.
Reason: 'korean_PP-OCRv5_mobile_rec' is not a known model.
```

Disabling HPI works, so the model itself is fine — it is simply not registered in the HPI prior-knowledge collection for this bucket.

## Root cause

`suggest_inference_backend_and_config()` in `paddlex/inference/models/runners/hpi/backend.py` normalizes any Paddle ≥ 3.1.0 to the `paddle311` knowledge bucket:

```python
if paddle_version[:3] >= (3, 1, 0):
    # "...The prior knowledge of Paddle 3.1.1 will be used."
    paddle_version = (3, 1, 1, None)   # -> key "paddle311"
```

It then looks up `collection[env]["paddle311"][model_name]`. For `env = gpu_cuda12`, the `paddle311` bucket is missing the three models above — they exist in `gpu_cuda12/paddle30` and `gpu_cuda12/paddle31`, and in every `cpu_x64` / `gpu_cuda11` bucket — so the lookup hits the "is not a known model" branch.

Per-bucket model count (and presence of the `korean/el/th` PP-OCRv5 mobile rec models):

| env | paddle30 | paddle31 | paddle311 |
|-----|:--------:|:--------:|:---------:|
| cpu_x64 | 281 ✓ | 281 ✓ | 281 ✓ |
| gpu_cuda11 | 281 ✓ | 281 ✓ | 281 ✓ |
| gpu_cuda12 | 281 ✓ | 281 ✓ | **278 ✗ (korean / el / th missing)** |

## Fix

Add the three missing entries to `gpu_cuda12/paddle311`, mirroring `gpu_cuda12/paddle31` (backends `["onnxruntime", "paddle"]`). This restores exact key parity between `gpu_cuda12/paddle311` and `gpu_cuda12/paddle31`.

## Verification

- `json.load()` succeeds on the edited file.
- `set(gpu_cuda12/paddle311) == set(gpu_cuda12/paddle31)` after the change (278 → 281 models).
- No other env/version bucket is modified — the diff is `+12` lines (three entries).

## Related

- #5162 — `'PP-OCRv6_small_det' is not a known model for hpi` (same registration-gap class).
- PaddlePaddle/PaddleOCR#16450 — `'latin_PP-OCRv5_mobile_rec' is not a known model when enable_hpi=True` (same class).
