### PR TITLE
[Performance] Avoid redundant CTC logits copy during text recognition

### DIFF
--- a/paddlex/inference/models/text_recognition/processors.py
+++ b/paddlex/inference/models/text_recognition/processors.py
@@ -292,7 +292,7 @@ class CTCLabelDecode(BaseRecLabelDecode):
 
     def __call__(self, pred, return_word_box=False, **kwargs):
         """apply"""
-        preds = np.array(pred[0])
+        preds = np.asarray(pred[0])
         preds_idx = preds.argmax(axis=-1)
         preds_prob = preds.max(axis=-1)
         text = self.decode(

--- a/tests/test_text_recognition_processors.py
+++ b/tests/test_text_recognition_processors.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from paddlex.inference.models.text_recognition.processors import CTCLabelDecode
+
+
+def _make_logits():
+    token_ids = np.array([[1, 1, 0, 2]], dtype=np.int64)
+    logits = np.full((1, token_ids.shape[1], 3), -1.0, dtype=np.float32)
+    np.put_along_axis(logits, token_ids[..., None], 1.0, axis=-1)
+    return logits
+
+
+def test_ctc_label_decode_does_not_copy_numpy_predictions(monkeypatch):
+    logits = _make_logits()
+    original_asarray = np.asarray
+    conversion = {}
+
+    def record_asarray(value):
+        result = original_asarray(value)
+        conversion["shares_memory"] = np.shares_memory(result, value)
+        return result
+
+    monkeypatch.setattr(np, "asarray", record_asarray)
+
+    decoder = CTCLabelDecode(character_list=["a", "b"])
+    texts, scores = decoder([logits])
+
+    assert conversion["shares_memory"]
+    assert texts == ["ab"]
+    assert len(scores) == 1
+
+
+def test_ctc_label_decode_keeps_array_like_compatibility():
+    logits = _make_logits()
+    decoder = CTCLabelDecode(character_list=["a", "b"])
+
+    ndarray_result = decoder([logits])
+    list_result = decoder([logits.tolist()])
+
+    assert list_result == ndarray_result


### PR DESCRIPTION
## Summary

- replace the unconditional `np.array` conversion in `CTCLabelDecode` with
  `np.asarray`
- avoid copying NumPy logits already returned by the inference runners
- preserve conversion support for list and other array-like inputs
- add focused tests for zero-copy NumPy handling and array-like compatibility

Closes #5181.

## Why

The Paddle static and HPI runner contracts return `List[np.ndarray]`. Calling
`np.array(pred[0])` therefore allocates and copies the complete recognition
logits before CTC decoding. On a complex real-world page in our profiling,
19 recognition batches produced 794.45 MiB of cumulative logits.

Across 75 paired observations from 75 real document images:

| Placement | Images | Official mean | `np.asarray` mean | Paired mean reduction | p95 before | p95 after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Local NUMA | 41 | 1.1557 s | 0.8484 s | 25.47% | 1.8380 s | 1.3849 s |
| Cross-NUMA | 34 | 3.1997 s | 1.5222 s | 31.26% | 10.8966 s | 2.4293 s |

Direct conversion timing for the 794.45 MiB logits was 0.2472 s locally and
1.2089 s across NUMA with `np.array`, versus about 0.00002 s with
`np.asarray`.

All 75 paired outputs were identical in line count, character count, title and
full-text hashes, parsed OCR lines JSON, and downstream semantic fields JSON.

## Compatibility

`np.asarray` returns the same object for an existing NumPy array and still
converts list and other array-like inputs. The decoder only reads `preds`
through `argmax` and `max`; it does not mutate the runner output.

## Validation

- `python -m pytest -q tests`: 5 passed
- Black 24.4.2: passed
- Flake8 7.0.0 with the repository's selected rules: passed
- license header check: passed
- `git diff --check`: passed
