### PR TITLE
Remove xformers dependency from genai server plugin (no runtime usage; unblocks aarch64 CUDA deploy)

### DIFF
--- a/.precommit/check_imports.py
+++ b/.precommit/check_imports.py
@@ -102,7 +102,6 @@ MOD_TO_DEP = {
     "uvicorn": "uvicorn",
     "uvloop": "uvloop",
     "vllm": "vllm",
-    "xformers": "xformers",
     "yarl": "yarl",
     "bidi": "python-bidi",
 }

--- a/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
+++ b/paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py
@@ -592,7 +592,6 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
             if self.attn_backend not in {
                 _Backend.FLASH_ATTN,
                 _Backend.TORCH_SDPA,
-                _Backend.XFORMERS,
             }:
                 raise RuntimeError(
                     f"PaddleOCR-VL does not support {self.attn_backend} backend now."
@@ -653,18 +652,6 @@ if all(map(is_dep_available, ("einops", "torch", "transformers", "vllm"))):
                     output_i = rearrange(output_i, "b h s d -> b s h d ")
                     outputs.append(output_i)
                 context_layer = torch.cat(outputs, dim=1)
-            elif self.attn_backend == _Backend.XFORMERS:
-                from xformers import ops as xops
-                from xformers.ops.fmha.attn_bias import BlockDiagonalMask
-
-                seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
-                attn_bias = BlockDiagonalMask.from_seqlens(
-                    q_seqlen=seqlens, kv_seqlen=None, device=q.device
-                )
-
-                context_layer = xops.memory_efficient_attention_forward(
-                    q, k, v, attn_bias=attn_bias, p=0, scale=None
-                )
 
             context_layer = rearrange(
                 context_layer, "b s h d -> b s (h d)"

--- a/paddlex/paddlex_cli.py
+++ b/paddlex/paddlex_cli.py
@@ -375,7 +375,6 @@ def install(args):
 
         for plugin_type in plugin_types:
             if "vllm" in plugin_type or "sglang" in plugin_type:
-                install_packages(["xformers"], constraints="required")
                 if is_cuda_available():
                     try:
                         install_packages(["wheel"], constraints="required")

--- a/paddlex/utils/deps.py
+++ b/paddlex/utils/deps.py
@@ -280,7 +280,7 @@ def is_genai_engine_plugin_available(backend="any"):
             from .env import is_cuda_available
 
             if is_cuda_available():
-                return is_dep_available("xformers") and is_dep_available("flash-attn")
+                return is_dep_available("flash-attn")
             return True
         return False
 


### PR DESCRIPTION
## 背景

`paddlex --install genai-vllm-server` 会强制安装 xformers（`paddlex_cli.py` 中 `install_packages(["xformers"])`）。但经过代码级与运行时实证，**xformers 在 genai vllm/sglang server 路径上没有任何实际运行时调用**，而这个依赖在 aarch64 CUDA 平台（如 NVIDIA DGX Spark，GB10，sm_121）上完全无法安装：

- xformers 全版本无 aarch64 wheel；
- 源码编译与 torch 强 ABI 耦合，在当前栈（torch 2.8 / CUDA 12.9+）下构建失败。

这使得 PaddleOCR-VL 的 genai vllm-server 无法在这类新架构机器上通过官方安装入口部署。

## xformers 运行时无调用的证据链

1. **安装/检查路径**：仓库内 xformers 引用仅有 `paddlex_cli.py`（安装命令）、`utils/deps.py`（双包导入检查）、`_vllm.py`（ViT 的 XFORMERS 分支内 import）与 pre-commit 映射，无任何运行时逻辑依赖；
2. **ViT attention 后端选择**：`get_vit_attn_backend(support_fa=True)` 经由 vllm 的平台逻辑，在 flash-attn 可用时恒定返回 `FLASH_ATTN`，仅当 flash-attn **缺失**时才回退 `XFORMERS`；
3. **flash-attn 是同一安装流程的强制依赖**：`paddlex_cli.py` 在 CUDA 平台按算力强制安装 `flash-attn == 2.8.3`（cap ≥ 12.0）或 `2.8.2`，失败即 `sys.exit(1)`。因此安装成功的环境下 `_vllm.py` 的 XFORMERS 分支永不可达；
4. **主模型 attention** 走 vllm 自有后端（FLASH_ATTN/FLASHINFER），与 xformers 无关；sglang 服务端代码亦无 xformers 引用；
5. **实机实证**（NVIDIA DGX Spark / GB10 / sm_121）：用 `meta_path` Blocker 彻底屏蔽 xformers 导入后，`is_genai_engine_plugin_available('vllm-server')` 仍返回 True，且 PaddleOCR-VL-1.6 两进程（genai_server + paddlex --serve）端到端解析正常。

## 本 PR 改动（4 个文件，+1/−16）

| 文件 | 改动 |
|---|---|
| `paddlex/paddlex_cli.py` | 删除 `install_packages(["xformers"], constraints="required")`，genai vllm/sglang server 依赖链收敛为只依赖 flash-attn |
| `paddlex/utils/deps.py` | CUDA 下插件可用性检查由 `xformers and flash-attn` 改为仅检查 `flash-attn` |
| `paddlex/inference/genai/models/paddleocr_vl_09b/_vllm.py` | 删除 ViT attention 的 XFORMERS 分支及其在支持集合中的声明（15_09b/16_09b 复用 09b 代码，一并生效） |
| `.precommit/check_imports.py` | 从可选依赖映射中移除 xformers |

## 行为变化说明

flash-attn 缺失时，ViT 后端若被 vllm 选为 XFORMERS，初始化将抛出明确的 `RuntimeError("PaddleOCR-VL does not support ... backend now.")`，而非尝试导入 xformers。由于官方安装流程已强制 flash-attn，此变化不影响任何受支持配置，且报错更明确。

## 验证

- `python -m py_compile` 四个文件语法检查通过；
- 全仓库 `grep -rn xformers` 无残留；
- DGX Spark 实机：屏蔽 xformers 导入后插件检查与端到端服务均正常（见上）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)