### PR TITLE
fix(deps): detect any distribution that provides `cv2`

### DIFF
--- a/paddlex/utils/deps.py
+++ b/paddlex/utils/deps.py
@@ -109,6 +109,13 @@ def is_dep_available(dep, /, check_version=False):
         return importlib.util.find_spec("fastdeploy") is not None
     elif dep == "onnxruntime":
         return importlib.util.find_spec("onnxruntime") is not None
+    elif dep == "opencv-contrib-python":
+        # `cv2` is provided by several mutually exclusive distributions
+        # (`opencv-python`, `opencv-python-headless`, `opencv-contrib-python`,
+        # `opencv-contrib-python-headless`). Headless builds are commonly used in
+        # containers and other environments without GUI libraries, so check for the
+        # import package rather than for a specific distribution.
+        return importlib.util.find_spec("cv2") is not None
     version = get_dep_version(dep)
     if version is None:
         return False


### PR DESCRIPTION
### Problem

`cv2` is shipped by four mutually exclusive distributions: `opencv-python`, `opencv-python-headless`, `opencv-contrib-python` and `opencv-contrib-python-headless`. `is_dep_available()` resolved the `opencv-contrib-python` **distribution name**, so PaddleX raised `DependencyError` even when a fully working `cv2` was already installed from another build.

On a `python:3.11-slim-bookworm` base image — a very common choice for serving containers — the non-headless builds cannot be used at all. Importing `cv2` from `opencv-contrib-python` fails with:

ImportError: libGL.so.1: cannot open shared object file: No such file or directory

The slim image ships no GUI libraries, and the wheel links against them even though nothing in a serving workload ever opens a window. So today the options are either to install extra system packages (`libgl1`, `libglib2.0-0`) purely so that an unused GUI backend can load, or to patch PaddleX locally. The headless wheel has no such dependency and is the natural choice for containers — but PaddleX refuses to recognize it.

### Reproduction

In an environment where `cv2` comes from `opencv-python-headless`, any pipeline fails at construction time:

paddlex.utils.deps.DependencyError: OCR requires additional dependencies. To install them,
run pip install "paddlex[ocr]==<PADDLEX_VERSION>" ...

even though `import cv2` works and reports `4.10.0`. The message is misleading: the dependency *is* installed, just under a different distribution name.

### Fix

Check for the `cv2` import package, exactly like the existing handling of `onnxruntime` a few lines above, which has the same one-import/several-distributions shape.

### Compatibility

- **No packaging change.** `paddlex[...]` still depends on `opencv-contrib-python == 4.10.0.84`, so a plain `pip install paddlex[...]` behaves exactly as before.
- PaddleX uses no contrib-only OpenCV API (`cv2.ximgproc`, `cv2.freetype`, `cv2.aruco`, …), so accepting the non-contrib builds loses nothing in practice.
- `is_dep_available("opencv-contrib-python", check_version=True)` is not used anywhere in the codebase; the version pin was already unenforced at runtime, same as for `onnxruntime`.

### Verification

Environment: `paddlepaddle==3.2.0`, `paddlex` installed from this branch, and **only** `opencv-python-headless==4.10.0.84` present (no `opencv-contrib-python`, `opencv-contrib-python-headless` or `opencv-python`).

Running `api_examples/pipelines/test_ocr.py` unchanged:

- **before this patch** — `DependencyError: \`OCR\` requires additional dependencies`
- **after this patch** — 33 text lines recognized, visualization saved correctly

Also checked: `black==24.4.2`, `flake8==7.0.0`, `isort==5.12.0` and the local `.precommit` hooks (`check_imports.py`, `check_license_headers.py`, `check_py38_compat.py`) all pass.