### PR TITLE
Fix save_to_markdown overwriting images with same coordinates on different pages

### DIFF
--- a/paddlex/inference/common/result/converter/markdown_converter.py
+++ b/paddlex/inference/common/result/converter/markdown_converter.py
@@ -39,6 +39,7 @@ class MarkdownConverter:
         use_seg_flag=False,
         get_seg_flag_func=None,
         imgs_in_doc=None,
+        page_index=None,
     ) -> dict:
         """Convert *blocks* to Markdown.
 
@@ -55,6 +56,11 @@ class MarkdownConverter:
             get_seg_flag_func: ``(block, prev_block) -> (start, end)`` called
                 when *use_seg_flag* is *True*.
             imgs_in_doc: Extra images to include (list of ``{"path", "img"}``).
+            page_index: Zero-based index of this page within a multi-page
+                document. When set to a value greater than ``0`` the emitted
+                image paths are namespaced by page so that pages saved into the
+                same directory do not overwrite each other. ``None`` / ``0`` (a
+                single page) leaves paths unchanged for backward compatibility.
 
         Returns:
             dict with keys ``markdown_texts``, ``markdown_images``, and
@@ -133,4 +139,42 @@ class MarkdownConverter:
             for img in imgs_in_doc:
                 result["markdown_images"][img["path"]] = img["img"]
 
+        # In a multi-page document every page is converted separately but saved
+        # into the same directory. Image filenames are derived from (label, box)
+        # only, so a figure at the same coordinates on different pages resolves
+        # to the same path and later pages silently overwrite earlier ones.
+        # Namespace the image paths of pages after the first by their page index
+        # so they stay unique (page 0 / single-page output is left unchanged).
+        if page_index:
+            result = MarkdownConverter._namespace_page_images(result, page_index)
+
+        return result
+
+    @staticmethod
+    def _namespace_page_images(result: dict, page_index: int) -> dict:
+        """Prefix every ``imgs/`` image path with ``imgs/page_{page_index}/``.
+
+        Rewrites both the ``markdown_images`` keys and the corresponding
+        references inside ``markdown_texts`` so they stay consistent. Paths are
+        rewritten longest-first so no path can match inside another during the
+        text substitution.
+        """
+        images = result.get("markdown_images") or {}
+        if not images:
+            return result
+
+        text = result.get("markdown_texts", "")
+        remapped: dict = {}
+        for path in sorted(images, key=len, reverse=True):
+            img = images[path]
+            if isinstance(path, str) and path.startswith("imgs/"):
+                new_path = f"imgs/page_{page_index}/" + path[len("imgs/") :]
+                if new_path != path:
+                    text = text.replace(path, new_path)
+                remapped[new_path] = img
+            else:
+                remapped[path] = img
+
+        result["markdown_texts"] = text
+        result["markdown_images"] = remapped
         return result

--- a/paddlex/inference/pipelines/layout_parsing/result_v2.py
+++ b/paddlex/inference/pipelines/layout_parsing/result_v2.py
@@ -353,6 +353,7 @@ class LayoutParsingResultV2(
             use_seg_flag=True,
             get_seg_flag_func=get_seg_flag,
             imgs_in_doc=self["imgs_in_doc"],
+            page_index=self["page_index"],
         )
         result["page_index"] = self["page_index"]
         result["input_path"] = self["input_path"]

--- a/paddlex/inference/pipelines/paddleocr_vl/result.py
+++ b/paddlex/inference/pipelines/paddleocr_vl/result.py
@@ -478,6 +478,7 @@ class PaddleOCRVLResult(BaseCVResult, HtmlMixin, XlsxMixin, MarkdownMixin, WordM
             handle_funcs_dict=handle_funcs_dict,
             show_formula_number=show_formula_number,
             imgs_in_doc=self["imgs_in_doc"],
+            page_index=self["page_index"],
         )
         result["page_index"] = self["page_index"]
         result["input_path"] = self["input_path"]

--- a/tests/test_markdown_converter_page_namespacing.py
+++ b/tests/test_markdown_converter_page_namespacing.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for per-page namespacing of Markdown image paths.
+
+``save_to_markdown`` derives image filenames from (label, box) only, so a
+figure at the same coordinates on different pages of one document used to
+resolve to the same path and later pages silently overwrote earlier ones.
+``MarkdownConverter.convert(..., page_index=...)`` now namespaces the image
+paths of pages after the first.
+"""
+
+from paddlex.inference.common.result.converter.markdown_converter import (
+    MarkdownConverter,
+)
+
+
+def _convert(imgs_in_doc, page_index):
+    return MarkdownConverter.convert(
+        [],
+        handle_funcs_dict={},
+        imgs_in_doc=imgs_in_doc,
+        page_index=page_index,
+    )
+
+
+def test_same_coordinates_on_different_pages_do_not_collide():
+    imgs = [{"path": "imgs/img_in_image_box_0_0_100_100.jpg", "img": "DATA"}]
+    page1 = _convert(imgs, page_index=1)
+    page2 = _convert(imgs, page_index=2)
+    keys = set(page1["markdown_images"]) | set(page2["markdown_images"])
+    # Two distinct filenames instead of one overwritten file.
+    assert keys == {
+        "imgs/page_1/img_in_image_box_0_0_100_100.jpg",
+        "imgs/page_2/img_in_image_box_0_0_100_100.jpg",
+    }
+
+
+def test_first_page_and_single_page_paths_are_unchanged():
+    imgs = [{"path": "imgs/img_in_image_box_1_2_3_4.jpg", "img": "DATA"}]
+    for page_index in (0, None):
+        result = _convert(imgs, page_index=page_index)
+        assert "imgs/img_in_image_box_1_2_3_4.jpg" in result["markdown_images"]
+
+
+def test_text_references_are_rewritten_to_match_saved_files():
+    result = {
+        "markdown_texts": "before ![](imgs/img_in_image_box_1_2_3_4.jpg) after",
+        "markdown_images": {"imgs/img_in_image_box_1_2_3_4.jpg": "DATA"},
+    }
+    out = MarkdownConverter._namespace_page_images(result, 2)
+    assert "![](imgs/page_2/img_in_image_box_1_2_3_4.jpg)" in out["markdown_texts"]
+    # Every saved image key is referenced by the text (no dangling references).
+    for key in out["markdown_images"]:
+        assert key in out["markdown_texts"]
+
+
+def test_rewrite_is_substring_safe():
+    # One path is a numeric prefix of the other; both must be rewritten exactly.
+    result = {
+        "markdown_texts": (
+            "![](imgs/img_in_image_box_1_2_3_4.jpg) "
+            "![](imgs/img_in_image_box_1_2_3_40.jpg)"
+        ),
+        "markdown_images": {
+            "imgs/img_in_image_box_1_2_3_4.jpg": "A",
+            "imgs/img_in_image_box_1_2_3_40.jpg": "B",
+        },
+    }
+    out = MarkdownConverter._namespace_page_images(result, 3)
+    assert set(out["markdown_images"]) == {
+        "imgs/page_3/img_in_image_box_1_2_3_4.jpg",
+        "imgs/page_3/img_in_image_box_1_2_3_40.jpg",
+    }
+    assert "![](imgs/page_3/img_in_image_box_1_2_3_4.jpg)" in out["markdown_texts"]
+    assert "![](imgs/page_3/img_in_image_box_1_2_3_40.jpg)" in out["markdown_texts"]


### PR DESCRIPTION
## Problem

Fixes PaddleOCR#18305.

`save_to_markdown` derives image filenames from `(label, box)` only:

```python
# paddlex/inference/pipelines/layout_parsing/utils.py
def construct_img_path(label, box):
    x_min, y_min, x_max, y_max = list(map(int, box))
    return f"imgs/img_in_{label}_box_{x_min}_{y_min}_{x_max}_{y_max}.jpg"
```

When a multi-page document (e.g. a PDF) is exported, every page is converted to its own result but written into the **same** output directory. A figure at the same coordinates on different pages therefore resolves to the **same** filename, and `_save_data` writes each page's image to that path in turn — so later pages silently overwrite earlier ones and those images go missing from the exported Markdown.

## Fix

`MarkdownConverter.convert` now takes an optional `page_index` and, for pages **after the first**, namespaces image paths as `imgs/page_{page_index}/...`. It rewrites **both** the `markdown_images` keys (what gets saved) **and** the `![](...)` references in `markdown_texts` (what points at them), so the reference always matches the saved file. Rewriting is done longest-path-first so one path can't match inside another.

- Page `0` / single-page output is left **byte-for-byte unchanged** (backward compatible) — `page_index` `0`/`None` is a no-op.
- Wired through both `_to_markdown` sites: `LayoutParsingResultV2` (PP-StructureV3) and the PaddleOCR-VL result. Both already carry `self["page_index"]`, so no pipeline changes are needed.

## Tests

`tests/test_markdown_converter_page_namespacing.py`:
- same coordinates on different pages now produce **distinct** filenames (no overwrite);
- first-page / single-page paths are unchanged;
- text `![](...)` references are rewritten to match the saved keys (no dangling references);
- the rewrite is substring-safe when one filename is a numeric prefix of another.

I validated the namespacing logic directly (it's pure string handling); I don't have a full Paddle runtime locally to run the whole suite, so CI is the execution check — happy to adjust if the maintainers prefer threading `page_index` through `construct_img_path`/`gather_imgs` at the source instead.