### PR TITLE
fix(ocr): make UVDoc output C-contiguous

### DIFF
--- a/paddlex/inference/pipelines/doc_preprocessor/pipeline.py
+++ b/paddlex/inference/pipelines/doc_preprocessor/pipeline.py
@@ -28,6 +28,10 @@ from ..components import rotate_image
 from .result import DocPreprocessorResult
 
 
+def _to_bgr_contiguous(image: np.ndarray) -> np.ndarray:
+    return np.ascontiguousarray(image[:, :, ::-1])
+
+
 @benchmark.time_methods
 class _DocPreprocessorPipeline(BasePipeline):
     """Doc Preprocessor Pipeline"""
@@ -182,7 +186,7 @@ class _DocPreprocessorPipeline(BasePipeline):
 
             if model_settings["use_doc_unwarping"]:
                 output_imgs = [
-                    item["doctr_img"][:, :, ::-1]
+                    _to_bgr_contiguous(item["doctr_img"])
                     for item in self.doc_unwarping_model(rot_imgs)
                 ]
             else:

--- a/tests/test_doc_preprocessor_pipeline.py
+++ b/tests/test_doc_preprocessor_pipeline.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from paddlex.inference.pipelines.doc_preprocessor.pipeline import (
+    _to_bgr_contiguous,
+)
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 3), (7, 5, 3)])
+def test_to_bgr_contiguous_preserves_pixels(shape):
+    image = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+
+    output = _to_bgr_contiguous(image)
+
+    np.testing.assert_array_equal(output, image[:, :, ::-1])
+    assert output.flags.c_contiguous
+    assert all(stride >= 0 for stride in output.strides)
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        np.arange(6 * 8 * 3, dtype=np.uint8).reshape(6, 8, 3)[::2, ::2],
+        np.arange(4 * 5 * 3, dtype=np.uint8).reshape(4, 5, 3).transpose(1, 0, 2),
+    ],
+)
+def test_to_bgr_contiguous_handles_noncontiguous_input(image):
+    expected = image[:, :, ::-1].copy()
+    image.setflags(write=False)
+
+    output = _to_bgr_contiguous(image)
+
+    np.testing.assert_array_equal(output, expected)
+    assert output.flags.c_contiguous
+    assert output.flags.writeable
+    assert all(stride >= 0 for stride in output.strides)


### PR DESCRIPTION
## What

- make the UVDoc RGB-to-BGR output C-contiguous at the document-preprocessor boundary
- add CPU-only regression tests for pixel equivalence and memory layout

## Why

The current channel reversal returns a NumPy view with a negative channel
stride. The OCR pipeline then passes the full page to `cv2.warpPerspective`
once per detected text region. OpenCV has to handle the incompatible layout
for every crop, which makes region cropping dominate OCR latency on
text-dense pages.

Converting the page once with `np.ascontiguousarray` preserves the current
BGR pixels while avoiding repeated downstream layout conversion.

Fixes #5178.

## Validation

- `pytest -q tests/test_doc_preprocessor_pipeline.py`: 4 passed
- repository pre-commit hooks on both changed files: passed
- tests cover contiguous, sliced, transposed, and read-only inputs
- output pixels equal the previous expression
- output is writable, `C_CONTIGUOUS=True`, and has no negative strides

A deterministic synthetic `1600x1132` image with 200 perspective crops
measured:

| Input layout | Crop p50 |
|---|---:|
| negative channel stride | 1.664214s |
| C-contiguous | 0.021812s |

In a separate 20-run warm OCR check on two text-dense pages, normalized OCR
output remained identical and end-to-end p50 changed from `1.330s` to
`0.537s` and from `3.209s` to `1.172s`.

No private images or OCR text are included in this pull request.

## Compatibility

There is no public API or model-behavior change. The no-unwarping path is
unchanged. If appropriate, this fix can also be backported to `release/3.7`.
