### PR TITLE
fix(paddleocr_vl): make repetition truncation catch multi-line and cap-truncated output

### DIFF
--- a/paddlex/inference/pipelines/paddleocr_vl/uilts.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/uilts.py
@@ -1042,13 +1042,31 @@ def truncate_repetitive_content(
     if not stripped_content:
         return content
 
-    # Priority 1: Phrase-level suffix repetition in long single lines.
-    if "\n" not in stripped_content and len(stripped_content) > 100:
-        suffix_match = find_repeating_suffix(stripped_content, min_len=8, min_repeats=5)
-        if suffix_match:
-            prefix, repeating_unit, count = suffix_match
-            if len(repeating_unit) * count > len(stripped_content) * 0.5:
-                return prefix
+    # Priority 1: Phrase-level suffix repetition, checked line by line.
+    #
+    # Per line rather than only for single-line content: a block that decodes a few valid lines and
+    # then loops on the last one passes every check below, because Priority 2 is skipped once a
+    # newline is present and Priority 3 needs `line_threshold` near-identical lines.
+    #
+    # The trailing U+FFFD is dropped first: a generation stopped at max_new_tokens can be cut in the
+    # middle of a character, and decoding leaves a replacement character at the end.
+    # find_repeating_suffix() anchors on the exact suffix, so that one character stops every
+    # candidate unit from matching and the check silently returns the degenerate text unchanged.
+    truncated_lines = []
+    suffix_repetition_found = False
+    for line in content.split("\n"):
+        candidate = line.strip().rstrip("\ufffd").rstrip()
+        if len(candidate) > 100:
+            suffix_match = find_repeating_suffix(candidate, min_len=8, min_repeats=5)
+            if suffix_match:
+                prefix, repeating_unit, count = suffix_match
+                if len(repeating_unit) * count > len(candidate) * 0.5:
+                    truncated_lines.append(prefix)
+                    suffix_repetition_found = True
+                    continue
+        truncated_lines.append(line)
+    if suffix_repetition_found:
+        return "\n".join(truncated_lines)
 
     # Priority 2: Full-string character-level repetition (e.g., 'ababab')
     if "\n" not in stripped_content and len(stripped_content) > min_len:


### PR DESCRIPTION
PaddleOCR-VL decodes greedily with no repetition penalty (the local predictor ignores `repetition_penalty`/`temperature`/`top_p`, and `generation_config.json` sets none), so `truncate_repetitive_content()` is the only thing that stops a degenerate block from reaching the document. It misses two common shapes.

### 1. Repetition inside a multi-line block

The phrase-level check runs only when the content has no newline, and the line-level check needs `line_threshold` (10) near-identical lines. A block that decodes a few valid lines and then loops on the last one passes every check.

### 2. Output cut in the middle of a character

A generation stopped at `max_new_tokens` can be cut mid-character; decoding leaves U+FFFD at the end. `find_repeating_suffix()` anchors on the exact suffix (`s.endswith(unit * min_repeats)`), so that single character stops every candidate unit from matching. The check silently returns the degenerate text unchanged — on exactly the output it exists for.

### Reproduction

No model needed:

```python
from paddlex.inference.pipelines.paddleocr_vl.uilts import truncate_repetitive_content

loop = "abcdefgh " * 200

# works today
truncate_repetitive_content(loop, min_count=50)                      # -> truncated

# 1. multi-line: not truncated
truncate_repetitive_content("line one\nline two\n" + loop, min_count=50)

# 2. trailing U+FFFD: not truncated
truncate_repetitive_content(loop + "�", min_count=50)
```

`min_count=50` is what `pipeline.py` passes for non-table blocks.

### Fix

Run the phrase-level check per line instead of only for single-line content, and drop a trailing replacement character before anchoring. Priority 2 and 3 are unchanged.

### Impact

Checked against the recognition output of a full 1649-page OmniDocBench run (78,710 blocks, `min_count=50`, `5000` for tables):

- 78,681 blocks byte-identical before/after — no behaviour change on normal output.
- 29 blocks newly truncated (17 unique), all degenerate: repeated `-10 -10 -10 …`, `CH2-CH2-CH2 …`, a text block looping on the same formula for 5,134 characters. Every one has a newline, so the current code leaves all of them intact.

Related user reports of the symptom: #17288, #17828, #17903 (PaddleOCR).