### PR TITLE
Fix duplicate Markdown images across pages

### DIFF
--- a/paddlex/inference/common/result/converter/markdown_converter.py
+++ b/paddlex/inference/common/result/converter/markdown_converter.py
@@ -39,6 +39,7 @@ class MarkdownConverter:
         use_seg_flag=False,
         get_seg_flag_func=None,
         imgs_in_doc=None,
+        image_path_transform=None,
     ) -> dict:
         """Convert *blocks* to Markdown.
 
@@ -55,12 +56,43 @@ class MarkdownConverter:
             get_seg_flag_func: ``(block, prev_block) -> (start, end)`` called
                 when *use_seg_flag* is *True*.
             imgs_in_doc: Extra images to include (list of ``{"path", "img"}``).
+            image_path_transform: Optional ``(path, source) -> path`` callback.
+                ``source`` is the block or extra-image dictionary that owns the
+                path. The transformed path is used in both the Markdown and the
+                returned image mapping.
 
         Returns:
             dict with keys ``markdown_texts``, ``markdown_images``, and
             optionally ``page_continuation_flags``.
         """
-        blocks_list = list(blocks)  # ensure indexable for lookahead
+        imgs_in_doc = list(imgs_in_doc or [])
+        blocks_list = []
+        for original_block in blocks:
+            block = original_block
+            if image_path_transform is not None:
+                new_content = block.content
+                if isinstance(new_content, str):
+                    for img in imgs_in_doc:
+                        old_path = img["path"]
+                        new_path = image_path_transform(old_path, block)
+                        if old_path != new_path:
+                            new_content = new_content.replace(old_path, new_path)
+
+                image = block.image
+                new_image = image
+                if image is not None:
+                    new_path = image_path_transform(image["path"], block)
+                    if new_path != image["path"]:
+                        if isinstance(new_content, str):
+                            new_content = new_content.replace(image["path"], new_path)
+                        new_image = {**image, "path": new_path}
+
+                if new_content != block.content or new_image is not image:
+                    block = copy.copy(block)
+                    block.content = new_content
+                    block.image = new_image
+
+            blocks_list.append(block)
 
         markdown_content = ""
         markdown_images: dict = {}
@@ -115,6 +147,13 @@ class MarkdownConverter:
                     )
                 last_label = label
 
+        if imgs_in_doc:
+            for img in imgs_in_doc:
+                img_path = img["path"]
+                if image_path_transform is not None:
+                    img_path = image_path_transform(img_path, img)
+                markdown_images[img_path] = img["img"]
+
         # --- build return dict ---
         result = {
             "markdown_texts": markdown_content,
@@ -128,9 +167,5 @@ class MarkdownConverter:
                 page_first_element_seg_start_flag,
                 seg_end_flag,
             )
-
-        if imgs_in_doc:
-            for img in imgs_in_doc:
-                result["markdown_images"][img["path"]] = img["img"]
 
         return result

--- a/paddlex/inference/common/result/mixin.py
+++ b/paddlex/inference/common/result/mixin.py
@@ -794,6 +794,24 @@ class MarkdownMixin:
         """
         return self._to_markdown()
 
+    def _get_markdown_image_path(self, image_path, source):
+        """Return a page-scoped image path for multi-page documents."""
+        page_count = self.get("page_count")
+        if page_count is None or page_count <= 1:
+            return image_path
+
+        page_index = self.get("page_index")
+        if page_index is None:
+            if isinstance(source, dict):
+                page_index = source.get("page_index")
+            else:
+                page_index = getattr(source, "page_index", None)
+        if page_index is None:
+            return image_path
+
+        image_path = Path(image_path)
+        return (image_path.parent / f"page_{page_index}_{image_path.name}").as_posix()
+
     def save_to_markdown(
         self, save_path, pretty=True, show_formula_number=False, *args, **kwargs
     ) -> None:

--- a/paddlex/inference/pipelines/layout_parsing/result_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/result_v2.py
@@ -353,6 +353,7 @@ class LayoutParsingResultV2(
             use_seg_flag=True,
             get_seg_flag_func=get_seg_flag,
             imgs_in_doc=self["imgs_in_doc"],
+            image_path_transform=self._get_markdown_image_path,
         )
         result["page_index"] = self["page_index"]
         result["input_path"] = self["input_path"]

--- a/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/pipeline.py
@@ -1322,8 +1322,9 @@ class _PaddleOCRVLPipeline(BasePipeline):
         concatenate_res = []
         if concatenate_pages:
             all_imgs_in_doc = []
-            for res in res_list:
-                all_imgs_in_doc.extend(res.get("imgs_in_doc", []))
+            for page_idx, res in enumerate(res_list):
+                for img in res.get("imgs_in_doc", []):
+                    all_imgs_in_doc.append({**img, "page_index": page_idx})
             res_list[0]["imgs_in_doc"] = all_imgs_in_doc
             all_page_res = res_list[0]
             all_blocks = []

--- a/paddlex/inference/pipelines/paddleocr_vl/result.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/result.py
@@ -478,6 +478,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin, WordM
             handle_funcs_dict=handle_funcs_dict,
             show_formula_number=show_formula_number,
             imgs_in_doc=self["imgs_in_doc"],
+            image_path_transform=self._get_markdown_image_path,
         )
         result["page_index"] = self["page_index"]
         result["input_path"] = self["input_path"]

--- a/tests/inference/common/result/converter/test_markdown_converter.py
+++ b/tests/inference/common/result/converter/test_markdown_converter.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from paddlex.inference.common.result.converter import MarkdownConverter
+
+
+def test_convert_scopes_duplicate_image_paths_by_page():
+    image_path = "imgs/img_in_image_box_1_2_3_4.jpg"
+    image_0 = object()
+    image_1 = object()
+    blocks = [
+        SimpleNamespace(
+            label="image",
+            content=f'<img src="{image_path}">',
+            image={"path": image_path, "img": image_0},
+            page_index=0,
+        ),
+        SimpleNamespace(
+            label="image",
+            content=f'<img src="{image_path}">',
+            image={"path": image_path, "img": image_1},
+            page_index=1,
+        ),
+    ]
+
+    def page_path(path, source):
+        return path.replace("imgs/", f"imgs/page_{source.page_index}_")
+
+    result = MarkdownConverter.convert(
+        blocks,
+        handle_funcs_dict={"image": lambda block: block.content},
+        image_path_transform=page_path,
+    )
+
+    assert set(result["markdown_images"]) == {
+        "imgs/page_0_img_in_image_box_1_2_3_4.jpg",
+        "imgs/page_1_img_in_image_box_1_2_3_4.jpg",
+    }
+    assert 'src="imgs/page_0_img_in_image_box_1_2_3_4.jpg"' in result["markdown_texts"]
+    assert 'src="imgs/page_1_img_in_image_box_1_2_3_4.jpg"' in result["markdown_texts"]
+
+
+def test_convert_scopes_duplicate_embedded_image_paths_by_page():
+    image_path = "imgs/img_in_image_box_1_2_3_4.jpg"
+    blocks = [
+        SimpleNamespace(
+            label="table",
+            content=f'<img src="{image_path}">',
+            image=None,
+            page_index=0,
+        ),
+        SimpleNamespace(
+            label="table",
+            content=f'<img src="{image_path}">',
+            image=None,
+            page_index=1,
+        ),
+    ]
+    imgs_in_doc = [
+        {"path": image_path, "img": object(), "page_index": 0},
+        {"path": image_path, "img": object(), "page_index": 1},
+    ]
+
+    def page_path(path, source):
+        page_index = (
+            source["page_index"] if isinstance(source, dict) else source.page_index
+        )
+        return path.replace("imgs/", f"imgs/page_{page_index}_")
+
+    result = MarkdownConverter.convert(
+        blocks,
+        handle_funcs_dict={"table": lambda block: block.content},
+        imgs_in_doc=imgs_in_doc,
+        image_path_transform=page_path,
+    )
+
+    assert set(result["markdown_images"]) == {
+        "imgs/page_0_img_in_image_box_1_2_3_4.jpg",
+        "imgs/page_1_img_in_image_box_1_2_3_4.jpg",
+    }
+    assert 'src="imgs/page_0_img_in_image_box_1_2_3_4.jpg"' in result["markdown_texts"]
+    assert 'src="imgs/page_1_img_in_image_box_1_2_3_4.jpg"' in result["markdown_texts"]


### PR DESCRIPTION
## What this changes

- scopes Markdown image filenames by page for multi-page documents
- keeps the existing filenames for single-page results
- updates both Markdown references and the returned image mapping
- preserves page metadata when PaddleOCR-VL concatenates page results
- adds regressions for regular image blocks and images embedded in tables

## Root cause

Image paths were derived only from the block label and coordinates. Two images at the same coordinates on different PDF pages therefore shared one dictionary key and output filename, causing the later image to overwrite the earlier one.

## Validation

- two isolated regression tests covering same-coordinate images on two pages
- `python3 -m compileall` on all changed Python files
- Ruff checks and formatting checks on the new converter, mixin, and test changes
- `git diff --check`

The full PaddleX test suite was not run locally because this checkout is intentionally sparse and does not contain the complete optional runtime dependencies.

Fixes PaddlePaddle/PaddleOCR#18305
