### PR TITLE
fix(ocr): support Japanese kana word boxes

### DIFF
--- a/paddlex/inference/models/text_recognition/processors.py
+++ b/paddlex/inference/models/text_recognition/processors.py
@@ -42,6 +42,16 @@ def validate_text_rec_image_array(img: np.ndarray, index: Optional[int] = None) 
         )
 
 
+def is_japanese_kana_char(char: str) -> bool:
+    """Return True for Japanese kana characters that should receive char boxes."""
+    code = ord(char)
+    return (
+        0x3040 <= code <= 0x309F  # Hiragana
+        or 0x30A0 <= code <= 0x30FF  # Katakana, including prolonged sound mark
+        or 0xFF65 <= code <= 0xFF9F  # Halfwidth Katakana
+    )
+
+
 @benchmark.timeit
 @class_requires_deps("opencv-contrib-python")
 class OCRReisizeNormImg:
@@ -171,7 +181,7 @@ class BaseRecLabelDecode:
         valid_col = np.where(selection == True)[0]
 
         for c_i, char in enumerate(text):
-            if "\u4e00" <= char <= "\u9fff":
+            if "\u4e00" <= char <= "\u9fff" or is_japanese_kana_char(char):
                 c_state = "cn"
             elif bool(re.search("[a-zA-Z0-9]", char)):
                 c_state = "en&num"

--- a/tests/test_text_recognition_word_info.py
+++ b/tests/test_text_recognition_word_info.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from paddlex.inference.models.text_recognition.processors import (
+    BaseRecLabelDecode,
+    is_japanese_kana_char,
+)
+from paddlex.inference.pipelines.components.common.cal_ocr_word_box import (
+    cal_ocr_word_box,
+)
+
+
+def test_japanese_kana_chars_are_classified_for_char_level_boxes():
+    assert is_japanese_kana_char("あ")
+    assert is_japanese_kana_char("ア")
+    assert is_japanese_kana_char("ｰ")
+    assert not is_japanese_kana_char("亜")
+    assert not is_japanese_kana_char("A")
+
+
+def test_get_word_info_treats_japanese_kana_as_cn_state():
+    decoder = BaseRecLabelDecode()
+    text = "りんごジュースストレート"
+    selection = np.ones(len(text), dtype=bool)
+
+    word_list, word_col_list, state_list = decoder.get_word_info(text, selection)
+
+    assert ["".join(word) for word in word_list] == [text]
+    assert word_col_list == [list(range(len(text)))]
+    assert state_list == ["cn"]
+
+
+def test_japanese_kana_state_produces_character_level_word_boxes():
+    text = "りんご"
+    word_info = [
+        len(text),
+        [list(text)],
+        [list(range(len(text)))],
+        ["cn"],
+    ]
+    line_box = np.array([[0, 0], [60, 0], [60, 20], [0, 20]], dtype=np.float32)
+
+    words, boxes = cal_ocr_word_box(text, line_box, word_info)
+
+    assert words == list(text)
+    assert len(boxes) == len(text)


### PR DESCRIPTION
## Summary

Fix Japanese kana word-box grouping when OCR is run with `return_word_box=True`.

Japanese Hiragana, Katakana, the prolonged sound mark, and halfwidth Katakana are now treated as character-level word-box characters while keeping the existing `cn` state name for backward compatibility.

Fixes PaddlePaddle/PaddleOCR#18222

## Prior Art / Search

I searched the PaddleOCR docs, issues, and discussions. I found related `return_word_box` reports and fixes for accented Latin text and Arabic text, but I did not find a Japanese kana-specific report.

This PR is still worth tracking separately because Japanese kana currently gets phrase-level boxes while Japanese/Chinese Han characters already get character-level boxes. That makes Japanese mixed-script output inconsistent for downstream consumers of `text_word` and `text_word_boxes`.

Related context:

- PaddlePaddle/PaddleOCR#16520
- PaddlePaddle/PaddleOCR#17156
- PaddlePaddle/PaddleOCR#17201
- PaddlePaddle/PaddleX#5030

## Root Cause

`BaseRecLabelDecode.get_word_info()` only classified CJK Unified Ideographs (`\u4e00`-`\u9fff`) as `cn`. Japanese kana fell into `symbol`.

`cal_ocr_word_box()` expands `state == "cn"` groups to character-level boxes, but non-`cn` groups are returned as one grouped box. Therefore kana-only Japanese text could be returned as a single phrase-level word box, while Han characters already returned character-level boxes.

## Fix

Add a small kana classifier for:

- Hiragana
- Katakana, including the prolonged sound mark
- Halfwidth Katakana

Then route those characters to the existing `cn` state so the downstream word-box logic keeps returning character-level boxes without renaming or changing the public state value.

## Reproduction

A synthetic image is enough; no real document image is required.

```python
from PIL import Image, ImageDraw, ImageFont

font = ImageFont.truetype("/usr/share/fonts/opentype/noto/NotoSansCJK-Medium.ttc", 48)
text = "りんごジュースストレート"
img = Image.new("RGB", (760, 160), "white")
draw = ImageDraw.Draw(img)
draw.rectangle((16, 16, 744, 144), outline=(180, 180, 180), width=2)
draw.text((48, 50), text, fill="black", font=font)
img.save("paddlex_kana_word_box_repro.png")
```

Observed grouping with PP-OCRv6 medium OCR and `return_word_box=True`:

| Pattern | Before | After |
| --- | --- | --- |
| `りんごジュースストレート` | 1 grouped box | 12 character boxes |
| `東京都中央区請求書` | 9 character boxes | 9 character boxes |
| `東京りんごジュース` | 3 boxes: `東`, `京`, `りんごジュース` | 9 character boxes |

I checked the same synthetic patterns with Noto Sans CJK JP Medium, Noto Sans CJK JP Bold, and Noto Serif CJK JP SemiBold.

## Tests

There was no existing unit test file for `BaseRecLabelDecode.get_word_info()` or `return_word_box` word grouping in PaddleX, so this PR adds focused unit coverage under `tests/`.

- `python -m py_compile paddlex/inference/models/text_recognition/processors.py tests/test_text_recognition_word_info.py`
- `python -m pytest tests/test_text_recognition_word_info.py`
- Manual PP-OCRv6 medium OCR check on synthetic rendered Japanese test patterns.

